### PR TITLE
feat: [72] Add Account management page

### DIFF
--- a/app/Enums/AccountGroup.php
+++ b/app/Enums/AccountGroup.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+enum AccountGroup: string
+{
+    case DayToDay = 'day-to-day';
+    case LongTermSavings = 'long-term-savings';
+    case Hidden = 'hidden';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::DayToDay => 'Day to Day',
+            self::LongTermSavings => 'Long Term Savings',
+            self::Hidden => 'Hidden',
+        };
+    }
+}

--- a/app/Livewire/AccountManager.php
+++ b/app/Livewire/AccountManager.php
@@ -1,0 +1,197 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire;
+
+use App\Casts\MoneyCast;
+use App\Enums\AccountClass;
+use App\Enums\AccountGroup;
+use App\Enums\AccountStatus;
+use App\Models\Account;
+use Illuminate\Validation\Rule;
+use Illuminate\View\View;
+use Livewire\Component;
+
+final class AccountManager extends Component
+{
+    public bool $showFormModal = false;
+
+    public bool $showDeleteModal = false;
+
+    public ?int $editingAccountId = null;
+
+    public ?int $deletingAccountId = null;
+
+    public string $deletingAccountName = '';
+
+    public int $deletingTransactionCount = 0;
+
+    public string $name = '';
+
+    public string $balance = '';
+
+    public bool $hasCreditLimit = false;
+
+    public string $credit_limit = '';
+
+    public string $description = '';
+
+    public string $type = '';
+
+    public string $group = '';
+
+    public string $institution = '';
+
+    public function openAddModal(): void
+    {
+        $this->resetForm();
+        $this->group = AccountGroup::DayToDay->value;
+        $this->type = AccountClass::Transaction->value;
+        $this->showFormModal = true;
+    }
+
+    public function openEditModal(int $accountId): void
+    {
+        $account = $this->findUserAccount($accountId);
+
+        if (! $account) {
+            return;
+        }
+
+        $this->editingAccountId = $account->id;
+        $this->name = $account->name;
+        $this->balance = number_format($account->balance / 100, 2, '.', '');
+        $this->hasCreditLimit = $account->credit_limit !== null;
+        $this->credit_limit = $account->credit_limit !== null
+            ? number_format($account->credit_limit / 100, 2, '.', '')
+            : '';
+        $this->description = $account->description ?? '';
+        $this->type = $account->type->value;
+        $this->group = $account->group->value;
+        $this->institution = $account->institution ?? '';
+        $this->showFormModal = true;
+    }
+
+    public function save(): void
+    {
+        $validated = $this->validate($this->formRules());
+
+        $mutableData = [
+            'name' => $validated['name'],
+            'balance' => (int) round((float) $validated['balance'] * 100),
+            'type' => $validated['type'],
+            'group' => $validated['group'],
+            'institution' => $validated['institution'] ?: null,
+            'description' => $validated['description'] ?: null,
+        ];
+
+        if ($this->hasCreditLimit && $validated['credit_limit'] !== null && $validated['credit_limit'] !== '') {
+            $mutableData['credit_limit'] = (int) round((float) $validated['credit_limit'] * 100);
+        } else {
+            $mutableData['credit_limit'] = null;
+        }
+
+        if ($this->editingAccountId) {
+            $account = $this->findUserAccount($this->editingAccountId);
+
+            $account?->update($mutableData);
+        } else {
+            Account::query()->create($mutableData + [
+                'user_id' => auth()->id(),
+                'currency' => 'AUD',
+                'status' => AccountStatus::Active,
+            ]);
+        }
+
+        $this->showFormModal = false;
+        $this->resetForm();
+    }
+
+    public function confirmDelete(int $accountId): void
+    {
+        $account = $this->findUserAccount($accountId);
+
+        if (! $account) {
+            return;
+        }
+
+        $this->deletingAccountId = $account->id;
+        $this->deletingAccountName = $account->name;
+        $this->deletingTransactionCount = $account->transactions()->count();
+        $this->showDeleteModal = true;
+    }
+
+    public function delete(): void
+    {
+        if (! $this->deletingAccountId) {
+            return;
+        }
+
+        $account = $this->findUserAccount($this->deletingAccountId);
+
+        $account?->delete();
+
+        $this->showDeleteModal = false;
+        $this->deletingAccountId = null;
+        $this->deletingAccountName = '';
+        $this->deletingTransactionCount = 0;
+    }
+
+    public function render(): View
+    {
+        $accounts = auth()->user()
+            ->accounts()
+            ->orderBy('name')
+            ->get()
+            ->sortBy(fn (Account $account): int => match ($account->group) {
+                AccountGroup::DayToDay => 0,
+                AccountGroup::LongTermSavings => 1,
+                AccountGroup::Hidden => 2,
+            });
+
+        $grouped = $accounts->groupBy(fn (Account $account) => $account->group->value);
+
+        return view('livewire.account-manager', [
+            'grouped' => $grouped,
+            'formatMoney' => MoneyCast::format(...),
+            'accountTypes' => AccountClass::cases(),
+            'accountGroups' => AccountGroup::cases(),
+        ]);
+    }
+
+    private function resetForm(): void
+    {
+        $this->editingAccountId = null;
+        $this->name = '';
+        $this->balance = '';
+        $this->hasCreditLimit = false;
+        $this->credit_limit = '';
+        $this->description = '';
+        $this->type = '';
+        $this->group = '';
+        $this->institution = '';
+        $this->resetValidation();
+    }
+
+    /** @return array<string, mixed> */
+    private function formRules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'balance' => ['required', 'numeric'],
+            'credit_limit' => [$this->hasCreditLimit ? 'required' : 'nullable', 'numeric', 'min:0'],
+            'description' => ['nullable', 'string', 'max:1000'],
+            'type' => ['required', Rule::enum(AccountClass::class)],
+            'group' => ['required', Rule::enum(AccountGroup::class)],
+            'institution' => ['nullable', 'string', 'max:255'],
+        ];
+    }
+
+    private function findUserAccount(int $accountId): ?Account
+    {
+        return Account::query()
+            ->where('user_id', auth()->id())
+            ->find($accountId);
+    }
+}

--- a/app/Livewire/AccountOverview.php
+++ b/app/Livewire/AccountOverview.php
@@ -35,6 +35,7 @@ final class AccountOverview extends Component
         $accounts = $user
             ->accounts()
             ->active()
+            ->visible()
             ->orderBy('type')
             ->get();
 

--- a/app/Models/Account.php
+++ b/app/Models/Account.php
@@ -6,6 +6,7 @@ namespace App\Models;
 
 use App\Casts\MoneyCast;
 use App\Enums\AccountClass;
+use App\Enums\AccountGroup;
 use App\Enums\AccountStatus;
 use Carbon\CarbonImmutable;
 use Database\Factories\AccountFactory;
@@ -26,6 +27,8 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  * @property int $balance
  * @property int|null $credit_limit
  * @property int|null $available_funds
+ * @property string|null $description
+ * @property AccountGroup $group
  * @property AccountStatus $status
  * @property CarbonImmutable $created_at
  * @property CarbonImmutable $updated_at
@@ -48,6 +51,8 @@ final class Account extends Model
         'balance',
         'credit_limit',
         'available_funds',
+        'description',
+        'group',
         'status',
     ];
 
@@ -70,6 +75,15 @@ final class Account extends Model
     public function scopeActive(Builder $query): Builder
     {
         return $query->whereIn('status', [AccountStatus::Active, AccountStatus::Available]);
+    }
+
+    /**
+     * @param  Builder<self>  $query
+     * @return Builder<self>
+     */
+    public function scopeVisible(Builder $query): Builder
+    {
+        return $query->where('group', '!=', AccountGroup::Hidden);
     }
 
     public function availableBalance(): int
@@ -106,6 +120,7 @@ final class Account extends Model
     {
         return [
             'type' => AccountClass::class,
+            'group' => AccountGroup::class,
             'status' => AccountStatus::class,
             'balance' => MoneyCast::class,
             'credit_limit' => MoneyCast::class,

--- a/database/factories/AccountFactory.php
+++ b/database/factories/AccountFactory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Database\Factories;
 
 use App\Enums\AccountClass;
+use App\Enums\AccountGroup;
 use App\Enums\AccountStatus;
 use App\Models\Account;
 use App\Models\User;
@@ -27,6 +28,7 @@ final class AccountFactory extends Factory
             'institution' => fake()->randomElement(['Commonwealth Bank', 'Westpac', 'ANZ', 'NAB', 'Macquarie Bank', 'ING', 'Bendigo Bank', 'Suncorp']),
             'currency' => 'AUD',
             'balance' => fake()->numberBetween(10000, 500000),
+            'group' => AccountGroup::DayToDay,
             'status' => AccountStatus::Active,
         ];
     }
@@ -103,6 +105,20 @@ final class AccountFactory extends Factory
         return $this->state(fn (array $attributes) => [
             'status' => AccountStatus::Closed,
             'balance' => 0,
+        ]);
+    }
+
+    public function longTermSavings(): self
+    {
+        return $this->state(fn (array $attributes) => [
+            'group' => AccountGroup::LongTermSavings,
+        ]);
+    }
+
+    public function hidden(): self
+    {
+        return $this->state(fn (array $attributes) => [
+            'group' => AccountGroup::Hidden,
         ]);
     }
 }

--- a/database/migrations/2026_03_25_010932_add_description_and_group_to_accounts_table.php
+++ b/database/migrations/2026_03_25_010932_add_description_and_group_to_accounts_table.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('accounts', function (Blueprint $table) {
+            $table->text('description')->nullable()->after('currency');
+            $table->string('group')->default('day-to-day')->after('description');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('accounts', function (Blueprint $table) {
+            $table->dropColumn(['description', 'group']);
+        });
+    }
+};

--- a/resources/views/accounts.blade.php
+++ b/resources/views/accounts.blade.php
@@ -1,0 +1,3 @@
+<x-layouts::app :title="__('Accounts')">
+    <livewire:account-manager />
+</x-layouts::app>

--- a/resources/views/layouts/app/header.blade.php
+++ b/resources/views/layouts/app/header.blade.php
@@ -13,6 +13,9 @@
                 <flux:navbar.item icon="layout-grid" :href="route('dashboard')" :current="request()->routeIs('dashboard')" wire:navigate>
                     {{ __('Dashboard') }}
                 </flux:navbar.item>
+                <flux:navbar.item icon="credit-card" :href="route('accounts')" :current="request()->routeIs('accounts')" wire:navigate>
+                    {{ __('Accounts') }}
+                </flux:navbar.item>
                 <flux:navbar.item icon="arrows-right-left" :href="route('transactions')" :current="request()->routeIs('transactions')" wire:navigate>
                     {{ __('Transactions') }}
                 </flux:navbar.item>
@@ -25,7 +28,7 @@
 
             <flux:navbar class="me-1.5 space-x-0.5 rtl:space-x-reverse py-0!">
                 <flux:tooltip :content="__('Search')" position="bottom">
-                    <flux:navbar.item class="!h-10 [&>div>svg]:size-5" icon="magnifying-glass" href="#" :label="__('Search')" />
+                    <flux:navbar.item class="h-10! [&>div>svg]:size-5" icon="magnifying-glass" href="#" :label="__('Search')" />
                 </flux:tooltip>
             </flux:navbar>
 
@@ -43,6 +46,9 @@
                 <flux:sidebar.group :heading="__('Platform')">
                     <flux:sidebar.item icon="layout-grid" :href="route('dashboard')" :current="request()->routeIs('dashboard')" wire:navigate>
                         {{ __('Dashboard') }}
+                    </flux:sidebar.item>
+                    <flux:sidebar.item icon="credit-card" :href="route('accounts')" :current="request()->routeIs('accounts')" wire:navigate>
+                        {{ __('Accounts') }}
                     </flux:sidebar.item>
                     <flux:sidebar.item icon="arrows-right-left" :href="route('transactions')" :current="request()->routeIs('transactions')" wire:navigate>
                         {{ __('Transactions') }}

--- a/resources/views/layouts/app/sidebar.blade.php
+++ b/resources/views/layouts/app/sidebar.blade.php
@@ -15,6 +15,9 @@
                     <flux:sidebar.item icon="home" :href="route('dashboard')" :current="request()->routeIs('dashboard')" wire:navigate>
                         {{ __('Dashboard') }}
                     </flux:sidebar.item>
+                    <flux:sidebar.item icon="credit-card" :href="route('accounts')" :current="request()->routeIs('accounts')" wire:navigate>
+                        {{ __('Accounts') }}
+                    </flux:sidebar.item>
                     <flux:sidebar.item icon="arrows-right-left" :href="route('transactions')" :current="request()->routeIs('transactions')" wire:navigate>
                         {{ __('Transactions') }}
                     </flux:sidebar.item>

--- a/resources/views/livewire/account-manager.blade.php
+++ b/resources/views/livewire/account-manager.blade.php
@@ -1,0 +1,173 @@
+@php use App\Enums\AccountGroup; use Illuminate\Support\Str; @endphp
+<div class="space-y-6">
+    <div class="flex items-center justify-between">
+        <flux:heading size="xl">{{ __('Accounts') }}</flux:heading>
+        <flux:button variant="primary" icon="plus" wire:click="openAddModal">
+            {{ __('Add Account') }}
+        </flux:button>
+    </div>
+
+    @forelse($grouped as $groupValue => $accounts)
+        @php $groupEnum = AccountGroup::from($groupValue); @endphp
+        <div>
+            <div class="mb-3 flex items-center gap-2">
+                <flux:heading size="lg">{{ $groupEnum->label() }}</flux:heading>
+                <flux:badge size="sm" color="zinc">{{ $accounts->count() }}</flux:badge>
+            </div>
+
+            <div class="rounded-xl border border-neutral-200 dark:border-neutral-700">
+                <div class="divide-y divide-neutral-200 dark:divide-neutral-700">
+                    @foreach($accounts as $account)
+                        <div wire:key="account-{{ $account->id }}" class="flex items-center justify-between px-4 py-3">
+                            <div class="min-w-0 flex-1">
+                                <div class="flex items-center gap-2">
+                                    <flux:icon :name="$account->type->icon()" class="size-5 shrink-0 text-zinc-400"/>
+                                    <flux:heading size="sm" class="truncate">{{ $account->name }}</flux:heading>
+                                    <flux:badge size="sm" color="zinc">{{ $account->type->label() }}</flux:badge>
+                                </div>
+                                @if($account->institution)
+                                    <flux:text size="sm" class="mt-0.5 pl-7">{{ $account->institution }}</flux:text>
+                                @endif
+                            </div>
+                            <div class="flex items-center gap-4">
+                                <div class="text-right">
+                                    <flux:text class="tabular-nums font-medium {{ $account->balance < 0 ? 'text-red-600 dark:text-red-500' : '' }}">
+                                        {{ $formatMoney($account->balance) }}
+                                    </flux:text>
+                                    @if($account->credit_limit !== null)
+                                        <flux:text size="sm" class="tabular-nums text-zinc-500">
+                                            Limit {{ $formatMoney($account->credit_limit) }}
+                                        </flux:text>
+                                    @endif
+                                </div>
+                                <div class="flex items-center gap-1">
+                                    <flux:button variant="ghost" size="sm" icon="pencil" wire:click="openEditModal({{ $account->id }})"/>
+                                    <flux:button variant="ghost" size="sm" icon="trash" wire:click="confirmDelete({{ $account->id }})"
+                                                 class="text-red-500 hover:text-red-600"/>
+                                </div>
+                            </div>
+                        </div>
+                    @endforeach
+                </div>
+            </div>
+        </div>
+    @empty
+        <flux:card class="p-8 text-center">
+            <flux:icon.building-library class="mx-auto size-12 text-zinc-400"/>
+            <flux:heading size="lg" class="mt-4">{{ __('No accounts yet') }}</flux:heading>
+            <flux:text class="mt-2">{{ __('Add your first account to start tracking your finances.') }}</flux:text>
+            <div class="mt-6">
+                <flux:button variant="primary" icon="plus" wire:click="openAddModal">
+                    {{ __('Add Account') }}
+                </flux:button>
+            </div>
+        </flux:card>
+    @endforelse
+
+    <flux:modal wire:model="showFormModal" class="md:w-lg">
+        <form wire:submit="save" class="space-y-6">
+            <div>
+                <flux:heading size="lg">
+                    {{ $editingAccountId ? __('Edit Account') : __('Add Account') }}
+                </flux:heading>
+                <flux:text class="mt-2">
+                    {{ $editingAccountId ? __('Update your account details.') : __('Add a new account to track.') }}
+                </flux:text>
+            </div>
+
+            <flux:input
+                    wire:model="name"
+                    :label="__('Name')"
+                    placeholder="e.g. Everyday Account"
+                    required
+            />
+
+            <flux:input
+                    wire:model="balance"
+                    :label="__('Current Balance')"
+                    type="number"
+                    step="0.01"
+                    placeholder="0.00"
+                    required
+            />
+
+            <flux:field variant="inline">
+                <flux:checkbox wire:model.live="hasCreditLimit"/>
+                <flux:label>{{ __('Credit Limit') }}</flux:label>
+                <flux:description>{{ __('Check if this is a credit account (e.g. credit card, line of credit)') }}</flux:description>
+            </flux:field>
+
+            @if($hasCreditLimit)
+                <flux:input
+                        wire:model="credit_limit"
+                        :label="__('Credit Limit Amount')"
+                        type="number"
+                        step="0.01"
+                        min="0"
+                        placeholder="0.00"
+                        required
+                />
+            @endif
+
+            <flux:textarea
+                    wire:model="description"
+                    :label="__('Description')"
+                    placeholder="{{ __('Optional description') }}"
+                    rows="2"
+            />
+
+            <flux:select wire:model="type" :label="__('Account Type')" required>
+                @foreach($accountTypes as $accountType)
+                    <flux:select.option value="{{ $accountType->value }}">{{ $accountType->label() }}</flux:select.option>
+                @endforeach
+            </flux:select>
+
+            <flux:select wire:model="group" :label="__('Account Group')" required>
+                @foreach($accountGroups as $accountGroup)
+                    <flux:select.option value="{{ $accountGroup->value }}">{{ $accountGroup->label() }}</flux:select.option>
+                @endforeach
+            </flux:select>
+
+            <flux:input
+                    wire:model="institution"
+                    :label="__('Institution')"
+                    placeholder="e.g. Commonwealth Bank"
+            />
+
+            <div class="flex">
+                <flux:spacer/>
+                <flux:button type="submit" variant="primary">
+                    {{ $editingAccountId ? __('Update Account') : __('Add Account') }}
+                </flux:button>
+            </div>
+        </form>
+    </flux:modal>
+
+    <flux:modal wire:model="showDeleteModal" class="md:w-96">
+        <div class="space-y-6">
+            <div>
+                <flux:heading size="lg">{{ __('Delete Account') }}</flux:heading>
+                <flux:text class="mt-2">
+                    {{ __('Are you sure you want to delete') }} <strong>{{ $deletingAccountName }}</strong>?
+                </flux:text>
+                @if($deletingTransactionCount > 0)
+                    <flux:text class="mt-2 font-medium text-red-600 dark:text-red-500">
+                        {{ __('This will also delete :count :transactions associated with this account.', [
+                            'count' => $deletingTransactionCount,
+                            'transactions' => Str::plural('transaction', $deletingTransactionCount),
+                        ]) }}
+                    </flux:text>
+                @endif
+            </div>
+            <div class="flex gap-2">
+                <flux:spacer/>
+                <flux:modal.close>
+                    <flux:button variant="ghost">{{ __('Cancel') }}</flux:button>
+                </flux:modal.close>
+                <flux:button variant="danger" wire:click="delete">
+                    {{ __('Delete Account') }}
+                </flux:button>
+            </div>
+        </div>
+    </flux:modal>
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -18,6 +18,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::view('smoke-test', 'smoke-test')->name('smoke-test');
     Route::view('connect-bank', 'connect-bank')->name('connect-bank');
     Route::view('transactions', 'transactions')->name('transactions');
+    Route::view('accounts', 'accounts')->name('accounts');
     Route::get('basiq/callback', BasiqCallbackController::class)->name('basiq.callback');
 });
 

--- a/tests/Feature/Livewire/AccountManagerTest.php
+++ b/tests/Feature/Livewire/AccountManagerTest.php
@@ -1,0 +1,295 @@
+<?php
+
+/** @noinspection StaticClosureCanBeUsedInspection */
+
+declare(strict_types=1);
+
+use App\Enums\AccountClass;
+use App\Enums\AccountGroup;
+use App\Livewire\AccountManager;
+use App\Models\Account;
+use App\Models\Transaction;
+use App\Models\User;
+use Livewire\Livewire;
+
+test('component renders for authenticated user', function () {
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(AccountManager::class)
+        ->assertSuccessful();
+});
+
+test('shows empty state when no accounts exist', function () {
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(AccountManager::class)
+        ->assertSee('No accounts yet');
+});
+
+test('lists only current user accounts', function () {
+    $user = User::factory()->create();
+    $otherUser = User::factory()->create();
+
+    Account::factory()->for($user)->create(['name' => 'My Account']);
+    Account::factory()->for($otherUser)->create(['name' => 'Other Account']);
+
+    Livewire::actingAs($user)
+        ->test(AccountManager::class)
+        ->assertSee('My Account')
+        ->assertDontSee('Other Account');
+});
+
+test('displays accounts grouped by account group', function () {
+    $user = User::factory()->create();
+
+    Account::factory()->for($user)->create(['name' => 'Everyday', 'group' => AccountGroup::DayToDay]);
+    Account::factory()->for($user)->longTermSavings()->create(['name' => 'Savings Goal']);
+    Account::factory()->for($user)->hidden()->create(['name' => 'Hidden Fund']);
+
+    Livewire::actingAs($user)
+        ->test(AccountManager::class)
+        ->assertSee('Day to Day')
+        ->assertSee('Long Term Savings')
+        ->assertSee('Hidden')
+        ->assertSee('Everyday')
+        ->assertSee('Savings Goal')
+        ->assertSee('Hidden Fund');
+});
+
+test('can add a new account with valid data', function () {
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(AccountManager::class)
+        ->call('openAddModal')
+        ->set('name', 'Test Account')
+        ->set('balance', '1500.50')
+        ->set('type', AccountClass::Transaction->value)
+        ->set('group', AccountGroup::DayToDay->value)
+        ->call('save')
+        ->assertSet('showFormModal', false);
+
+    $account = Account::query()->where('user_id', $user->id)->first();
+    expect($account)
+        ->name->toBe('Test Account')
+        ->balance->toBe(150050)
+        ->type->toBe(AccountClass::Transaction)
+        ->group->toBe(AccountGroup::DayToDay)
+        ->currency->toBe('AUD');
+});
+
+test('validates required fields on add', function () {
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(AccountManager::class)
+        ->call('openAddModal')
+        ->set('name', '')
+        ->set('balance', '')
+        ->set('type', '')
+        ->set('group', '')
+        ->call('save')
+        ->assertHasErrors(['name', 'balance', 'type', 'group']);
+});
+
+test('balance is stored as cents', function () {
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(AccountManager::class)
+        ->call('openAddModal')
+        ->set('name', 'Cents Test')
+        ->set('balance', '42.99')
+        ->set('type', AccountClass::Transaction->value)
+        ->set('group', AccountGroup::DayToDay->value)
+        ->call('save');
+
+    expect(Account::query()->where('name', 'Cents Test')->first()->balance)->toBe(4299);
+});
+
+test('credit limit is stored as cents when enabled', function () {
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(AccountManager::class)
+        ->call('openAddModal')
+        ->set('name', 'Credit Test')
+        ->set('balance', '-500.00')
+        ->set('hasCreditLimit', true)
+        ->set('credit_limit', '5000.00')
+        ->set('type', AccountClass::CreditCard->value)
+        ->set('group', AccountGroup::DayToDay->value)
+        ->call('save');
+
+    $account = Account::query()->where('name', 'Credit Test')->first();
+    expect($account)
+        ->credit_limit->toBe(500000)
+        ->balance->toBe(-50000);
+});
+
+test('credit limit is null when checkbox unchecked', function () {
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(AccountManager::class)
+        ->call('openAddModal')
+        ->set('name', 'No Credit')
+        ->set('balance', '1000.00')
+        ->set('hasCreditLimit', false)
+        ->set('type', AccountClass::Transaction->value)
+        ->set('group', AccountGroup::DayToDay->value)
+        ->call('save');
+
+    expect(Account::query()->where('name', 'No Credit')->first()->credit_limit)->toBeNull();
+});
+
+test('can edit an existing account', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create([
+        'name' => 'Original Name',
+        'balance' => 100000,
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(AccountManager::class)
+        ->call('openEditModal', $account->id)
+        ->assertSet('name', 'Original Name')
+        ->assertSet('editingAccountId', $account->id)
+        ->set('name', 'Updated Name')
+        ->call('save');
+
+    expect($account->fresh()->name)->toBe('Updated Name');
+});
+
+test('can update account description', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create(['description' => null]);
+
+    Livewire::actingAs($user)
+        ->test(AccountManager::class)
+        ->call('openEditModal', $account->id)
+        ->set('description', 'My savings for a rainy day')
+        ->call('save');
+
+    expect($account->fresh()->description)->toBe('My savings for a rainy day');
+});
+
+test('can delete an account without transactions', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+
+    Livewire::actingAs($user)
+        ->test(AccountManager::class)
+        ->call('confirmDelete', $account->id)
+        ->assertSet('showDeleteModal', true)
+        ->assertSet('deletingAccountName', $account->name)
+        ->assertSet('deletingTransactionCount', 0)
+        ->call('delete');
+
+    expect(Account::query()->find($account->id))->toBeNull();
+});
+
+test('delete cascades and removes account with transactions', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    Transaction::factory()->for($user)->for($account)->count(3)->create();
+
+    Livewire::actingAs($user)
+        ->test(AccountManager::class)
+        ->call('confirmDelete', $account->id)
+        ->assertSet('deletingTransactionCount', 3)
+        ->call('delete');
+
+    expect(Account::query()->find($account->id))
+        ->toBeNull()
+        ->and(Transaction::query()->where('account_id', $account->id)->count())->toBe(0);
+});
+
+test('cannot delete another user account', function () {
+    $user = User::factory()->create();
+    $otherUser = User::factory()->create();
+    $otherAccount = Account::factory()->for($otherUser)->create();
+
+    Livewire::actingAs($user)
+        ->test(AccountManager::class)
+        ->call('confirmDelete', $otherAccount->id)
+        ->assertSet('showDeleteModal', false);
+
+    expect(Account::query()->find($otherAccount->id))->not->toBeNull();
+});
+
+test('cannot edit another user account', function () {
+    $user = User::factory()->create();
+    $otherUser = User::factory()->create();
+    $otherAccount = Account::factory()->for($otherUser)->create();
+
+    Livewire::actingAs($user)
+        ->test(AccountManager::class)
+        ->call('openEditModal', $otherAccount->id)
+        ->assertSet('editingAccountId', null)
+        ->assertSet('showFormModal', false);
+});
+
+test('account group defaults to day to day on add', function () {
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(AccountManager::class)
+        ->call('openAddModal')
+        ->assertSet('group', AccountGroup::DayToDay->value);
+});
+
+test('account type defaults to transaction on add', function () {
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(AccountManager::class)
+        ->call('openAddModal')
+        ->assertSet('type', AccountClass::Transaction->value);
+});
+
+test('displays account type label and institution', function () {
+    $user = User::factory()->create();
+    Account::factory()->for($user)->create([
+        'name' => 'My Card',
+        'type' => AccountClass::CreditCard,
+        'institution' => 'Westpac',
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(AccountManager::class)
+        ->assertSee('My Card')
+        ->assertSee('Credit Card')
+        ->assertSee('Westpac');
+});
+
+test('shows formatted balance for each account', function () {
+    $user = User::factory()->create();
+    Account::factory()->for($user)->create([
+        'name' => 'Balance Test',
+        'balance' => 123456,
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(AccountManager::class)
+        ->assertSee('$1,234.56');
+});
+
+test('institution is optional when adding account', function () {
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(AccountManager::class)
+        ->call('openAddModal')
+        ->set('name', 'No Institution')
+        ->set('balance', '100.00')
+        ->set('type', AccountClass::Transaction->value)
+        ->set('group', AccountGroup::DayToDay->value)
+        ->set('institution', '')
+        ->call('save')
+        ->assertHasNoErrors();
+
+    expect(Account::query()->where('name', 'No Institution')->first()->institution)->toBeNull();
+});

--- a/tests/Feature/Livewire/AccountOverviewTest.php
+++ b/tests/Feature/Livewire/AccountOverviewTest.php
@@ -292,3 +292,15 @@ test('uses three-column grid on medium screens', function () {
         ->test(AccountOverview::class)
         ->assertSeeHtml('md:grid-cols-3');
 });
+
+test('hidden group accounts are excluded from totals', function () {
+    $user = User::factory()->create();
+    Account::factory()->for($user)->create(['name' => 'Visible', 'balance' => 100000]);
+    Account::factory()->for($user)->hidden()->create(['name' => 'Hidden', 'balance' => 999999]);
+
+    Livewire::actingAs($user)
+        ->test(AccountOverview::class)
+        ->assertSee('Visible')
+        ->assertDontSee('Hidden')
+        ->assertSeeInOrder(['Available', MoneyCast::format(100000)]);
+});


### PR DESCRIPTION
## Summary

- Adds a dedicated `/accounts` page with full CRUD (add, edit, delete) for managing accounts
- Introduces `AccountGroup` enum (`Day to Day`, `Long Term Savings`, `Hidden`) as a new `group` column, separate from the existing `AccountClass` financial type
- Adds `description` (optional text) column to accounts
- Accounts page lists all user accounts grouped by their `AccountGroup`, with inline type badges, institution, and formatted balances
- Add/Edit modal with: name, balance, credit limit toggle, description, account type, account group, and institution (free text)
- Delete modal with confirmation and transaction count warning (cascade delete via FK)
- Hidden accounts are excluded from Dashboard summary totals (Owed, Available, Needed)
- Sidebar navigation updated with "Accounts" link in all layouts (sidebar, header, mobile)

Closes #72

## Test plan

- [x] `op ci` passes — 470 tests, 0 failures, PHPStan clean, Pint clean
- [ ] Navigate to `/accounts` — verify empty state renders with "Add Account" button
- [ ] Add a new account — verify it appears in the correct group with formatted balance
- [ ] Edit an account — verify fields are pre-populated and changes persist
- [ ] Delete an account with transactions — verify confirmation shows transaction count warning
- [ ] Set account group to Hidden — verify it disappears from Dashboard summary cards
- [ ] Verify sidebar "Accounts" link appears on desktop and mobile layouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)