### PR TITLE
Add AccountOverview Livewire component (Issue #18)

### DIFF
--- a/app/Enums/AccountClass.php
+++ b/app/Enums/AccountClass.php
@@ -15,4 +15,42 @@ enum AccountClass: string
     case Insurance = 'insurance';
     case Foreign = 'foreign';
     case TermDeposit = 'term-deposit';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Transaction => 'Transaction',
+            self::Savings => 'Savings',
+            self::CreditCard => 'Credit Card',
+            self::Loan => 'Loan',
+            self::Mortgage => 'Mortgage',
+            self::Investment => 'Investment',
+            self::Insurance => 'Insurance',
+            self::Foreign => 'Foreign',
+            self::TermDeposit => 'Term Deposit',
+        };
+    }
+
+    public function isAsset(): bool
+    {
+        return match ($this) {
+            self::CreditCard, self::Loan, self::Mortgage => false,
+            default => true,
+        };
+    }
+
+    public function icon(): string
+    {
+        return match ($this) {
+            self::Transaction => 'banknotes',
+            self::Savings => 'building-library',
+            self::CreditCard => 'credit-card',
+            self::Loan => 'document-text',
+            self::Mortgage => 'home',
+            self::Investment => 'chart-bar',
+            self::Insurance => 'shield-check',
+            self::Foreign => 'globe-alt',
+            self::TermDeposit => 'clock',
+        };
+    }
 }

--- a/app/Livewire/AccountOverview.php
+++ b/app/Livewire/AccountOverview.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire;
+
+use App\Casts\MoneyCast;
+use App\Models\Account;
+use Illuminate\View\View;
+use Livewire\Component;
+
+final class AccountOverview extends Component
+{
+    public function placeholder(): string
+    {
+        return <<<'HTML'
+        <div>
+            <div class="space-y-4">
+                <div class="animate-pulse rounded-xl bg-zinc-100 dark:bg-zinc-800 h-24"></div>
+                <div class="animate-pulse rounded-xl bg-zinc-100 dark:bg-zinc-800 h-48"></div>
+                <div class="animate-pulse rounded-xl bg-zinc-100 dark:bg-zinc-800 h-48"></div>
+            </div>
+        </div>
+        HTML;
+    }
+
+    public function render(): View
+    {
+        $accounts = auth()->user()
+            ->accounts()
+            ->active()
+            ->orderBy('type')
+            ->get();
+
+        $grouped = $accounts->groupBy(fn (Account $account) => $account->type->value);
+
+        $totalAssets = $accounts->filter(fn (Account $a) => $a->type->isAsset())->sum('balance');
+        $totalLiabilities = $accounts->filter(fn (Account $a) => ! $a->type->isAsset())->sum('balance');
+        $netWorth = $totalAssets + $totalLiabilities;
+
+        return view('livewire.account-overview', [
+            'grouped' => $grouped,
+            'totalAssets' => $totalAssets,
+            'totalLiabilities' => $totalLiabilities,
+            'netWorth' => $netWorth,
+            'formatMoney' => MoneyCast::format(...),
+        ]);
+    }
+}

--- a/app/Models/Account.php
+++ b/app/Models/Account.php
@@ -7,6 +7,7 @@ namespace App\Models;
 use App\Casts\MoneyCast;
 use App\Enums\AccountClass;
 use App\Enums\AccountStatus;
+use Carbon\CarbonImmutable;
 use Database\Factories\AccountFactory;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -14,6 +15,19 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
+/**
+ * @property int $id
+ * @property int $user_id
+ * @property string|null $basiq_account_id
+ * @property string $name
+ * @property AccountClass $type
+ * @property string $institution
+ * @property string $currency
+ * @property int $balance
+ * @property AccountStatus $status
+ * @property CarbonImmutable $created_at
+ * @property CarbonImmutable $updated_at
+ */
 final class Account extends Model
 {
     /** @use HasFactory<AccountFactory> */
@@ -43,6 +57,15 @@ final class Account extends Model
     public function transactions(): HasMany
     {
         return $this->hasMany(Transaction::class);
+    }
+
+    /**
+     * @param  Builder<self>  $query
+     * @return Builder<self>
+     */
+    public function scopeActive(Builder $query): Builder
+    {
+        return $query->where('status', AccountStatus::Active);
     }
 
     /**

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -11,8 +11,6 @@
                 <x-placeholder-pattern class="absolute inset-0 size-full stroke-gray-900/20 dark:stroke-neutral-100/20" />
             </div>
         </div>
-        <div class="relative h-full flex-1 overflow-hidden rounded-xl border border-neutral-200 dark:border-neutral-700">
-            <x-placeholder-pattern class="absolute inset-0 size-full stroke-gray-900/20 dark:stroke-neutral-100/20" />
-        </div>
+        <livewire:account-overview lazy />
     </div>
 </x-layouts::app>

--- a/resources/views/livewire/account-overview.blade.php
+++ b/resources/views/livewire/account-overview.blade.php
@@ -1,0 +1,64 @@
+@php use App\Enums\AccountClass; @endphp
+<div class="space-y-6">
+    @if($grouped->isEmpty())
+        <div class="rounded-xl border border-neutral-200 p-8 text-center dark:border-neutral-700">
+            <flux:icon.building-library class="mx-auto size-12 text-zinc-400" />
+            <flux:heading size="lg" class="mt-4">No linked accounts</flux:heading>
+            <flux:text class="mt-2">Connect your bank to see your accounts and track your net worth.</flux:text>
+            <div class="mt-6">
+                <flux:button variant="primary" icon="plus" href="{{ route('connect-bank') }}">Connect Bank</flux:button>
+            </div>
+        </div>
+    @else
+        <div class="rounded-xl border border-neutral-200 p-6 dark:border-neutral-700">
+            <div class="grid gap-4 sm:grid-cols-3">
+                <div>
+                    <flux:text>Net Worth</flux:text>
+                    <flux:heading size="xl" class="mt-1 tabular-nums">{{ $formatMoney($netWorth) }}</flux:heading>
+                </div>
+                <div>
+                    <flux:text>Assets</flux:text>
+                    <flux:heading size="lg" class="mt-1 tabular-nums text-green-600 dark:text-green-500">{{ $formatMoney($totalAssets) }}</flux:heading>
+                </div>
+                <div>
+                    <flux:text>Liabilities</flux:text>
+                    <flux:heading size="lg" class="mt-1 tabular-nums text-red-600 dark:text-red-500">{{ $formatMoney(abs($totalLiabilities)) }}</flux:heading>
+                </div>
+            </div>
+        </div>
+
+        @foreach($grouped as $typeValue => $accounts)
+            @php $type = AccountClass::from($typeValue) @endphp
+            <div class="rounded-xl border border-neutral-200 dark:border-neutral-700">
+                <div class="flex items-center justify-between p-4">
+                    <div class="flex items-center gap-2">
+                        <flux:icon :name="$type->icon()" variant="mini" class="text-zinc-500" />
+                        <flux:heading>{{ $type->label() }}</flux:heading>
+                    </div>
+                    <flux:badge color="zinc">{{ $formatMoney($accounts->sum('balance')) }}</flux:badge>
+                </div>
+
+                <flux:separator />
+
+                <div class="divide-y divide-neutral-200 dark:divide-neutral-700">
+                    @foreach($accounts as $account)
+                        <div wire:key="account-{{ $account->id }}" class="flex items-center justify-between px-4 py-3">
+                            <div>
+                                <flux:heading size="sm">{{ $account->name }}</flux:heading>
+                                <flux:text size="sm">{{ $account->institution }}</flux:text>
+                            </div>
+                            <div class="text-right">
+                                <flux:text class="tabular-nums font-medium">{{ $formatMoney($account->balance) }}</flux:text>
+                                <flux:text size="sm">{{ $account->updated_at->diffForHumans() }}</flux:text>
+                            </div>
+                        </div>
+                    @endforeach
+                </div>
+            </div>
+        @endforeach
+
+        <div class="flex justify-center">
+            <flux:button variant="primary" icon="plus" href="{{ route('connect-bank') }}">Connect Bank</flux:button>
+        </div>
+    @endif
+</div>

--- a/tests/Feature/Livewire/AccountOverviewTest.php
+++ b/tests/Feature/Livewire/AccountOverviewTest.php
@@ -1,0 +1,128 @@
+<?php
+
+/** @noinspection StaticClosureCanBeUsedInspection */
+
+declare(strict_types=1);
+
+use App\Casts\MoneyCast;
+use App\Livewire\AccountOverview;
+use App\Models\Account;
+use App\Models\User;
+use Livewire\Livewire;
+
+test('component renders for authenticated user', function () {
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(AccountOverview::class)
+        ->assertSuccessful();
+});
+
+test('accounts are grouped by type', function () {
+    $user = User::factory()->create();
+    Account::factory()->for($user)->create();
+    Account::factory()->savings()->for($user)->create();
+
+    Livewire::actingAs($user)
+        ->test(AccountOverview::class)
+        ->assertSee('Transaction')
+        ->assertSee('Savings');
+});
+
+test('net worth calculates correctly from assets and liabilities', function () {
+    $user = User::factory()->create();
+    Account::factory()->for($user)->create(['balance' => 100000]);
+    Account::factory()->savings()->for($user)->create(['balance' => 200000]);
+    Account::factory()->creditCard()->for($user)->create(['balance' => -50000]);
+
+    Livewire::actingAs($user)
+        ->test(AccountOverview::class)
+        ->assertSee(MoneyCast::format(250000));
+});
+
+test('displays account name institution and formatted balance', function () {
+    $user = User::factory()->create();
+    Account::factory()->for($user)->create([
+        'name' => 'My Everyday',
+        'institution' => 'Commonwealth Bank',
+        'balance' => 123456,
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(AccountOverview::class)
+        ->assertSee('My Everyday')
+        ->assertSee('Commonwealth Bank')
+        ->assertSee(MoneyCast::format(123456));
+});
+
+test('shows last synced as relative time', function () {
+    $user = User::factory()->create();
+    Account::factory()->for($user)->create([
+        'updated_at' => now()->subHours(2),
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(AccountOverview::class)
+        ->assertSee('2 hours ago');
+});
+
+test('shows empty state when no accounts exist', function () {
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(AccountOverview::class)
+        ->assertSee('No linked accounts');
+});
+
+test('only shows current user accounts', function () {
+    $user = User::factory()->create();
+    $otherUser = User::factory()->create();
+
+    Account::factory()->for($user)->create(['name' => 'My Account']);
+    Account::factory()->for($otherUser)->create(['name' => 'Other Account']);
+
+    Livewire::actingAs($user)
+        ->test(AccountOverview::class)
+        ->assertSee('My Account')
+        ->assertDontSee('Other Account');
+});
+
+test('excludes closed accounts', function () {
+    $user = User::factory()->create();
+    Account::factory()->for($user)->create(['name' => 'Active Account']);
+    Account::factory()->closed()->for($user)->create(['name' => 'Closed Account']);
+
+    Livewire::actingAs($user)
+        ->test(AccountOverview::class)
+        ->assertSee('Active Account')
+        ->assertDontSee('Closed Account');
+});
+
+test('excludes inactive accounts', function () {
+    $user = User::factory()->create();
+    Account::factory()->for($user)->create(['name' => 'Active Account']);
+    Account::factory()->inactive()->for($user)->create(['name' => 'Inactive Account']);
+
+    Livewire::actingAs($user)
+        ->test(AccountOverview::class)
+        ->assertSee('Active Account')
+        ->assertDontSee('Inactive Account');
+});
+
+test('shows subtotals per group', function () {
+    $user = User::factory()->create();
+    Account::factory()->for($user)->create(['balance' => 100000]);
+    Account::factory()->for($user)->create(['balance' => 200000]);
+
+    Livewire::actingAs($user)
+        ->test(AccountOverview::class)
+        ->assertSee(MoneyCast::format(300000));
+});
+
+test('connect bank button links to connect-bank route', function () {
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(AccountOverview::class)
+        ->assertSeeHtml('href="'.route('connect-bank').'"');
+});

--- a/tests/Feature/Models/AccountTest.php
+++ b/tests/Feature/Models/AccountTest.php
@@ -119,3 +119,25 @@ test('closed state sets status to closed with zero balance', function () {
     expect($account->status)->toBe(AccountStatus::Closed)
         ->and($account->balance)->toBe(0);
 });
+
+test('active scope excludes closed accounts', function () {
+    $user = User::factory()->create();
+    $active = Account::factory()->for($user)->create();
+    Account::factory()->closed()->for($user)->create();
+
+    $activeAccounts = Account::query()->active()->where('user_id', $user->id)->get();
+
+    expect($activeAccounts)->toHaveCount(1)
+        ->and($activeAccounts->first()->id)->toBe($active->id);
+});
+
+test('active scope excludes inactive accounts', function () {
+    $user = User::factory()->create();
+    $active = Account::factory()->for($user)->create();
+    Account::factory()->inactive()->for($user)->create();
+
+    $activeAccounts = Account::query()->active()->where('user_id', $user->id)->get();
+
+    expect($activeAccounts)->toHaveCount(1)
+        ->and($activeAccounts->first()->id)->toBe($active->id);
+});

--- a/tests/Unit/Enums/AccountClassTest.php
+++ b/tests/Unit/Enums/AccountClassTest.php
@@ -26,3 +26,38 @@ test('account class resolves from backing value', function () {
     expect(AccountClass::from('credit-card'))->toBe(AccountClass::CreditCard)
         ->and(AccountClass::from('term-deposit'))->toBe(AccountClass::TermDeposit);
 });
+
+test('label returns human-readable names', function () {
+    expect(AccountClass::Transaction->label())->toBe('Transaction')
+        ->and(AccountClass::Savings->label())->toBe('Savings')
+        ->and(AccountClass::CreditCard->label())->toBe('Credit Card')
+        ->and(AccountClass::Loan->label())->toBe('Loan')
+        ->and(AccountClass::Mortgage->label())->toBe('Mortgage')
+        ->and(AccountClass::Investment->label())->toBe('Investment')
+        ->and(AccountClass::Insurance->label())->toBe('Insurance')
+        ->and(AccountClass::Foreign->label())->toBe('Foreign')
+        ->and(AccountClass::TermDeposit->label())->toBe('Term Deposit');
+});
+
+test('isAsset returns true for asset account types', function (AccountClass $type) {
+    expect($type->isAsset())->toBeTrue();
+})->with([
+    'transaction' => AccountClass::Transaction,
+    'savings' => AccountClass::Savings,
+    'investment' => AccountClass::Investment,
+    'insurance' => AccountClass::Insurance,
+    'foreign' => AccountClass::Foreign,
+    'term deposit' => AccountClass::TermDeposit,
+]);
+
+test('isAsset returns false for liability account types', function (AccountClass $type) {
+    expect($type->isAsset())->toBeFalse();
+})->with([
+    'credit card' => AccountClass::CreditCard,
+    'loan' => AccountClass::Loan,
+    'mortgage' => AccountClass::Mortgage,
+]);
+
+test('icon returns a non-empty string for all cases', function (AccountClass $type) {
+    expect($type->icon())->toBeString()->not->toBeEmpty();
+})->with(AccountClass::cases());


### PR DESCRIPTION
## Summary

- Add `AccountOverview` Livewire component to the dashboard that displays all linked bank accounts grouped by type with net worth summary
- Enhance `AccountClass` enum with `label()`, `isAsset()`, and `icon()` methods for display and classification logic
- Add `scopeActive()` to Account model to filter out closed/inactive accounts
- Replace dashboard bottom placeholder with lazy-loaded `<livewire:account-overview />` component

Closes #18

## Changes

| File | Change |
|------|--------|
| `app/Enums/AccountClass.php` | Added `label()`, `isAsset()`, `icon()` methods |
| `app/Models/Account.php` | Added `scopeActive()` scope + `@property` PHPDoc |
| `app/Livewire/AccountOverview.php` | New component with lazy placeholder, grouping, net worth calc |
| `resources/views/livewire/account-overview.blade.php` | Blade view with empty state, summary, grouped accounts (Flux UI) |
| `resources/views/dashboard.blade.php` | Embed `<livewire:account-overview lazy />` |
| `tests/Unit/Enums/AccountClassTest.php` | 19 new tests for enum methods |
| `tests/Feature/Models/AccountTest.php` | 2 new tests for active scope |
| `tests/Feature/Livewire/AccountOverviewTest.php` | 11 new tests for component |

## Test plan

- [x] 277 tests pass (32 new), zero failures
- [x] Pint: clean
- [x] PHPStan: clean on app files
- [ ] Manual: visit dashboard as authenticated user with seeded accounts — see grouped accounts with net worth
- [ ] Manual: visit dashboard as user with no accounts — see empty state with Connect Bank button
- [ ] Manual: verify lazy loading skeleton appears briefly before component loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)