### PR TITLE
feat: [20] Spending over time area chart

### DIFF
--- a/app/Livewire/SpendingOverTime.php
+++ b/app/Livewire/SpendingOverTime.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire;
+
+use App\Casts\MoneyCast;
+use App\Enums\TransactionDirection;
+use App\Models\Transaction;
+use Carbon\CarbonImmutable;
+use Carbon\CarbonPeriod;
+use Carbon\Constants\UnitValue;
+use Illuminate\Database\Connection;
+use Illuminate\View\View;
+use Livewire\Attributes\Computed;
+use Livewire\Component;
+
+final class SpendingOverTime extends Component
+{
+    public string $period = '30d';
+
+    /** @return array<int, array{date: string, total: int}> */
+    #[Computed(persist: true)]
+    public function timeSeriesData(): array
+    {
+        $start = $this->periodStart();
+        $aggregation = $this->aggregationLevel();
+
+        /** @var Connection $connection */
+        $connection = Transaction::query()->getConnection();
+        $isSqlite = $connection->getDriverName() === 'sqlite';
+
+        $groupExpression = match ($aggregation) {
+            'day' => 'DATE(post_date)',
+            'week' => $isSqlite
+                ? "DATE(post_date, '-' || ((CAST(strftime('%w', post_date) AS INTEGER) + 6) % 7) || ' days')"
+                : 'DATE(DATE_SUB(post_date, INTERVAL WEEKDAY(post_date) DAY))',
+            'month' => $isSqlite
+                ? "strftime('%Y-%m-01', post_date)"
+                : "DATE_FORMAT(post_date, '%Y-%m-01')",
+        };
+
+        $rows = Transaction::query()
+            ->where('user_id', auth()->id())
+            ->where('direction', TransactionDirection::Debit)
+            ->where('post_date', '>=', $start)
+            ->selectRaw("{$groupExpression} as period_date, SUM(amount) as total")
+            ->groupBy('period_date')
+            ->orderBy('period_date')
+            ->pluck('total', 'period_date');
+
+        if ($rows->isEmpty()) {
+            return [];
+        }
+
+        $interval = match ($aggregation) {
+            'day' => '1 day',
+            'week' => '1 week',
+            'month' => '1 month',
+        };
+
+        $periodDates = CarbonPeriod::create($start->startOfDay(), $interval, now()->startOfDay());
+
+        $series = [];
+
+        foreach ($periodDates as $date) {
+            $key = match ($aggregation) {
+                'day' => $date->format('Y-m-d'),
+                'week' => $date->startOfWeek(UnitValue::MONDAY)->format('Y-m-d'),
+                'month' => $date->format('Y-m-01'),
+            };
+
+            if (isset($series[$key])) {
+                continue;
+            }
+
+            $series[$key] = [
+                'date' => $key,
+                'total' => (int) ($rows[$key] ?? 0),
+            ];
+        }
+
+        return array_values($series);
+    }
+
+    public function updatedPeriod(): void
+    {
+        unset($this->timeSeriesData); // @phpstan-ignore property.notFound
+        $this->dispatch('spending-over-time-updated', data: $this->timeSeriesData, aggregation: $this->aggregationLevel()); // @phpstan-ignore property.notFound
+    }
+
+    public function placeholder(): string
+    {
+        return <<<'HTML'
+        <div>
+            <div class="space-y-4">
+                <div class="animate-pulse rounded-xl bg-zinc-100 dark:bg-zinc-800 h-8 w-32"></div>
+                <div class="animate-pulse rounded-xl bg-zinc-100 dark:bg-zinc-800 h-64"></div>
+            </div>
+        </div>
+        HTML;
+    }
+
+    public function render(): View
+    {
+        return view('livewire.spending-over-time', [
+            'formatMoney' => MoneyCast::format(...),
+            'aggregation' => $this->aggregationLevel(),
+        ]);
+    }
+
+    private function periodStart(): CarbonImmutable
+    {
+        return match ($this->period) {
+            '7d' => CarbonImmutable::now()->subDays(7)->startOfDay(),
+            '30d' => CarbonImmutable::now()->subDays(30)->startOfDay(),
+            '90d' => CarbonImmutable::now()->subDays(90)->startOfWeek(UnitValue::MONDAY),
+            '12m' => CarbonImmutable::now()->subMonths(12)->startOfMonth(),
+            default => CarbonImmutable::now()->subDays(30)->startOfDay(),
+        };
+    }
+
+    /** @return 'day'|'week'|'month' */
+    private function aggregationLevel(): string
+    {
+        return match ($this->period) {
+            '7d', '30d' => 'day',
+            '90d' => 'week',
+            '12m' => 'month',
+            default => 'day',
+        };
+    }
+}

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -2,9 +2,7 @@
     <div class="flex h-full w-full flex-1 flex-col gap-4 rounded-xl">
         <div class="grid auto-rows-min gap-4 md:grid-cols-3">
             <livewire:spending-by-category lazy />
-            <div class="relative aspect-video overflow-hidden rounded-xl border border-neutral-200 dark:border-neutral-700">
-                <x-placeholder-pattern class="absolute inset-0 size-full stroke-gray-900/20 dark:stroke-neutral-100/20" />
-            </div>
+            <livewire:spending-over-time lazy />
             <div class="relative aspect-video overflow-hidden rounded-xl border border-neutral-200 dark:border-neutral-700">
                 <x-placeholder-pattern class="absolute inset-0 size-full stroke-gray-900/20 dark:stroke-neutral-100/20" />
             </div>

--- a/resources/views/livewire/spending-by-category.blade.php
+++ b/resources/views/livewire/spending-by-category.blade.php
@@ -1,4 +1,4 @@
-<div>
+<div data-testid="spending-by-category">
     <div class="rounded-xl border border-neutral-200 dark:border-neutral-700">
         <div class="flex items-center justify-between p-4">
             <flux:heading>Spending by Category</flux:heading>

--- a/resources/views/livewire/spending-over-time.blade.php
+++ b/resources/views/livewire/spending-over-time.blade.php
@@ -1,0 +1,117 @@
+<div data-testid="spending-over-time">
+    <div class="rounded-xl border border-neutral-200 dark:border-neutral-700">
+        <div class="flex items-center justify-between p-4">
+            <flux:heading>Spending Over Time</flux:heading>
+            <flux:select wire:model.live="period" size="sm" class="w-auto">
+                <flux:select.option value="7d">7 days</flux:select.option>
+                <flux:select.option value="30d">30 days</flux:select.option>
+                <flux:select.option value="90d">90 days</flux:select.option>
+                <flux:select.option value="12m">12 months</flux:select.option>
+            </flux:select>
+        </div>
+
+        <flux:separator/>
+
+        @if(empty($this->timeSeriesData))
+            <div class="p-8 text-center">
+                <flux:icon.chart-bar class="mx-auto size-12 text-zinc-400"/>
+                <flux:heading size="lg" class="mt-4">No spending data</flux:heading>
+                <flux:text class="mt-2">Spending trends will appear here once you have transactions.</flux:text>
+            </div>
+        @else
+            <div class="p-4">
+                <div
+                        wire:ignore
+                        x-data="{
+                        chart: null,
+                        aggregation: @js($aggregation, JSON_THROW_ON_ERROR),
+                        init() {
+                            this.chart = new ApexCharts(this.$refs.chart, this.chartOptions(@js($this->timeSeriesData, JSON_THROW_ON_ERROR), this.aggregation))
+                            this.chart.render()
+
+                            Livewire.on('spending-over-time-updated', (event) => {
+                                this.aggregation = event.aggregation
+                                this.chart.updateOptions(this.chartOptions(event.data, event.aggregation))
+                            })
+                        },
+                        tooltipDateFormat(aggregation) {
+                            if (aggregation === 'month') return 'MMM yyyy'
+                            if (aggregation === 'week') return 'dd MMM yyyy'
+                            return 'dd MMM'
+                        },
+                        chartOptions(data, aggregation) {
+                            const isDark = document.documentElement.classList.contains('dark')
+                            const textColor = isDark ? '#d4d4d8' : '#3f3f46'
+
+                            return {
+                                chart: {
+                                    type: 'area',
+                                    height: 300,
+                                    toolbar: { show: false },
+                                    zoom: { enabled: false },
+                                },
+                                series: [{
+                                    name: 'Spending',
+                                    data: data.map(item => {
+                                        const [year, month, day] = item.date.split('-').map(Number)
+
+                                        return {
+                                            x: new Date(year, month - 1, day).getTime(),
+                                            y: item.total,
+                                        }
+                                    }),
+                                }],
+                                xaxis: {
+                                    type: 'datetime',
+                                    labels: {
+                                        style: { colors: textColor },
+                                        datetimeUTC: false,
+                                    },
+                                },
+                                yaxis: {
+                                    labels: {
+                                        style: { colors: textColor },
+                                        formatter: (val) => '$' + (val / 100).toLocaleString('en-AU', { minimumFractionDigits: 0, maximumFractionDigits: 0 }),
+                                    },
+                                },
+                                tooltip: {
+                                    x: { format: this.tooltipDateFormat(aggregation) },
+                                    y: {
+                                        formatter: (val) => '$' + (val / 100).toLocaleString('en-AU', { minimumFractionDigits: 2, maximumFractionDigits: 2 }),
+                                    },
+                                },
+                                colors: ['#6366F1'],
+                                fill: {
+                                    type: 'gradient',
+                                    gradient: {
+                                        shadeIntensity: 1,
+                                        opacityFrom: 0.45,
+                                        opacityTo: 0.05,
+                                        stops: [0, 100],
+                                    },
+                                },
+                                stroke: {
+                                    curve: 'smooth',
+                                    width: 2,
+                                },
+                                dataLabels: { enabled: false },
+                                grid: {
+                                    borderColor: isDark ? '#3f3f46' : '#e5e7eb',
+                                    strokeDashArray: 4,
+                                },
+                                responsive: [{
+                                    breakpoint: 480,
+                                    options: {
+                                        chart: { height: 250 },
+                                    },
+                                }],
+                            }
+                        }
+                    }"
+                >
+                    <div x-ref="chart"></div>
+                </div>
+            </div>
+        @endif
+    </div>
+</div>

--- a/tests/Browser/Livewire/SpendingByCategoryBrowserTest.php
+++ b/tests/Browser/Livewire/SpendingByCategoryBrowserTest.php
@@ -45,7 +45,7 @@ test('period selector changes update the chart', function () {
 
     $page->assertSee('Spending by Category')
         ->assertSee('Recent Spend')
-        ->select('[wire\\:model\\.live="period"]', '7d')
+        ->select('[data-testid="spending-by-category"] [wire\\:model\\.live="period"]', '7d')
         ->assertSee('Recent Spend');
 });
 

--- a/tests/Browser/Livewire/SpendingOverTimeBrowserTest.php
+++ b/tests/Browser/Livewire/SpendingOverTimeBrowserTest.php
@@ -1,0 +1,54 @@
+<?php
+
+/** @noinspection StaticClosureCanBeUsedInspection */
+
+declare(strict_types=1);
+
+use App\Models\Account;
+use App\Models\Transaction;
+use App\Models\User;
+
+test('spending chart renders area chart with data on dashboard', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+
+    Transaction::factory()->for($user)->debit()->count(3)->create([
+        'account_id' => $account->id,
+        'post_date' => now()->subDays(5),
+    ]);
+
+    $this->actingAs($user);
+
+    $page = visit('/dashboard');
+
+    $page->assertSee('Spending Over Time');
+});
+
+test('period selector changes update the chart', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+
+    Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'post_date' => now()->subDays(3),
+    ]);
+
+    $this->actingAs($user);
+
+    $page = visit('/dashboard');
+
+    $page->assertSee('Spending Over Time')
+        ->select('[data-testid="spending-over-time"] [wire\\:model\\.live="period"]', '7d')
+        ->assertSee('Spending Over Time');
+});
+
+test('empty state displays when no transactions', function () {
+    $user = User::factory()->create();
+
+    $this->actingAs($user);
+
+    $page = visit('/dashboard');
+
+    $page->assertSee('Spending Over Time')
+        ->assertSee('No spending data');
+});

--- a/tests/Feature/Livewire/SpendingOverTimeTest.php
+++ b/tests/Feature/Livewire/SpendingOverTimeTest.php
@@ -1,0 +1,258 @@
+<?php
+
+/** @noinspection StaticClosureCanBeUsedInspection */
+
+declare(strict_types=1);
+
+use App\Livewire\SpendingOverTime;
+use App\Models\Account;
+use App\Models\Transaction;
+use App\Models\User;
+use Livewire\Livewire;
+
+test('component renders for authenticated user', function () {
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(SpendingOverTime::class)
+        ->assertSuccessful();
+});
+
+test('only shows debit transactions', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+
+    Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'amount' => 5000,
+        'post_date' => now()->subDays(5),
+    ]);
+
+    Transaction::factory()->for($user)->credit()->create([
+        'account_id' => $account->id,
+        'amount' => 100000,
+        'post_date' => now()->subDays(5),
+    ]);
+
+    $component = Livewire::actingAs($user)
+        ->test(SpendingOverTime::class);
+
+    $data = $component->get('timeSeriesData');
+    $totals = collect($data)->pluck('total')->filter(fn (int $t) => $t > 0)->values();
+
+    expect($totals)->toHaveCount(1)
+        ->and($totals->first())->toBe(5000);
+});
+
+test('only shows current user transactions', function () {
+    $user = User::factory()->create();
+    $otherUser = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $otherAccount = Account::factory()->for($otherUser)->create();
+
+    Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'amount' => 3000,
+        'post_date' => now()->subDays(5),
+    ]);
+
+    Transaction::factory()->for($otherUser)->debit()->create([
+        'account_id' => $otherAccount->id,
+        'amount' => 8000,
+        'post_date' => now()->subDays(5),
+    ]);
+
+    $component = Livewire::actingAs($user)
+        ->test(SpendingOverTime::class);
+
+    $data = $component->get('timeSeriesData');
+    $nonZeroTotals = collect($data)->pluck('total')->filter(fn (int $t) => $t > 0)->values();
+
+    expect($nonZeroTotals)->toHaveCount(1)
+        ->and($nonZeroTotals->first())->toBe(3000);
+});
+
+test('aggregates daily for 7d period', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+
+    Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'amount' => 2000,
+        'post_date' => now()->subDays(3),
+    ]);
+
+    Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'amount' => 3000,
+        'post_date' => now()->subDays(3),
+    ]);
+
+    Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'amount' => 1000,
+        'post_date' => now()->subDays(1),
+    ]);
+
+    $component = Livewire::actingAs($user)
+        ->test(SpendingOverTime::class)
+        ->set('period', '7d');
+
+    $data = $component->get('timeSeriesData');
+    $nonZero = collect($data)->filter(fn (array $item) => $item['total'] > 0);
+
+    expect($nonZero)->toHaveCount(2);
+
+    $dayThreeAgo = $nonZero->firstWhere('date', now()->subDays(3)->format('Y-m-d'));
+    expect($dayThreeAgo['total'])->toBe(5000);
+});
+
+test('aggregates daily for 30d period', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+
+    Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'amount' => 4000,
+        'post_date' => now()->subDays(15),
+    ]);
+
+    $component = Livewire::actingAs($user)
+        ->test(SpendingOverTime::class)
+        ->set('period', '30d');
+
+    $data = $component->get('timeSeriesData');
+
+    expect($data)->toHaveCount(31)
+        ->and(collect($data)->firstWhere('date', now()->subDays(15)->format('Y-m-d'))['total'])->toBe(4000);
+});
+
+test('aggregates weekly for 90d period', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+
+    $monday = now()->subWeeks(4)->startOfWeek();
+
+    Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'amount' => 2000,
+        'post_date' => $monday,
+    ]);
+
+    Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'amount' => 3000,
+        'post_date' => $monday->copy()->addDays(2),
+    ]);
+
+    $component = Livewire::actingAs($user)
+        ->test(SpendingOverTime::class)
+        ->set('period', '90d');
+
+    $data = $component->get('timeSeriesData');
+    $weekEntry = collect($data)->firstWhere('date', $monday->format('Y-m-d'));
+
+    expect($weekEntry)->not->toBeNull()
+        ->and($weekEntry['total'])->toBe(5000);
+});
+
+test('aggregates monthly for 12m period', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+
+    $monthStart = now()->subMonths(3)->startOfMonth();
+
+    Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'amount' => 6000,
+        'post_date' => $monthStart->copy()->addDays(5),
+    ]);
+
+    Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'amount' => 4000,
+        'post_date' => $monthStart->copy()->addDays(10),
+    ]);
+
+    $component = Livewire::actingAs($user)
+        ->test(SpendingOverTime::class)
+        ->set('period', '12m');
+
+    $data = $component->get('timeSeriesData');
+    $monthEntry = collect($data)->firstWhere('date', $monthStart->format('Y-m-01'));
+
+    expect($monthEntry)->not->toBeNull()
+        ->and($monthEntry['total'])->toBe(10000);
+});
+
+test('fills zero values for missing periods', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+
+    Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'amount' => 1000,
+        'post_date' => now()->subDays(1),
+    ]);
+
+    Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'amount' => 2000,
+        'post_date' => now()->subDays(5),
+    ]);
+
+    $component = Livewire::actingAs($user)
+        ->test(SpendingOverTime::class)
+        ->set('period', '7d');
+
+    $data = $component->get('timeSeriesData');
+
+    expect($data)->toHaveCount(8);
+
+    $zeroEntries = collect($data)->filter(fn (array $item) => $item['total'] === 0);
+    expect($zeroEntries)->toHaveCount(6);
+});
+
+test('period selector filters by date range', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+
+    Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'amount' => 2000,
+        'post_date' => now()->subDays(3),
+    ]);
+
+    Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'amount' => 5000,
+        'post_date' => now()->subDays(20),
+    ]);
+
+    $component = Livewire::actingAs($user)
+        ->test(SpendingOverTime::class)
+        ->set('period', '7d');
+
+    $data = $component->get('timeSeriesData');
+    $nonZeroTotals = collect($data)->pluck('total')->filter(fn (int $t) => $t > 0);
+
+    expect($nonZeroTotals)->toHaveCount(1)
+        ->and($nonZeroTotals->first())->toBe(2000);
+});
+
+test('changing period dispatches spending-over-time-updated event', function () {
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(SpendingOverTime::class)
+        ->set('period', '90d')
+        ->assertDispatched('spending-over-time-updated');
+});
+
+test('empty state when no transactions exist', function () {
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(SpendingOverTime::class)
+        ->assertSee('No spending data');
+});


### PR DESCRIPTION
## Summary

- Add `SpendingOverTime` Livewire component with ApexCharts area chart displaying spending trends over configurable time periods (7d, 30d, 90d, 12m)
- Smart aggregation: daily for 7d/30d, weekly for 90d, monthly for 12m — with zero-filled gaps for continuous x-axis
- Replace second dashboard placeholder with the new chart widget
- Scope period selector test IDs (`data-testid`) on both chart components to prevent ambiguous selectors now that two period selects exist on the dashboard

## Test plan

- [x] 11 Pest feature tests covering rendering, data isolation, aggregation levels (daily/weekly/monthly), zero-fill gaps, period filtering, event dispatch, and empty state
- [x] 3 Pest Browser tests covering chart rendering on dashboard, period selector interaction, and empty state
- [x] Fix pre-existing `SpendingByCategoryBrowserTest` selector ambiguity caused by two `wire:model.live="period"` selects on dashboard
- [x] All 317 tests passing, PHPStan clean, Pint clean

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)