### PR TITLE
feat: [54] Pay cycle settings + Buffer Until Next Pay dashboard widget

### DIFF
--- a/app/Enums/PayFrequency.php
+++ b/app/Enums/PayFrequency.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+enum PayFrequency: string
+{
+    case Weekly = 'weekly';
+    case Fortnightly = 'fortnightly';
+    case Monthly = 'monthly';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Weekly => 'Weekly',
+            self::Fortnightly => 'Fortnightly',
+            self::Monthly => 'Monthly',
+        };
+    }
+}

--- a/app/Livewire/AccountOverview.php
+++ b/app/Livewire/AccountOverview.php
@@ -26,7 +26,9 @@ final class AccountOverview extends Component
 
     public function render(): View
     {
-        $accounts = auth()->user()
+        $user = auth()->user();
+
+        $accounts = $user
             ->accounts()
             ->active()
             ->orderBy('type')
@@ -35,12 +37,14 @@ final class AccountOverview extends Component
         $availableToSpend = $accounts
             ->filter(fn (Account $a) => $a->type->isSpendable())
             ->sum(fn (Account $a) => $a->availableBalance());
-
+        $buffer = $user->bufferUntilNextPay($availableToSpend);
         $lastSynced = $accounts->max('updated_at');
 
         return view('livewire.account-overview', [
             'accounts' => $accounts,
             'availableToSpend' => $availableToSpend,
+            'buffer' => $buffer,
+            'hasPayCycle' => $user->hasPayCycleConfigured(),
             'lastSynced' => $lastSynced,
             'formatMoney' => MoneyCast::format(...),
         ]);

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use App\Casts\MoneyCast;
+use App\Enums\PayFrequency;
 use Carbon\CarbonImmutable;
 use Database\Factories\UserFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -13,7 +15,13 @@ use Illuminate\Notifications\Notifiable;
 use Illuminate\Support\Str;
 use Laravel\Fortify\TwoFactorAuthenticatable;
 
-/** @property CarbonImmutable|null $last_synced_at */
+/**
+ * @property CarbonImmutable|null $last_synced_at
+ * @property int|null $pay_amount
+ * @property PayFrequency|null $pay_frequency
+ * @property CarbonImmutable|null $next_pay_date
+ * @property int|null $committed_per_cycle
+ */
 final class User extends Authenticatable
 {
     /** @use HasFactory<UserFactory> */
@@ -30,6 +38,10 @@ final class User extends Authenticatable
         'basiq_user_id',
         'last_synced_at',
         'password',
+        'pay_amount',
+        'pay_frequency',
+        'next_pay_date',
+        'committed_per_cycle',
     ];
 
     /**
@@ -74,9 +86,24 @@ final class User extends Authenticatable
         return $this->hasMany(Budget::class);
     }
 
+    public function hasPayCycleConfigured(): bool
+    {
+        return $this->pay_amount !== null
+            && $this->pay_frequency !== null
+            && $this->next_pay_date !== null
+            && $this->committed_per_cycle !== null;
+    }
+
+    public function bufferUntilNextPay(int $availableToSpend): ?int
+    {
+        if (! $this->hasPayCycleConfigured()) {
+            return null;
+        }
+
+        return $availableToSpend - $this->committed_per_cycle;
+    }
+
     /**
-     * Get the attributes that should be cast.
-     *
      * @return array<string, string>
      */
     protected function casts(): array
@@ -85,6 +112,10 @@ final class User extends Authenticatable
             'email_verified_at' => 'datetime',
             'last_synced_at' => 'datetime',
             'password' => 'hashed',
+            'pay_amount' => MoneyCast::class,
+            'pay_frequency' => PayFrequency::class,
+            'next_pay_date' => 'date',
+            'committed_per_cycle' => MoneyCast::class,
         ];
     }
 }

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Database\Factories;
 
+use App\Enums\PayFrequency;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Facades\Hash;
@@ -69,6 +70,16 @@ final class UserFactory extends Factory
             'two_factor_secret' => encrypt('secret'),
             'two_factor_recovery_codes' => encrypt(json_encode(['recovery-code-1'])),
             'two_factor_confirmed_at' => now(),
+        ]);
+    }
+
+    public function withPayCycle(): self
+    {
+        return $this->state(fn (array $attributes) => [
+            'pay_amount' => 300000,
+            'pay_frequency' => PayFrequency::Fortnightly,
+            'next_pay_date' => now()->addDays(7),
+            'committed_per_cycle' => 180000,
         ]);
     }
 }

--- a/database/migrations/2026_03_21_120031_add_pay_cycle_settings_to_users_table.php
+++ b/database/migrations/2026_03_21_120031_add_pay_cycle_settings_to_users_table.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->bigInteger('pay_amount')->nullable();
+            $table->string('pay_frequency')->nullable();
+            $table->date('next_pay_date')->nullable();
+            $table->bigInteger('committed_per_cycle')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn(['pay_amount', 'pay_frequency', 'next_pay_date', 'committed_per_cycle']);
+        });
+    }
+};

--- a/resources/views/livewire/account-overview.blade.php
+++ b/resources/views/livewire/account-overview.blade.php
@@ -1,3 +1,4 @@
+@php use App\Enums\AccountClass; @endphp
 <div class="space-y-6">
     @if($accounts->isEmpty())
         <div class="rounded-xl border border-neutral-200 p-8 text-center dark:border-neutral-700">
@@ -14,6 +15,21 @@
             <p class="mt-1 text-5xl font-bold tracking-tight tabular-nums sm:text-6xl md:text-7xl {{ $availableToSpend >= 0 ? 'text-green-600 dark:text-green-500' : 'text-red-600 dark:text-red-500' }}">
                 {{ $formatMoney($availableToSpend) }}
             </p>
+            @if($hasPayCycle)
+                <p class="mt-2 text-lg font-semibold tabular-nums {{ $buffer > 0 ? 'text-green-600 dark:text-green-500' : ($buffer < 0 ? 'text-red-600 dark:text-red-500' : 'text-zinc-500 dark:text-zinc-400') }}">
+                    @if($buffer > 0)
+                        +{{ $formatMoney($buffer) }} above what you need
+                    @elseif($buffer < 0)
+                        {{ $formatMoney($buffer) }} below what you need
+                    @else
+                        {{ $formatMoney(0) }} — right on target
+                    @endif
+                </p>
+            @else
+                <div class="mt-2">
+                    <flux:link href="{{ route('pay-cycle.edit') }}" variant="subtle" class="text-sm">Set up pay cycle →</flux:link>
+                </div>
+            @endif
             @if($lastSynced)
                 <flux:text size="sm" class="mt-2">Last synced {{ $lastSynced->diffForHumans() }}</flux:text>
             @endif
@@ -21,20 +37,20 @@
 
         <div x-data="{ open: false }">
             <button
-                x-on:click="open = !open"
-                class="flex w-full items-center justify-between rounded-xl border border-neutral-200 px-4 py-3 text-left dark:border-neutral-700"
+                    x-on:click="open = !open"
+                    class="flex w-full items-center justify-between rounded-xl border border-neutral-200 px-4 py-3 text-left dark:border-neutral-700"
             >
                 <flux:text class="font-medium">Account breakdown</flux:text>
                 <flux:icon.chevron-down
-                    class="size-5 text-zinc-400 transition-transform duration-200"
-                    ::class="open ? 'rotate-180' : ''"
+                        class="size-5 text-zinc-400 transition-transform duration-200"
+                        ::class="open ? 'rotate-180' : ''"
                 />
             </button>
 
             <div
-                x-show="open"
-                x-collapse
-                class="mt-2 rounded-xl border border-neutral-200 dark:border-neutral-700"
+                    x-show="open"
+                    x-collapse
+                    class="mt-2 rounded-xl border border-neutral-200 dark:border-neutral-700"
             >
                 <div class="divide-y divide-neutral-200 dark:divide-neutral-700">
                     @foreach($accounts as $account)
@@ -45,7 +61,7 @@
                             </div>
                             <div class="text-right">
                                 <flux:text class="tabular-nums font-medium">{{ $formatMoney($account->availableBalance()) }}</flux:text>
-                                @if($account->type === \App\Enums\AccountClass::CreditCard)
+                                @if($account->type === AccountClass::CreditCard)
                                     <flux:text size="sm" class="tabular-nums text-zinc-500">Current {{ $formatMoney($account->balance) }}</flux:text>
                                 @endif
                             </div>

--- a/resources/views/pages/settings/layout.blade.php
+++ b/resources/views/pages/settings/layout.blade.php
@@ -1,5 +1,5 @@
 <div class="flex items-start max-md:flex-col">
-    <div class="me-10 w-full pb-4 md:w-[220px]">
+    <div class="me-10 w-full pb-4 md:w-56">
         <flux:navlist aria-label="{{ __('Settings') }}">
             <flux:navlist.item :href="route('profile.edit')" wire:navigate>{{ __('Profile') }}</flux:navlist.item>
             <flux:navlist.item :href="route('user-password.edit')" wire:navigate>{{ __('Password') }}</flux:navlist.item>
@@ -7,6 +7,7 @@
                 <flux:navlist.item :href="route('two-factor.show')" wire:navigate>{{ __('Two-factor auth') }}</flux:navlist.item>
             @endif
             <flux:navlist.item :href="route('appearance.edit')" wire:navigate>{{ __('Appearance') }}</flux:navlist.item>
+            <flux:navlist.item :href="route('pay-cycle.edit')" wire:navigate>{{ __('Pay cycle') }}</flux:navlist.item>
         </flux:navlist>
     </div>
 

--- a/resources/views/pages/settings/⚡pay-cycle.blade.php
+++ b/resources/views/pages/settings/⚡pay-cycle.blade.php
@@ -1,0 +1,101 @@
+<?php
+
+use App\Enums\PayFrequency;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\Rule;
+use Livewire\Attributes\Title;
+use Livewire\Component;
+
+new #[Title('Pay cycle settings')] class extends Component {
+    public string $pay_amount = '';
+    public string $pay_frequency = '';
+    public string $next_pay_date = '';
+    public string $committed_per_cycle = '';
+
+    public function mount(): void
+    {
+        $user = Auth::user();
+
+        $this->pay_amount = $user->pay_amount ? number_format($user->pay_amount / 100, 2, '.', '') : '';
+        $this->pay_frequency = $user->pay_frequency?->value ?? '';
+        $this->next_pay_date = $user->next_pay_date?->format('Y-m-d') ?? '';
+        $this->committed_per_cycle = $user->committed_per_cycle ? number_format($user->committed_per_cycle / 100, 2, '.', '') : '';
+    }
+
+    public function save(): void
+    {
+        $validated = $this->validate([
+            'pay_amount' => ['required', 'numeric', 'min:0'],
+            'pay_frequency' => ['required', Rule::enum(PayFrequency::class)],
+            'next_pay_date' => ['required', 'date', 'after_or_equal:today'],
+            'committed_per_cycle' => ['required', 'numeric', 'min:0'],
+        ]);
+
+        Auth::user()->update([
+            'pay_amount' => (int) round((float) $validated['pay_amount'] * 100),
+            'pay_frequency' => $validated['pay_frequency'],
+            'next_pay_date' => $validated['next_pay_date'],
+            'committed_per_cycle' => (int) round((float) $validated['committed_per_cycle'] * 100),
+        ]);
+
+        $this->dispatch('pay-cycle-updated');
+    }
+}; ?>
+
+<section class="w-full">
+    @include('partials.settings-heading')
+
+    <flux:heading class="sr-only">{{ __('Pay cycle settings') }}</flux:heading>
+
+    <x-pages::settings.layout :heading="__('Pay cycle')" :subheading="__('Configure your pay schedule and committed expenses')">
+        <form wire:submit="save" class="my-6 w-full space-y-6">
+            <flux:input
+                wire:model="pay_amount"
+                :label="__('Pay amount per cycle')"
+                type="number"
+                step="0.01"
+                min="0"
+                placeholder="0.00"
+                :description="__('How much you receive each pay cycle (before tax)')"
+                required
+            />
+
+            <flux:select wire:model="pay_frequency" :label="__('Pay frequency')" required>
+                <flux:select.option value="">{{ __('Select frequency') }}</flux:select.option>
+                @foreach(PayFrequency::cases() as $frequency)
+                    <flux:select.option value="{{ $frequency->value }}">{{ $frequency->label() }}</flux:select.option>
+                @endforeach
+            </flux:select>
+
+            <flux:input
+                wire:model="next_pay_date"
+                :label="__('Next pay date')"
+                type="date"
+                required
+            />
+
+            <flux:input
+                wire:model="committed_per_cycle"
+                :label="__('Committed expenses per cycle')"
+                type="number"
+                step="0.01"
+                min="0"
+                placeholder="0.00"
+                :description="__('How much you need for essentials each cycle (bills, rent, groceries)')"
+                required
+            />
+
+            <div class="flex items-center gap-4">
+                <div class="flex items-center justify-end">
+                    <flux:button variant="primary" type="submit" class="w-full" data-test="save-pay-cycle-button">
+                        {{ __('Save') }}
+                    </flux:button>
+                </div>
+
+                <x-action-message class="me-3" on="pay-cycle-updated">
+                    {{ __('Saved.') }}
+                </x-action-message>
+            </div>
+        </form>
+    </x-pages::settings.layout>
+</section>

--- a/routes/settings.php
+++ b/routes/settings.php
@@ -14,14 +14,15 @@ Route::middleware(['auth'])->group(function () {
 Route::middleware(['auth', 'verified'])->group(function () {
     Route::livewire('settings/password', 'pages::settings.password')->name('user-password.edit');
     Route::livewire('settings/appearance', 'pages::settings.appearance')->name('appearance.edit');
+    Route::livewire('settings/pay-cycle', 'pages::settings.pay-cycle')->name('pay-cycle.edit');
 
     Route::livewire('settings/two-factor', 'pages::settings.two-factor')
         ->middleware(
             when(
                 Features::canManageTwoFactorAuthentication()
                 && Features::optionEnabled(Features::twoFactorAuthentication(), 'confirmPassword'),
-                ['password.confirm'],
-                [],
+                static fn () => ['password.confirm'],
+                static fn () => [],
             ),
         )
         ->name('two-factor.show');

--- a/tests/Browser/Livewire/AccountOverviewBrowserTest.php
+++ b/tests/Browser/Livewire/AccountOverviewBrowserTest.php
@@ -1,0 +1,72 @@
+<?php
+
+/** @noinspection StaticClosureCanBeUsedInspection */
+
+declare(strict_types=1);
+
+use App\Models\Account;
+use App\Models\User;
+
+test('dashboard shows buffer number when pay cycle is configured', function () {
+    $user = User::factory()->withPayCycle()->create([
+        'committed_per_cycle' => 100000,
+    ]);
+    Account::factory()->for($user)->create(['balance' => 150000]);
+
+    $this->actingAs($user);
+
+    $page = visit('/dashboard');
+
+    $page->assertSee('Available to Spend')
+        ->assertSee('above what you need');
+});
+
+test('buffer text shows positive message for positive buffer', function () {
+    $user = User::factory()->withPayCycle()->create([
+        'committed_per_cycle' => 100000,
+    ]);
+    Account::factory()->for($user)->create(['balance' => 200000]);
+
+    $this->actingAs($user);
+
+    $page = visit('/dashboard');
+
+    $page->assertSee('above what you need');
+});
+
+test('buffer text shows negative message for negative buffer', function () {
+    $user = User::factory()->withPayCycle()->create([
+        'committed_per_cycle' => 300000,
+    ]);
+    Account::factory()->for($user)->create(['balance' => 100000]);
+
+    $this->actingAs($user);
+
+    $page = visit('/dashboard');
+
+    $page->assertSee('below what you need');
+});
+
+test('set up pay cycle CTA appears when not configured', function () {
+    $user = User::factory()->create();
+    Account::factory()->for($user)->create();
+
+    $this->actingAs($user);
+
+    $page = visit('/dashboard');
+
+    $page->assertSee('Set up pay cycle');
+});
+
+test('set up pay cycle CTA links to settings page', function () {
+    $user = User::factory()->create();
+    Account::factory()->for($user)->create();
+
+    $this->actingAs($user);
+
+    $page = visit('/dashboard');
+
+    $page->assertSee('Set up pay cycle')
+        ->click('Set up pay cycle →')
+        ->assertPathBeginsWith('/settings/pay-cycle');
+});

--- a/tests/Browser/Settings/PayCycleSettingsBrowserTest.php
+++ b/tests/Browser/Settings/PayCycleSettingsBrowserTest.php
@@ -1,0 +1,57 @@
+<?php
+
+/** @noinspection StaticClosureCanBeUsedInspection */
+
+declare(strict_types=1);
+
+use App\Models\User;
+
+test('pay cycle settings page renders with all form fields', function () {
+    $user = User::factory()->create();
+
+    $this->actingAs($user);
+
+    $page = visit('/settings/pay-cycle');
+
+    $page->assertSee('Pay cycle')
+        ->assertSee('Pay amount per cycle')
+        ->assertSee('Pay frequency')
+        ->assertSee('Next pay date')
+        ->assertSee('Committed expenses per cycle');
+});
+
+test('user can fill and save pay cycle form', function () {
+    $user = User::factory()->create();
+
+    $this->actingAs($user);
+
+    $page = visit('/settings/pay-cycle');
+
+    $page->assertSee('Pay cycle')
+        ->fill('[wire\\:model="pay_amount"]', '3000')
+        ->select('[wire\\:model="pay_frequency"]', 'fortnightly')
+        ->fill('[wire\\:model="next_pay_date"]', now()->addDays(7)->format('Y-m-d'))
+        ->fill('[wire\\:model="committed_per_cycle"]', '1800')
+        ->click('[data-test="save-pay-cycle-button"]')
+        ->assertSee('Saved.');
+
+    $user->refresh();
+
+    expect($user->pay_amount)->toBe(300000)
+        ->and($user->committed_per_cycle)->toBe(180000);
+});
+
+test('saved values persist on page reload', function () {
+    $user = User::factory()->withPayCycle()->create([
+        'pay_amount' => 250000,
+        'committed_per_cycle' => 150000,
+    ]);
+
+    $this->actingAs($user);
+
+    $page = visit('/settings/pay-cycle');
+
+    $page->assertSee('Pay cycle')
+        ->assertSee('Pay amount per cycle')
+        ->assertSee('Committed expenses per cycle');
+});

--- a/tests/Feature/Livewire/AccountOverviewTest.php
+++ b/tests/Feature/Livewire/AccountOverviewTest.php
@@ -180,3 +180,71 @@ test('connect bank button links to connect-bank route', function () {
         ->test(AccountOverview::class)
         ->assertSeeHtml('href="'.route('connect-bank').'"');
 });
+
+test('shows positive buffer when pay cycle configured and above committed', function () {
+    $user = User::factory()->withPayCycle()->create([
+        'committed_per_cycle' => 100000,
+    ]);
+    Account::factory()->for($user)->create(['balance' => 150000]);
+
+    Livewire::actingAs($user)
+        ->test(AccountOverview::class)
+        ->assertSee('above what you need')
+        ->assertSee(MoneyCast::format(50000));
+});
+
+test('shows negative buffer when pay cycle configured and below committed', function () {
+    $user = User::factory()->withPayCycle()->create([
+        'committed_per_cycle' => 200000,
+    ]);
+    Account::factory()->for($user)->create(['balance' => 100000]);
+
+    Livewire::actingAs($user)
+        ->test(AccountOverview::class)
+        ->assertSee('below what you need')
+        ->assertSee(MoneyCast::format(-100000));
+});
+
+test('shows zero buffer state', function () {
+    $user = User::factory()->withPayCycle()->create([
+        'committed_per_cycle' => 100000,
+    ]);
+    Account::factory()->for($user)->create(['balance' => 100000]);
+
+    Livewire::actingAs($user)
+        ->test(AccountOverview::class)
+        ->assertSee('right on target');
+});
+
+test('shows set up pay cycle link when not configured', function () {
+    $user = User::factory()->create();
+    Account::factory()->for($user)->create();
+
+    Livewire::actingAs($user)
+        ->test(AccountOverview::class)
+        ->assertSee('Set up pay cycle')
+        ->assertDontSee('above what you need')
+        ->assertDontSee('below what you need');
+});
+
+test('buffer does not show when no accounts exist', function () {
+    $user = User::factory()->withPayCycle()->create();
+
+    Livewire::actingAs($user)
+        ->test(AccountOverview::class)
+        ->assertDontSee('above what you need')
+        ->assertDontSee('below what you need');
+});
+
+test('buffer calculation excludes non-spendable accounts', function () {
+    $user = User::factory()->withPayCycle()->create([
+        'committed_per_cycle' => 100000,
+    ]);
+    Account::factory()->for($user)->create(['balance' => 150000]);
+    Account::factory()->loan()->for($user)->create(['balance' => -500000]);
+
+    Livewire::actingAs($user)
+        ->test(AccountOverview::class)
+        ->assertSee('above what you need')
+        ->assertSee(MoneyCast::format(50000));
+});

--- a/tests/Feature/Models/UserTest.php
+++ b/tests/Feature/Models/UserTest.php
@@ -4,6 +4,7 @@
 
 declare(strict_types=1);
 
+use App\Enums\PayFrequency;
 use App\Models\Account;
 use App\Models\Budget;
 use App\Models\Transaction;
@@ -61,4 +62,64 @@ test('user has many budgets', function () {
 
     expect($user->budgets)->toHaveCount(3)
         ->each(fn (Pest\Expectation $budget) => $budget->toBeInstanceOf(Budget::class));
+});
+
+test('hasPayCycleConfigured returns false when no pay cycle fields set', function () {
+    $user = User::factory()->create();
+
+    expect($user->hasPayCycleConfigured())->toBeFalse();
+});
+
+test('hasPayCycleConfigured returns false when only some fields set', function () {
+    $user = User::factory()->create([
+        'pay_amount' => 300000,
+        'pay_frequency' => PayFrequency::Fortnightly,
+    ]);
+
+    expect($user->hasPayCycleConfigured())->toBeFalse();
+});
+
+test('hasPayCycleConfigured returns true when all fields set', function () {
+    $user = User::factory()->withPayCycle()->create();
+
+    expect($user->hasPayCycleConfigured())->toBeTrue();
+});
+
+test('bufferUntilNextPay returns null when pay cycle not configured', function () {
+    $user = User::factory()->create();
+
+    expect($user->bufferUntilNextPay(200000))->toBeNull();
+});
+
+test('bufferUntilNextPay returns positive buffer when above committed', function () {
+    $user = User::factory()->withPayCycle()->create([
+        'committed_per_cycle' => 180000,
+    ]);
+
+    expect($user->bufferUntilNextPay(200000))->toBe(20000);
+});
+
+test('bufferUntilNextPay returns negative buffer when below committed', function () {
+    $user = User::factory()->withPayCycle()->create([
+        'committed_per_cycle' => 180000,
+    ]);
+
+    expect($user->bufferUntilNextPay(100000))->toBe(-80000);
+});
+
+test('bufferUntilNextPay returns zero when exactly at committed', function () {
+    $user = User::factory()->withPayCycle()->create([
+        'committed_per_cycle' => 200000,
+    ]);
+
+    expect($user->bufferUntilNextPay(200000))->toBe(0);
+});
+
+test('withPayCycle factory state sets all pay cycle fields', function () {
+    $user = User::factory()->withPayCycle()->create();
+
+    expect($user->pay_amount)->not->toBeNull()
+        ->and($user->pay_frequency)->toBe(PayFrequency::Fortnightly)
+        ->and($user->next_pay_date)->not->toBeNull()
+        ->and($user->committed_per_cycle)->not->toBeNull();
 });

--- a/tests/Feature/Settings/PayCycleSettingsTest.php
+++ b/tests/Feature/Settings/PayCycleSettingsTest.php
@@ -1,0 +1,160 @@
+<?php
+
+/** @noinspection StaticClosureCanBeUsedInspection */
+
+declare(strict_types=1);
+
+use App\Enums\PayFrequency;
+use App\Models\User;
+use Livewire\Livewire;
+
+test('pay cycle settings page is displayed', function () {
+    $this->actingAs(User::factory()->create());
+
+    $this->get(route('pay-cycle.edit'))->assertOk();
+});
+
+test('unauthenticated user is redirected from pay cycle settings', function () {
+    $this->get(route('pay-cycle.edit'))->assertRedirect(route('login'));
+});
+
+test('user can save pay cycle settings', function () {
+    $user = User::factory()->create();
+
+    $this->actingAs($user);
+
+    $response = Livewire::test('pages::settings.pay-cycle')
+        ->set('pay_amount', '3000.00')
+        ->set('pay_frequency', 'fortnightly')
+        ->set('next_pay_date', now()->addDays(7)->format('Y-m-d'))
+        ->set('committed_per_cycle', '1800.00')
+        ->call('save');
+
+    $response->assertHasNoErrors()
+        ->assertDispatched('pay-cycle-updated');
+
+    $user->refresh();
+
+    expect($user->pay_amount)->toBe(300000)
+        ->and($user->pay_frequency)->toBe(PayFrequency::Fortnightly)
+        ->and($user->next_pay_date)->not->toBeNull()
+        ->and($user->committed_per_cycle)->toBe(180000);
+});
+
+test('dollar inputs correctly convert to cents in database', function () {
+    $user = User::factory()->create();
+
+    $this->actingAs($user);
+
+    Livewire::test('pages::settings.pay-cycle')
+        ->set('pay_amount', '1234.56')
+        ->set('pay_frequency', 'weekly')
+        ->set('next_pay_date', now()->addDays(3)->format('Y-m-d'))
+        ->set('committed_per_cycle', '789.01')
+        ->call('save')
+        ->assertHasNoErrors();
+
+    $user->refresh();
+
+    expect($user->pay_amount)->toBe(123456)
+        ->and($user->committed_per_cycle)->toBe(78901);
+});
+
+test('saved settings display on reload', function () {
+    $user = User::factory()->withPayCycle()->create([
+        'pay_amount' => 250000,
+        'committed_per_cycle' => 150000,
+    ]);
+
+    $this->actingAs($user);
+
+    $component = Livewire::test('pages::settings.pay-cycle');
+
+    expect($component->get('pay_amount'))->toBe('2500.00')
+        ->and($component->get('pay_frequency'))->toBe('fortnightly')
+        ->and($component->get('committed_per_cycle'))->toBe('1500.00');
+});
+
+test('validation rejects missing pay amount', function () {
+    $user = User::factory()->create();
+
+    $this->actingAs($user);
+
+    Livewire::test('pages::settings.pay-cycle')
+        ->set('pay_amount', '')
+        ->set('pay_frequency', 'weekly')
+        ->set('next_pay_date', now()->addDays(3)->format('Y-m-d'))
+        ->set('committed_per_cycle', '500.00')
+        ->call('save')
+        ->assertHasErrors(['pay_amount']);
+});
+
+test('validation rejects negative pay amount', function () {
+    $user = User::factory()->create();
+
+    $this->actingAs($user);
+
+    Livewire::test('pages::settings.pay-cycle')
+        ->set('pay_amount', '-100.00')
+        ->set('pay_frequency', 'weekly')
+        ->set('next_pay_date', now()->addDays(3)->format('Y-m-d'))
+        ->set('committed_per_cycle', '500.00')
+        ->call('save')
+        ->assertHasErrors(['pay_amount']);
+});
+
+test('validation rejects invalid pay frequency', function () {
+    $user = User::factory()->create();
+
+    $this->actingAs($user);
+
+    Livewire::test('pages::settings.pay-cycle')
+        ->set('pay_amount', '3000.00')
+        ->set('pay_frequency', 'daily')
+        ->set('next_pay_date', now()->addDays(3)->format('Y-m-d'))
+        ->set('committed_per_cycle', '500.00')
+        ->call('save')
+        ->assertHasErrors(['pay_frequency']);
+});
+
+test('validation rejects missing next pay date', function () {
+    $user = User::factory()->create();
+
+    $this->actingAs($user);
+
+    Livewire::test('pages::settings.pay-cycle')
+        ->set('pay_amount', '3000.00')
+        ->set('pay_frequency', 'weekly')
+        ->set('next_pay_date', '')
+        ->set('committed_per_cycle', '500.00')
+        ->call('save')
+        ->assertHasErrors(['next_pay_date']);
+});
+
+test('validation rejects past next pay date', function () {
+    $user = User::factory()->create();
+
+    $this->actingAs($user);
+
+    Livewire::test('pages::settings.pay-cycle')
+        ->set('pay_amount', '3000.00')
+        ->set('pay_frequency', 'weekly')
+        ->set('next_pay_date', now()->subDay()->format('Y-m-d'))
+        ->set('committed_per_cycle', '500.00')
+        ->call('save')
+        ->assertHasErrors(['next_pay_date']);
+});
+
+test('validation rejects negative committed amount', function () {
+    $user = User::factory()->create();
+
+    $this->actingAs($user);
+
+    Livewire::test('pages::settings.pay-cycle')
+        ->set('pay_amount', '3000.00')
+        ->set('pay_frequency', 'weekly')
+        ->set('next_pay_date', now()->addDays(3)->format('Y-m-d'))
+        ->set('committed_per_cycle', '-200.00')
+        ->call('save')
+        ->assertHasErrors(['committed_per_cycle']);
+});

--- a/tests/Unit/Enums/PayFrequencyTest.php
+++ b/tests/Unit/Enums/PayFrequencyTest.php
@@ -1,0 +1,29 @@
+<?php
+
+/** @noinspection StaticClosureCanBeUsedInspection */
+
+declare(strict_types=1);
+
+use App\Enums\PayFrequency;
+
+test('all pay frequency cases exist', function () {
+    expect(PayFrequency::cases())->toHaveCount(3);
+});
+
+test('pay frequency has correct backing values', function () {
+    expect(PayFrequency::Weekly->value)->toBe('weekly')
+        ->and(PayFrequency::Fortnightly->value)->toBe('fortnightly')
+        ->and(PayFrequency::Monthly->value)->toBe('monthly');
+});
+
+test('pay frequency resolves from backing value', function () {
+    expect(PayFrequency::from('weekly'))->toBe(PayFrequency::Weekly)
+        ->and(PayFrequency::from('fortnightly'))->toBe(PayFrequency::Fortnightly)
+        ->and(PayFrequency::from('monthly'))->toBe(PayFrequency::Monthly);
+});
+
+test('pay frequency has labels', function () {
+    expect(PayFrequency::Weekly->label())->toBe('Weekly')
+        ->and(PayFrequency::Fortnightly->label())->toBe('Fortnightly')
+        ->and(PayFrequency::Monthly->label())->toBe('Monthly');
+});


### PR DESCRIPTION
## Summary

- Adds pay cycle configuration (pay amount, frequency, next pay date, committed expenses) to user settings
- Displays "Buffer Until Next Pay" on the dashboard below "Available to Spend" — green when above committed, red when below, with a "Set up pay cycle →" CTA when not configured
- Creates `PayFrequency` enum (`Weekly`, `Fortnightly`, `Monthly`)
- Adds `bufferUntilNextPay()` and `hasPayCycleConfigured()` methods to User model
- Fixes pre-existing PHPStan issue with `when()` helper in settings routes

## Files Changed

**New files:**
- `app/Enums/PayFrequency.php`
- `database/migrations/*_add_pay_cycle_settings_to_users_table.php`
- `resources/views/pages/settings/⚡pay-cycle.blade.php`
- `tests/Unit/Enums/PayFrequencyTest.php`
- `tests/Feature/Settings/PayCycleSettingsTest.php`
- `tests/Browser/Livewire/AccountOverviewBrowserTest.php`
- `tests/Browser/Settings/PayCycleSettingsBrowserTest.php`

**Modified files:**
- `app/Models/User.php` — pay cycle fields, casts, buffer methods
- `database/factories/UserFactory.php` — `withPayCycle()` state
- `routes/settings.php` — pay-cycle route + `when()` closure fix
- `resources/views/pages/settings/layout.blade.php` — nav item
- `app/Livewire/AccountOverview.php` — buffer calculation
- `resources/views/livewire/account-overview.blade.php` — buffer display
- `tests/Feature/Models/UserTest.php` — buffer tests
- `tests/Feature/Livewire/AccountOverviewTest.php` — buffer tests

## Test plan

- [ ] `op test` — 371 tests pass
- [ ] `op test.browser` — 19 browser tests pass
- [ ] `op analyse` — PHPStan clean
- [ ] `op lint.dirty` — Pint clean
- [ ] Visit `/settings/pay-cycle`, fill form, save, verify values persist on reload
- [ ] Visit `/dashboard`, confirm buffer displays below "Available to Spend"
- [ ] Verify green/red/neutral states for positive/negative/zero buffer
- [ ] Verify "Set up pay cycle →" CTA appears when no pay cycle configured

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)