### PR TITLE
feat: [#22] Dashboard layout and navigation

### DIFF
--- a/CLAUDE.local.md
+++ b/CLAUDE.local.md
@@ -96,7 +96,7 @@ date: 2026-03-17
 project: Can Eye Budget v2
 tags:
   - devlog
-  - compare-build
+  - can-eye-budget-v2
 ---
 
 ---
@@ -110,6 +110,14 @@ Every session should improve the codebase, not just add to it. Actively refactor
 - **Leverage:** Use battle-tested packages over custom implementations. Do not reinvent the wheel unless the wheel is broken.
 - **Readable:** Code must be self-documenting. Comments should explain *why*, not *what*.
 - **Safety:** If a refactor carries high risk of breaking functionality, flag it for user review rather than applying it silently.
+
+---
+
+### Operational Rule
+
+After every interaction that includes a code change, you **must** create a devlog file at the vault path before finishing. This is mandatory.
+
+**Goal:** If a new developer (or a new AI session) joins tomorrow, they should be able to browse `DevLogs/CanEyeBudget/` in Obsidian and understand the full state and history of the project immediately.
 
 ---
 

--- a/resources/views/layouts/app/header.blade.php
+++ b/resources/views/layouts/app/header.blade.php
@@ -13,6 +13,12 @@
                 <flux:navbar.item icon="layout-grid" :href="route('dashboard')" :current="request()->routeIs('dashboard')" wire:navigate>
                     {{ __('Dashboard') }}
                 </flux:navbar.item>
+                <flux:navbar.item icon="arrows-right-left" :href="route('transactions')" :current="request()->routeIs('transactions')" wire:navigate>
+                    {{ __('Transactions') }}
+                </flux:navbar.item>
+                <flux:navbar.item icon="building-library" :href="route('connect-bank')" :current="request()->routeIs('connect-bank')" wire:navigate>
+                    {{ __('Connect Bank') }}
+                </flux:navbar.item>
             </flux:navbar>
 
             <flux:spacer />
@@ -20,24 +26,6 @@
             <flux:navbar class="me-1.5 space-x-0.5 rtl:space-x-reverse py-0!">
                 <flux:tooltip :content="__('Search')" position="bottom">
                     <flux:navbar.item class="!h-10 [&>div>svg]:size-5" icon="magnifying-glass" href="#" :label="__('Search')" />
-                </flux:tooltip>
-                <flux:tooltip :content="__('Repository')" position="bottom">
-                    <flux:navbar.item
-                        class="h-10 max-lg:hidden [&>div>svg]:size-5"
-                        icon="folder-git-2"
-                        href="https://github.com/laravel/livewire-starter-kit"
-                        target="_blank"
-                        :label="__('Repository')"
-                    />
-                </flux:tooltip>
-                <flux:tooltip :content="__('Documentation')" position="bottom">
-                    <flux:navbar.item
-                        class="h-10 max-lg:hidden [&>div>svg]:size-5"
-                        icon="book-open-text"
-                        href="https://laravel.com/docs/starter-kits#livewire"
-                        target="_blank"
-                        :label="__('Documentation')"
-                    />
                 </flux:tooltip>
             </flux:navbar>
 
@@ -54,21 +42,17 @@
             <flux:sidebar.nav>
                 <flux:sidebar.group :heading="__('Platform')">
                     <flux:sidebar.item icon="layout-grid" :href="route('dashboard')" :current="request()->routeIs('dashboard')" wire:navigate>
-                        {{ __('Dashboard')  }}
+                        {{ __('Dashboard') }}
+                    </flux:sidebar.item>
+                    <flux:sidebar.item icon="arrows-right-left" :href="route('transactions')" :current="request()->routeIs('transactions')" wire:navigate>
+                        {{ __('Transactions') }}
+                    </flux:sidebar.item>
+                    <flux:sidebar.item icon="building-library" :href="route('connect-bank')" :current="request()->routeIs('connect-bank')" wire:navigate>
+                        {{ __('Connect Bank') }}
                     </flux:sidebar.item>
                 </flux:sidebar.group>
             </flux:sidebar.nav>
 
-            <flux:spacer />
-
-            <flux:sidebar.nav>
-                <flux:sidebar.item icon="folder-git-2" href="https://github.com/laravel/livewire-starter-kit" target="_blank">
-                    {{ __('Repository') }}
-                </flux:sidebar.item>
-                <flux:sidebar.item icon="book-open-text" href="https://laravel.com/docs/starter-kits#livewire" target="_blank">
-                    {{ __('Documentation') }}
-                </flux:sidebar.item>
-            </flux:sidebar.nav>
         </flux:sidebar>
 
         {{ $slot }}

--- a/resources/views/layouts/app/sidebar.blade.php
+++ b/resources/views/layouts/app/sidebar.blade.php
@@ -15,20 +15,16 @@
                     <flux:sidebar.item icon="home" :href="route('dashboard')" :current="request()->routeIs('dashboard')" wire:navigate>
                         {{ __('Dashboard') }}
                     </flux:sidebar.item>
+                    <flux:sidebar.item icon="arrows-right-left" :href="route('transactions')" :current="request()->routeIs('transactions')" wire:navigate>
+                        {{ __('Transactions') }}
+                    </flux:sidebar.item>
+                    <flux:sidebar.item icon="building-library" :href="route('connect-bank')" :current="request()->routeIs('connect-bank')" wire:navigate>
+                        {{ __('Connect Bank') }}
+                    </flux:sidebar.item>
                 </flux:sidebar.group>
             </flux:sidebar.nav>
 
             <flux:spacer />
-
-            <flux:sidebar.nav>
-                <flux:sidebar.item icon="folder-git-2" href="https://github.com/laravel/livewire-starter-kit" target="_blank">
-                    {{ __('Repository') }}
-                </flux:sidebar.item>
-
-                <flux:sidebar.item icon="book-open-text" href="https://laravel.com/docs/starter-kits#livewire" target="_blank">
-                    {{ __('Documentation') }}
-                </flux:sidebar.item>
-            </flux:sidebar.nav>
 
             <x-desktop-user-menu class="hidden lg:block" :name="auth()->user()->name" />
         </flux:sidebar>

--- a/tests/Browser/Navigation/SidebarNavigationBrowserTest.php
+++ b/tests/Browser/Navigation/SidebarNavigationBrowserTest.php
@@ -1,0 +1,68 @@
+<?php
+
+/** @noinspection StaticClosureCanBeUsedInspection */
+
+declare(strict_types=1);
+
+use App\Models\User;
+
+test('sidebar shows all navigation links', function () {
+    $this->actingAs(User::factory()->create());
+
+    $page = visit('/dashboard');
+
+    $page->assertSeeIn('[data-flux-sidebar-item][href$="/dashboard"]', 'Dashboard')
+        ->assertSeeIn('[data-flux-sidebar-item][href$="/transactions"]', 'Transactions')
+        ->assertSeeIn('[data-flux-sidebar-item][href$="/connect-bank"]', 'Connect Bank');
+});
+
+test('placeholder links are not present', function () {
+    $this->actingAs(User::factory()->create());
+
+    $page = visit('/dashboard');
+
+    $page->assertSourceMissing('github.com/laravel/livewire-starter-kit')
+        ->assertSourceMissing('laravel.com/docs/starter-kits');
+});
+
+test('clicking Transactions navigates to transactions page', function () {
+    $this->actingAs(User::factory()->create());
+
+    $page = visit('/dashboard');
+
+    $page->click('[data-flux-sidebar-item][href$="/transactions"]')
+        ->assertPathBeginsWith('/transactions');
+});
+
+test('clicking Connect Bank navigates to connect bank page', function () {
+    $this->actingAs(User::factory()->create());
+
+    $page = visit('/dashboard');
+
+    $page->click('[data-flux-sidebar-item][href$="/connect-bank"]')
+        ->assertPathBeginsWith('/connect-bank');
+});
+
+test('dashboard link has active state on dashboard page', function () {
+    $this->actingAs(User::factory()->create());
+
+    $page = visit('/dashboard');
+
+    $page->assertPresent('[data-flux-sidebar-item][href$="/dashboard"][data-current]');
+});
+
+test('transactions link has active state on transactions page', function () {
+    $this->actingAs(User::factory()->create());
+
+    $page = visit('/transactions');
+
+    $page->assertPresent('[data-flux-sidebar-item][href$="/transactions"][data-current]');
+});
+
+test('connect bank link has active state on connect bank page', function () {
+    $this->actingAs(User::factory()->create());
+
+    $page = visit('/connect-bank');
+
+    $page->assertPresent('[data-flux-sidebar-item][href$="/connect-bank"][data-current]');
+});


### PR DESCRIPTION
## Summary

Closes #22

- Add Transactions and Connect Bank navigation links to sidebar and header layouts with `wire:navigate` and active state highlighting
- Remove starter-kit placeholder links (Repository, Documentation) from all navigation areas
- Sync mobile header navigation to match sidebar links

## Changes

**Sidebar** (`resources/views/layouts/app/sidebar.blade.php`)
- Added `Transactions` (`arrows-right-left` icon) and `Connect Bank` (`building-library` icon) nav items
- Removed external Repository and Documentation links

**Header** (`resources/views/layouts/app/header.blade.php`)
- Added matching nav items to desktop navbar and mobile sidebar
- Removed external Repository and Documentation links from both sections

## Test plan

- [x] `op test.browser.filter SidebarNavigation` — 7 browser tests pass
- [x] `op test` — 390 tests pass, 0 regressions
- [x] `op lint.dirty` — Pint clean
- [ ] Visual: sidebar shows Dashboard, Transactions, Connect Bank on all pages
- [ ] Visual: active state highlights correctly per page
- [ ] Visual: mobile header nav matches sidebar
- [ ] Visual: no Repository/Documentation links anywhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)