### PR TITLE
Add Basiq integration test suite (Issue #17)

### DIFF
--- a/docs/basiq-sandbox-setup.md
+++ b/docs/basiq-sandbox-setup.md
@@ -1,0 +1,48 @@
+# Basiq Sandbox Setup
+
+## Getting Started
+
+1. Sign up at [dashboard.basiq.io](https://dashboard.basiq.io) for a free sandbox account
+2. Navigate to **API Keys** in the dashboard and generate a new key
+3. Copy your API key — you'll need it for your `.env` file
+
+## Environment Configuration
+
+Add these to your `.env` file:
+
+```dotenv
+BASIQ_API_KEY=your-sandbox-api-key-here
+BASIQ_BASE_URL=https://au-api.basiq.io
+```
+
+The sandbox and production APIs use the same base URL. Your API key determines which environment you're operating in.
+
+## Sandbox Test Credentials
+
+Basiq provides a sandbox institution called **"Hooli Bank"** for testing:
+
+| Field | Value |
+|-------|-------|
+| Institution | Hooli Bank (AU00000) |
+| Login ID | `gavinbelson` |
+| Password | `hooli2016` |
+| Security code | `hooli2016` |
+
+These credentials simulate a successful bank connection with pre-seeded accounts and transactions.
+
+## Sandbox Behaviour
+
+- Connections made with sandbox credentials return realistic account and transaction data
+- Webhooks fire normally in sandbox mode (use `basiq:register-webhook` to register)
+- Token expiry and rate limits still apply
+- No real bank data is accessed
+
+## Testing Without Sandbox
+
+All tests in this repository use `Http::fake()` to mock Basiq API responses. You do **not** need sandbox credentials to run the test suite:
+
+```bash
+op test.filter Basiq
+```
+
+The sandbox is only needed for manual integration testing or verifying the consent flow in a browser.

--- a/tests/Feature/Console/Commands/RegisterBasiqWebhookCommandTest.php
+++ b/tests/Feature/Console/Commands/RegisterBasiqWebhookCommandTest.php
@@ -1,0 +1,102 @@
+<?php
+
+/** @noinspection PhpUnhandledExceptionInspection */
+
+/** @noinspection StaticClosureCanBeUsedInspection */
+
+declare(strict_types=1);
+
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+
+beforeEach(function () {
+    Cache::forget('basiq:server_token');
+
+    config([
+        'services.basiq.api_key' => 'test-api-key',
+        'services.basiq.base_url' => 'https://au-api.basiq.io',
+    ]);
+});
+
+test('successful registration displays secret and env instructions', function () {
+    Http::fake([
+        '*/token' => Http::response(['access_token' => 'tok']),
+        '*/notifications/webhooks' => Http::response(['secret' => 'whsec_test123']),
+    ]);
+
+    $this->artisan('basiq:register-webhook')
+        ->expectsOutputToContain('Webhook registered successfully')
+        ->expectsOutputToContain('BASIQ_WEBHOOK_SECRET=whsec_test123')
+        ->assertSuccessful();
+});
+
+test('successful registration without secret shows warning', function () {
+    Http::fake([
+        '*/token' => Http::response(['access_token' => 'tok']),
+        '*/notifications/webhooks' => Http::response(['id' => 'wh-1']),
+    ]);
+
+    $this->artisan('basiq:register-webhook')
+        ->expectsOutputToContain('no secret was returned')
+        ->assertSuccessful();
+});
+
+test('custom --url option sends provided URL in request body', function () {
+    Http::fake([
+        '*/token' => Http::response(['access_token' => 'tok']),
+        '*/notifications/webhooks' => Http::response(['secret' => 'whsec_abc']),
+    ]);
+
+    $this->artisan('basiq:register-webhook', ['--url' => 'https://custom.example.com/hook'])
+        ->assertSuccessful();
+
+    Http::assertSent(fn (Request $r) => str_contains($r->url(), 'notifications/webhooks')
+        && $r['url'] === 'https://custom.example.com/hook');
+});
+
+test('default URL uses APP_URL with /webhooks/basiq', function () {
+    config(['app.url' => 'https://myapp.test']);
+
+    Http::fake([
+        '*/token' => Http::response(['access_token' => 'tok']),
+        '*/notifications/webhooks' => Http::response(['secret' => 'whsec_abc']),
+    ]);
+
+    $this->artisan('basiq:register-webhook')
+        ->assertSuccessful();
+
+    Http::assertSent(fn (Request $r) => str_contains($r->url(), 'notifications/webhooks')
+        && $r['url'] === 'https://myapp.test/webhooks/basiq');
+});
+
+test('API error returns failure exit code', function () {
+    Http::fake([
+        '*/token' => Http::response(['access_token' => 'tok']),
+        '*/notifications/webhooks' => Http::response(['error' => 'server error'], 500),
+    ]);
+
+    $this->artisan('basiq:register-webhook')
+        ->expectsOutputToContain('Failed to register webhook')
+        ->assertFailed();
+});
+
+test('correct events array is sent in webhook registration', function () {
+    Http::fake([
+        '*/token' => Http::response(['access_token' => 'tok']),
+        '*/notifications/webhooks' => Http::response(['secret' => 'whsec_xyz']),
+    ]);
+
+    $this->artisan('basiq:register-webhook')
+        ->assertSuccessful();
+
+    Http::assertSent(function (Request $r) {
+        if (! str_contains($r->url(), 'notifications/webhooks')) {
+            return false;
+        }
+
+        $events = $r['events'];
+
+        return $events === ['connection.created', 'transactions.updated'];
+    });
+});

--- a/tests/Feature/Jobs/SyncTransactionsJobTest.php
+++ b/tests/Feature/Jobs/SyncTransactionsJobTest.php
@@ -10,11 +10,14 @@ use App\Contracts\BasiqServiceContract;
 use App\DTOs\BasiqAccount;
 use App\DTOs\BasiqJob;
 use App\DTOs\BasiqTransaction;
+use App\Enums\AccountClass;
 use App\Jobs\SyncTransactionsJob;
 use App\Models\Account;
 use App\Models\Transaction;
 use App\Models\User;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\LazyCollection;
@@ -375,4 +378,123 @@ test('processes transactions across multiple DTOs', function () {
     new SyncTransactionsJob($user, 'job-1')->handle(app(BasiqServiceContract::class));
 
     expect(Transaction::count())->toBe(3);
+});
+
+test('end-to-end sync through real BasiqService with Http::fake', function () {
+    Cache::forget('basiq:server_token');
+
+    config([
+        'services.basiq.api_key' => 'test-api-key',
+        'services.basiq.base_url' => 'https://au-api.basiq.io',
+    ]);
+
+    $user = User::factory()->withBasiq()->create([
+        'last_synced_at' => null,
+    ]);
+
+    Http::fake([
+        '*/token' => Http::response(['access_token' => 'tok']),
+        '*/jobs/job-1' => Http::response([
+            'id' => 'job-1',
+            'steps' => [
+                ['title' => 'verify-credentials', 'status' => 'success'],
+                ['title' => 'retrieve-accounts', 'status' => 'success'],
+            ],
+        ]),
+        '*/users/*/accounts' => Http::response([
+            'data' => [
+                [
+                    'id' => 'acc-1',
+                    'name' => 'Everyday Account',
+                    'institution' => 'AU00000',
+                    'class' => ['type' => 'transaction'],
+                    'balance' => '1234.56',
+                    'currency' => 'AUD',
+                    'status' => 'active',
+                ],
+                [
+                    'id' => 'acc-2',
+                    'name' => 'Savings Account',
+                    'institution' => 'AU00000',
+                    'class' => ['type' => 'savings'],
+                    'balance' => '9999.00',
+                    'currency' => 'AUD',
+                    'status' => 'active',
+                ],
+            ],
+        ]),
+        '*/users/*/transactions*' => Http::response([
+            'data' => [
+                [
+                    'id' => 'txn-1',
+                    'amount' => '-42.50',
+                    'direction' => 'debit',
+                    'description' => 'WOOLWORTHS 1234',
+                    'postDate' => '2026-03-10',
+                    'transactionDate' => '2026-03-09',
+                    'account' => 'acc-1',
+                    'status' => 'posted',
+                    'enrich' => [
+                        'merchant' => ['businessName' => 'Woolworths'],
+                        'category' => ['anzsic' => ['code' => '4111']],
+                    ],
+                ],
+                [
+                    'id' => 'txn-2',
+                    'amount' => '150.00',
+                    'direction' => 'credit',
+                    'description' => 'SALARY DEPOSIT',
+                    'postDate' => '2026-03-11',
+                    'transactionDate' => '2026-03-11',
+                    'account' => 'acc-2',
+                    'status' => 'posted',
+                ],
+            ],
+            'links' => ['next' => null],
+        ]),
+    ]);
+
+    app()->forgetInstance(BasiqServiceContract::class);
+
+    $basiqService = app(BasiqServiceContract::class);
+    new SyncTransactionsJob($user, 'job-1')->handle($basiqService);
+
+    expect(Account::count())->toBe(2);
+
+    $everyday = Account::where('basiq_account_id', 'acc-1')->first();
+    expect($everyday)
+        ->name->toBe('Everyday Account')
+        ->balance->toBe(123456)
+        ->currency->toBe('AUD')
+        ->type->toBe(AccountClass::Transaction);
+
+    $savings = Account::where('basiq_account_id', 'acc-2')->first();
+    expect($savings)
+        ->name->toBe('Savings Account')
+        ->balance->toBe(999900)
+        ->type
+        ->toBe(AccountClass::Savings)
+        ->and(Transaction::count())->toBe(2);
+
+    $txn1 = Transaction::where('basiq_id', 'txn-1')->first();
+    expect($txn1)
+        ->user_id->toBe($user->id)
+        ->amount->toBe(-4250)
+        ->direction->value->toBe('debit')
+        ->description->toBe('WOOLWORTHS 1234')
+        ->post_date->format('Y-m-d')->toBe('2026-03-10')
+        ->merchant_name->toBe('Woolworths')
+        ->anzsic_code->toBe('4111');
+
+    $txn2 = Transaction::where('basiq_id', 'txn-2')->first();
+    expect($txn2)
+        ->amount->toBe(15000)
+        ->direction->value->toBe('credit')
+        ->description->toBe('SALARY DEPOSIT');
+
+    $user->refresh();
+    expect($user->last_synced_at)->not->toBeNull()
+        ->and($user->last_synced_at->isToday())->toBeTrue();
+
+    Http::assertSentCount(4);
 });


### PR DESCRIPTION
## Summary

- **6 new tests** for `RegisterBasiqWebhookCommand` covering success/failure paths, custom URL, default URL, and correct event payload
- **1 integration test** for `SyncTransactionsJob` using `Http::fake()` through the real `BasiqService` (not Mockery mocks), validating the full HTTP → DTO → DB chain
- **Sandbox documentation** (`docs/basiq-sandbox-setup.md`) covering Basiq sandbox setup, Hooli Bank test credentials, and `.env` configuration

All 72 Basiq tests pass (212 assertions). PHPStan and Pint clean.

Closes #17

## Test plan

- [ ] `op test.filter Basiq` — all 72 tests pass
- [ ] `op test.filter RegisterBasiq` — 6 new command tests pass
- [ ] `op analyse` — PHPStan reports no errors
- [ ] `op lint.dirty` — no style violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)