### PR TITLE
feat: [67] Update transaction page with button filters, account column, and color-coded amounts

### DIFF
--- a/app/Livewire/TransactionList.php
+++ b/app/Livewire/TransactionList.php
@@ -21,8 +21,10 @@ final class TransactionList extends Component
 
     private const array SORTABLE_COLUMNS = ['post_date', 'amount', 'description'];
 
+    private const array VALID_DIRECTIONS = ['all', 'incoming', 'outgoing'];
+
     #[Url]
-    public string $direction = 'spending';
+    public string $direction = 'all';
 
     #[Url]
     public ?int $account = null;
@@ -42,6 +44,13 @@ final class TransactionList extends Component
     #[Url]
     public string $sortDir = 'desc';
 
+    public function mount(): void
+    {
+        if (! in_array($this->direction, self::VALID_DIRECTIONS, true)) {
+            $this->direction = 'all';
+        }
+    }
+
     public function sort(string $column): void
     {
         if (! in_array($column, self::SORTABLE_COLUMNS, true)) {
@@ -60,6 +69,10 @@ final class TransactionList extends Component
 
     public function updatedDirection(): void
     {
+        if (! in_array($this->direction, self::VALID_DIRECTIONS, true)) {
+            $this->direction = 'all';
+        }
+
         $this->resetPage();
     }
 
@@ -85,13 +98,15 @@ final class TransactionList extends Component
 
     public function render(): View
     {
-        $directionEnum = $this->direction === 'income'
-            ? TransactionDirection::Credit
-            : TransactionDirection::Debit;
+        $directionEnum = match ($this->direction) {
+            'incoming' => TransactionDirection::Credit,
+            'outgoing' => TransactionDirection::Debit,
+            default => null,
+        };
 
         $transactions = Transaction::query()
             ->where('user_id', auth()->id())
-            ->where('direction', $directionEnum)
+            ->when($directionEnum, fn ($q, $dir) => $q->where('direction', $dir))
             ->when($this->account, fn ($q, $id) => $q->where('account_id', $id))
             ->when($this->category, fn ($q, $id) => $q->where('category_id', $id))
             ->when($this->search, fn ($q, $term) => $q->where(function ($q) use ($term) {
@@ -100,7 +115,7 @@ final class TransactionList extends Component
                     ->orWhere('merchant_name', 'like', "%{$term}%");
             }))
             ->where('post_date', '>=', $this->periodStart())
-            ->with('category')
+            ->withRelations()
             ->orderBy(
                 in_array($this->sortBy, self::SORTABLE_COLUMNS, true) ? $this->sortBy : 'post_date',
                 in_array($this->sortDir, ['asc', 'desc'], true) ? $this->sortDir : 'desc',

--- a/resources/views/livewire/transaction-list.blade.php
+++ b/resources/views/livewire/transaction-list.blade.php
@@ -8,21 +8,16 @@
                     All Transactions
                 @endif
             </flux:heading>
-            <flux:text class="mt-1">Showing {{ $direction === 'income' ? 'income' : 'spending' }} for the last {{ $period }}</flux:text>
+            <flux:text class="mt-1">
+                Showing
+                @if($direction === 'incoming') incoming
+                @elseif($direction === 'outgoing') outgoing
+                @else all
+                @endif
+                transactions for the last {{ $period }}
+            </flux:text>
         </div>
         <div class="flex flex-wrap items-center gap-3">
-            <flux:select wire:model.live="direction" size="sm" class="w-auto">
-                <flux:select.option value="spending">Spending</flux:select.option>
-                <flux:select.option value="income">Income</flux:select.option>
-            </flux:select>
-            @if($accounts->count() > 1)
-                <flux:select wire:model.live="account" size="sm" class="w-auto">
-                    <flux:select.option value="">All Accounts</flux:select.option>
-                    @foreach($accounts as $acc)
-                        <flux:select.option :value="$acc->id">{{ $acc->name }}</flux:select.option>
-                    @endforeach
-                </flux:select>
-            @endif
             <flux:select wire:model.live="period" size="sm" class="w-auto">
                 <flux:select.option value="7d">7 days</flux:select.option>
                 <flux:select.option value="30d">30 days</flux:select.option>
@@ -33,13 +28,48 @@
         </div>
     </div>
 
+    <div class="flex flex-wrap items-center gap-2">
+        <flux:button
+            wire:click="$set('direction', 'all')"
+            :variant="$direction === 'all' ? 'primary' : 'ghost'"
+            size="sm"
+        >All</flux:button>
+        <flux:button
+            wire:click="$set('direction', 'outgoing')"
+            :variant="$direction === 'outgoing' ? 'primary' : 'ghost'"
+            size="sm"
+        >Outgoing</flux:button>
+        <flux:button
+            wire:click="$set('direction', 'incoming')"
+            :variant="$direction === 'incoming' ? 'primary' : 'ghost'"
+            size="sm"
+        >Incoming</flux:button>
+
+        @if($accounts->count() > 1)
+            <div class="mx-2 h-6 w-px bg-neutral-200 dark:bg-neutral-700"></div>
+
+            <flux:button
+                wire:click="$set('account', null)"
+                :variant="$account === null ? 'primary' : 'ghost'"
+                size="sm"
+            >All Accounts</flux:button>
+            @foreach($accounts as $acc)
+                <flux:button
+                    wire:click="$set('account', {{ $acc->id }})"
+                    :variant="$account === $acc->id ? 'primary' : 'ghost'"
+                    size="sm"
+                >{{ $acc->name }}</flux:button>
+            @endforeach
+        @endif
+    </div>
+
     <flux:input wire:model.live.debounce.300ms="search" placeholder="Search transactions..." icon="magnifying-glass" size="sm" />
 
     @if($transactions->isEmpty())
         <div class="rounded-xl border border-neutral-200 p-8 text-center dark:border-neutral-700">
             <flux:icon.banknotes class="mx-auto size-12 text-zinc-400" />
             <flux:heading size="lg" class="mt-4">No transactions found</flux:heading>
-            <flux:text class="mt-2">No {{ $direction === 'income' ? 'income' : 'spending' }} transactions match your current filters.</flux:text>
+            <flux:text class="mt-2">No transactions match your current filters.</flux:text>
             <div class="mt-6">
                 <flux:button variant="primary" icon="arrow-left" href="{{ route('dashboard') }}">Back to Dashboard</flux:button>
             </div>
@@ -56,6 +86,9 @@
                         <flux:icon :name="$sortDir === 'asc' ? 'chevron-up' : 'chevron-down'" class="size-3" />
                     @endif
                 </button>
+                @if($account === null)
+                    <span class="w-32 text-xs font-medium uppercase tracking-wider text-zinc-500">Account</span>
+                @endif
                 <button wire:click="sort('post_date')" class="flex w-24 items-center gap-1 text-xs font-medium uppercase tracking-wider text-zinc-500 hover:text-zinc-900 dark:hover:text-zinc-200">
                     Date
                     @if($sortBy === 'post_date')
@@ -78,8 +111,13 @@
                                 <flux:badge size="sm" color="zinc" class="mt-1">{{ $transaction->category->name }}</flux:badge>
                             @endif
                         </div>
+                        @if($account === null)
+                            <flux:text size="sm" class="w-32 truncate">{{ $transaction->account?->name }}</flux:text>
+                        @endif
                         <flux:text size="sm" class="w-24">{{ $transaction->post_date->format('d M Y') }}</flux:text>
-                        <flux:text class="w-28 text-right tabular-nums font-medium">{{ $formatMoney($transaction->amount) }}</flux:text>
+                        <flux:text class="w-28 text-right tabular-nums font-medium {{ $direction === 'all' ? ($transaction->direction === \App\Enums\TransactionDirection::Debit ? 'text-red-600 dark:text-red-400' : 'text-green-600 dark:text-green-400') : '' }}">
+                            {{ $formatMoney($transaction->amount) }}
+                        </flux:text>
                     </div>
                 @endforeach
             </div>

--- a/tests/Browser/Livewire/TransactionListBrowserTest.php
+++ b/tests/Browser/Livewire/TransactionListBrowserTest.php
@@ -96,7 +96,7 @@ test('account filter shows only transactions from selected account', function ()
         ->assertDontSee('COLES MELBOURNE');
 });
 
-test('direction toggle switches between spending and income', function () {
+test('direction toggle switches between all outgoing and incoming', function () {
     $user = User::factory()->create();
     $account = Account::factory()->for($user)->create();
 
@@ -117,9 +117,14 @@ test('direction toggle switches between spending and income', function () {
     $page = visit('/transactions');
 
     $page->assertSee('WOOLWORTHS SYDNEY')
+        ->assertSee('SALARY PAYMENT');
+
+    $page = visit('/transactions?direction=outgoing');
+
+    $page->assertSee('WOOLWORTHS SYDNEY')
         ->assertDontSee('SALARY PAYMENT');
 
-    $page = visit('/transactions?direction=income');
+    $page = visit('/transactions?direction=incoming');
 
     $page->assertSee('SALARY PAYMENT')
         ->assertDontSee('WOOLWORTHS SYDNEY');
@@ -173,7 +178,7 @@ test('multiple filters work together via URL', function () {
 
     $this->actingAs($user);
 
-    $page = visit('/transactions?direction=spending&account='.$account->id.'&category='.$groceries->id.'&search=WOOLWORTHS');
+    $page = visit('/transactions?direction=outgoing&account='.$account->id.'&category='.$groceries->id.'&search=WOOLWORTHS');
 
     $page->assertSee('WOOLWORTHS SYDNEY')
         ->assertDontSee('WOOLWORTHS MELBOURNE');

--- a/tests/Feature/Livewire/TransactionListTest.php
+++ b/tests/Feature/Livewire/TransactionListTest.php
@@ -256,7 +256,7 @@ test('search with no matches shows empty state', function () {
         ->assertSee('No transactions found');
 });
 
-test('direction filter shows only debits when spending', function () {
+test('direction filter shows only debits when outgoing', function () {
     $user = User::factory()->create();
     $account = Account::factory()->for($user)->create();
 
@@ -273,12 +273,12 @@ test('direction filter shows only debits when spending', function () {
     ]);
 
     Livewire::actingAs($user)
-        ->test(TransactionList::class, ['direction' => 'spending'])
+        ->test(TransactionList::class, ['direction' => 'outgoing'])
         ->assertSee('WOOLWORTHS SYDNEY')
         ->assertDontSee('SALARY PAYMENT');
 });
 
-test('direction filter shows only credits when income', function () {
+test('direction filter shows only credits when incoming', function () {
     $user = User::factory()->create();
     $account = Account::factory()->for($user)->create();
 
@@ -295,7 +295,7 @@ test('direction filter shows only credits when income', function () {
     ]);
 
     Livewire::actingAs($user)
-        ->test(TransactionList::class, ['direction' => 'income'])
+        ->test(TransactionList::class, ['direction' => 'incoming'])
         ->assertSee('SALARY PAYMENT')
         ->assertDontSee('WOOLWORTHS SYDNEY');
 });
@@ -435,7 +435,7 @@ test('all filters work together', function () {
 
     Livewire::actingAs($user)
         ->test(TransactionList::class, [
-            'direction' => 'spending',
+            'direction' => 'outgoing',
             'account' => $accountA->id,
             'category' => $groceries->id,
             'search' => 'WOOLWORTHS',
@@ -453,7 +453,7 @@ test('filter state persists via url query string', function () {
 
     Livewire::actingAs($user)
         ->test(TransactionList::class, [
-            'direction' => 'income',
+            'direction' => 'incoming',
             'account' => $account->id,
             'category' => $category->id,
             'period' => '7d',
@@ -461,7 +461,7 @@ test('filter state persists via url query string', function () {
             'sortBy' => 'amount',
             'sortDir' => 'asc',
         ])
-        ->assertSet('direction', 'income')
+        ->assertSet('direction', 'incoming')
         ->assertSet('account', $account->id)
         ->assertSet('category', $category->id)
         ->assertSet('period', '7d')
@@ -482,6 +482,141 @@ test('loading indicator markup is present', function () {
     Livewire::actingAs($user)
         ->test(TransactionList::class)
         ->assertSee('wire:loading', escape: false);
+});
+
+test('default direction is all', function () {
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(TransactionList::class)
+        ->assertSet('direction', 'all');
+});
+
+test('direction all shows both debits and credits', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+
+    Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'description' => 'WOOLWORTHS SYDNEY',
+        'post_date' => now()->subDays(5),
+    ]);
+
+    Transaction::factory()->for($user)->credit()->create([
+        'account_id' => $account->id,
+        'description' => 'SALARY PAYMENT',
+        'post_date' => now()->subDays(5),
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(TransactionList::class)
+        ->assertSet('direction', 'all')
+        ->assertSee('WOOLWORTHS SYDNEY')
+        ->assertSee('SALARY PAYMENT');
+});
+
+test('account column visible when viewing all accounts', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create(['name' => 'Everyday']);
+
+    Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'description' => 'WOOLWORTHS',
+        'post_date' => now()->subDays(5),
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(TransactionList::class)
+        ->assertSee('Account')
+        ->assertSee('Everyday');
+});
+
+test('account column hidden when filtering single account', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create(['name' => 'Everyday']);
+
+    Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'description' => 'WOOLWORTHS',
+        'post_date' => now()->subDays(5),
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(TransactionList::class, ['account' => $account->id])
+        ->assertDontSee('Account');
+});
+
+test('invalid direction value normalizes to all', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+
+    Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'description' => 'DEBIT TXN',
+        'post_date' => now()->subDays(5),
+    ]);
+
+    Transaction::factory()->for($user)->credit()->create([
+        'account_id' => $account->id,
+        'description' => 'CREDIT TXN',
+        'post_date' => now()->subDays(5),
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(TransactionList::class, ['direction' => 'garbage'])
+        ->assertSet('direction', 'all')
+        ->assertSee('DEBIT TXN')
+        ->assertSee('CREDIT TXN');
+});
+
+test('legacy direction values normalize to all', function (string $legacy) {
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(TransactionList::class, ['direction' => $legacy])
+        ->assertSet('direction', 'all');
+})->with(['spending', 'income']);
+
+test('amounts show color coding when direction is all', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+
+    Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'description' => 'WOOLWORTHS SYDNEY',
+        'amount' => 4599,
+        'post_date' => now()->subDays(5),
+    ]);
+
+    Transaction::factory()->for($user)->credit()->create([
+        'account_id' => $account->id,
+        'description' => 'SALARY PAYMENT',
+        'amount' => 500000,
+        'post_date' => now()->subDays(5),
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(TransactionList::class)
+        ->assertSet('direction', 'all')
+        ->assertSeeHtml('text-red-600')
+        ->assertSeeHtml('text-green-600');
+});
+
+test('amounts do not show color coding when direction is filtered', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+
+    Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'description' => 'WOOLWORTHS SYDNEY',
+        'amount' => 4599,
+        'post_date' => now()->subDays(5),
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(TransactionList::class, ['direction' => 'outgoing'])
+        ->assertDontSeeHtml('text-red-600')
+        ->assertDontSeeHtml('text-green-600');
 });
 
 test('route requires authentication', function () {


### PR DESCRIPTION
## Summary
- Replace account and direction dropdowns with horizontal button groups for faster filtering
- Default view now shows all transactions (incoming & outgoing) with color-coded amounts (red for outgoing, green for incoming)
- Add conditional "Account" column visible when viewing all accounts, hidden when filtering a single account

Closes #67

## Test plan
- [x] All 414 tests passing, PHPStan clean, Pint clean
- [x] Navigate to `/transactions` — verify "All" is the default for both direction and account filters
- [x] Verify outgoing amounts display in red, incoming in green when viewing "All"
- [x] Click an account button — verify the Account column hides and transactions filter correctly
- [x] Click "Outgoing" / "Incoming" buttons — verify direction filtering works
- [x] Verify URL query params update correctly when toggling filters

🤖 Generated with [Claude Code](https://claude.com/claude-code)