### PR TITLE
feat: dashboard redesign with calendar view page

### DIFF
--- a/app/Livewire/CalendarView.php
+++ b/app/Livewire/CalendarView.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire;
+
+use App\Casts\MoneyCast;
+use App\Models\Transaction;
+use Carbon\CarbonImmutable;
+use Carbon\Constants\UnitValue;
+use Illuminate\Support\Collection;
+use Illuminate\View\View;
+use Livewire\Attributes\Computed;
+use Livewire\Component;
+
+final class CalendarView extends Component
+{
+    public string $currentMonth = '';
+
+    public function mount(): void
+    {
+        $this->currentMonth = CarbonImmutable::now()->format('Y-m');
+    }
+
+    public function previousMonth(): void
+    {
+        $this->currentMonth = $this->monthStart()->subMonth()->format('Y-m');
+        unset($this->calendarData); // @phpstan-ignore property.notFound
+    }
+
+    public function nextMonth(): void
+    {
+        $this->currentMonth = $this->monthStart()->addMonth()->format('Y-m');
+        unset($this->calendarData); // @phpstan-ignore property.notFound
+    }
+
+    public function goToToday(): void
+    {
+        $this->currentMonth = CarbonImmutable::now()->format('Y-m');
+        unset($this->calendarData); // @phpstan-ignore property.notFound
+    }
+
+    /** @return array{monthLabel: string, weeks: list<list<array{date: int, fullDate: string, isCurrentMonth: bool, isToday: bool, transactions: list<array{category: string, amount: int, direction: string}>}>>, isCurrentMonth: bool} */
+    #[Computed(persist: true)]
+    public function calendarData(): array
+    {
+        $monthStart = $this->monthStart();
+        $monthEnd = $monthStart->endOfMonth();
+        $today = CarbonImmutable::today();
+
+        $gridStart = $monthStart->startOfWeek(UnitValue::MONDAY);
+        $gridEnd = $monthEnd->endOfWeek(UnitValue::SUNDAY);
+
+        /** @var Collection<string, Collection<int, Transaction>> $transactionsByDate */
+        $transactionsByDate = Transaction::query()
+            ->where('user_id', auth()->id())
+            ->whereBetween('post_date', [$gridStart, $gridEnd])
+            ->with('category:id,name')
+            ->orderBy('post_date')
+            ->get()
+            ->groupBy(fn (Transaction $t) => $t->post_date->format('Y-m-d'));
+
+        $weeks = [];
+        $current = $gridStart;
+
+        while ($current <= $gridEnd) {
+            $week = [];
+            for ($i = 0; $i < 7; $i++) {
+                $dateKey = $current->format('Y-m-d');
+                $dayTransactions = $transactionsByDate->get($dateKey, collect());
+
+                $week[] = [
+                    'date' => $current->day,
+                    'fullDate' => $dateKey,
+                    'isCurrentMonth' => $current->month === $monthStart->month && $current->year === $monthStart->year,
+                    'isToday' => $current->isSameDay($today),
+                    'transactions' => $dayTransactions->map(fn (Transaction $t) => [
+                        'category' => $t->category?->name ?? $t->description, // @phpstan-ignore nullsafe.neverNull
+                        'amount' => $t->amount,
+                        'direction' => $t->direction->value,
+                    ])->values()->all(),
+                ];
+
+                $current = $current->addDay();
+            }
+            $weeks[] = $week;
+        }
+
+        return [
+            'monthLabel' => $monthStart->format('F Y'),
+            'weeks' => $weeks,
+            'isCurrentMonth' => $monthStart->month === $today->month && $monthStart->year === $today->year,
+        ];
+    }
+
+    public function placeholder(): string
+    {
+        return <<<'HTML'
+        <div>
+            <div class="space-y-4">
+                <div class="animate-pulse rounded-xl bg-zinc-100 dark:bg-zinc-800 h-10 w-48"></div>
+                <div class="animate-pulse rounded-xl bg-zinc-100 dark:bg-zinc-800 h-96"></div>
+            </div>
+        </div>
+        HTML;
+    }
+
+    public function render(): View
+    {
+        return view('livewire.calendar-view', [
+            'formatMoney' => MoneyCast::format(...),
+        ]);
+    }
+
+    private function monthStart(): CarbonImmutable
+    {
+        $date = CarbonImmutable::createFromFormat('Y-m', $this->currentMonth);
+
+        if (! $date instanceof CarbonImmutable) {
+            $date = CarbonImmutable::now();
+            $this->currentMonth = $date->format('Y-m');
+        }
+
+        return $date->startOfMonth();
+    }
+}

--- a/resources/views/calendar.blade.php
+++ b/resources/views/calendar.blade.php
@@ -1,0 +1,3 @@
+<x-layouts::app :title="__('Calendar')">
+    <livewire:calendar-view />
+</x-layouts::app>

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -1,9 +1,6 @@
 <x-layouts::app :title="__('Dashboard')">
     <div class="flex h-full w-full flex-1 flex-col gap-4 rounded-xl">
         <livewire:account-overview lazy />
-        <div class="grid auto-rows-min gap-4 md:grid-cols-2">
-            <livewire:spending-by-category lazy />
-            <livewire:spending-over-time lazy />
-        </div>
+        <livewire:spending-over-time lazy />
     </div>
 </x-layouts::app>

--- a/resources/views/layouts/app/header.blade.php
+++ b/resources/views/layouts/app/header.blade.php
@@ -19,6 +19,9 @@
                 <flux:navbar.item icon="arrows-right-left" :href="route('transactions')" :current="request()->routeIs('transactions')" wire:navigate>
                     {{ __('Transactions') }}
                 </flux:navbar.item>
+                <flux:navbar.item icon="calendar-days" :href="route('calendar')" :current="request()->routeIs('calendar')" wire:navigate>
+                    {{ __('Calendar') }}
+                </flux:navbar.item>
                 <flux:navbar.item icon="building-library" :href="route('connect-bank')" :current="request()->routeIs('connect-bank')" wire:navigate>
                     {{ __('Connect Bank') }}
                 </flux:navbar.item>
@@ -52,6 +55,9 @@
                     </flux:sidebar.item>
                     <flux:sidebar.item icon="arrows-right-left" :href="route('transactions')" :current="request()->routeIs('transactions')" wire:navigate>
                         {{ __('Transactions') }}
+                    </flux:sidebar.item>
+                    <flux:sidebar.item icon="calendar-days" :href="route('calendar')" :current="request()->routeIs('calendar')" wire:navigate>
+                        {{ __('Calendar') }}
                     </flux:sidebar.item>
                     <flux:sidebar.item icon="building-library" :href="route('connect-bank')" :current="request()->routeIs('connect-bank')" wire:navigate>
                         {{ __('Connect Bank') }}

--- a/resources/views/layouts/app/sidebar.blade.php
+++ b/resources/views/layouts/app/sidebar.blade.php
@@ -21,6 +21,9 @@
                     <flux:sidebar.item icon="arrows-right-left" :href="route('transactions')" :current="request()->routeIs('transactions')" wire:navigate>
                         {{ __('Transactions') }}
                     </flux:sidebar.item>
+                    <flux:sidebar.item icon="calendar-days" :href="route('calendar')" :current="request()->routeIs('calendar')" wire:navigate>
+                        {{ __('Calendar') }}
+                    </flux:sidebar.item>
                     <flux:sidebar.item icon="building-library" :href="route('connect-bank')" :current="request()->routeIs('connect-bank')" wire:navigate>
                         {{ __('Connect Bank') }}
                     </flux:sidebar.item>

--- a/resources/views/livewire/calendar-view.blade.php
+++ b/resources/views/livewire/calendar-view.blade.php
@@ -1,0 +1,98 @@
+@php use Carbon\CarbonImmutable; @endphp
+<div data-testid="calendar-view">
+    <div class="rounded-xl border border-neutral-200 dark:border-neutral-700">
+        <div class="flex items-center justify-between p-4">
+            <div class="flex items-center gap-2">
+                <flux:button wire:click="previousMonth" variant="ghost" icon="chevron-left" size="sm"/>
+                <flux:heading>{{ $this->calendarData['monthLabel'] }}</flux:heading>
+                <flux:button wire:click="nextMonth" variant="ghost" icon="chevron-right" size="sm"/>
+            </div>
+            @unless($this->calendarData['isCurrentMonth'])
+                <flux:button wire:click="goToToday" variant="subtle" size="sm">Today</flux:button>
+            @endunless
+        </div>
+
+        <flux:separator/>
+
+        <div class="hidden md:block">
+            <div class="grid grid-cols-7 border-b border-neutral-200 dark:border-neutral-700">
+                @foreach(['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'] as $day)
+                    <div class="px-2 py-2 text-center text-xs font-medium uppercase tracking-wider text-zinc-500">
+                        {{ $day }}
+                    </div>
+                @endforeach
+            </div>
+
+            @foreach($this->calendarData['weeks'] as $weekIndex => $week)
+                <div class="grid grid-cols-7 {{ !$loop->last ? 'border-b border-neutral-200 dark:border-neutral-700' : '' }}">
+                    @foreach($week as $day)
+                        <div
+                                wire:key="day-{{ $day['fullDate'] }}"
+                                class="min-h-28 border-r border-neutral-200 p-1.5 last:border-r-0 dark:border-neutral-700 {{ !$day['isCurrentMonth'] ? 'bg-zinc-50 dark:bg-zinc-900/50' : '' }}"
+                        >
+                            <div class="mb-1 text-right text-xs font-medium {{ $day['isToday'] ? 'flex items-center justify-end' : '' }} {{ !$day['isCurrentMonth'] ? 'text-zinc-400 dark:text-zinc-600' : 'text-zinc-700 dark:text-zinc-300' }}">
+                                @if($day['isToday'])
+                                    <span class="inline-flex size-6 items-center justify-center rounded-full bg-indigo-600 text-white">{{ $day['date'] }}</span>
+                                @else
+                                    {{ $day['date'] }}
+                                @endif
+                            </div>
+                            @if(count($day['transactions']) > 0)
+                                <div class="max-h-24 space-y-0.5 overflow-y-auto">
+                                    @foreach($day['transactions'] as $txn)
+                                        <div class="flex items-center justify-between gap-1 rounded px-1 py-0.5 text-xs {{ $txn['direction'] === 'debit' ? 'bg-red-50 dark:bg-red-950/30' : 'bg-green-50 dark:bg-green-950/30' }}">
+                                            <span class="truncate {{ !$day['isCurrentMonth'] ? 'text-zinc-400 dark:text-zinc-600' : 'text-zinc-600 dark:text-zinc-400' }}">{{ $txn['category'] }}</span>
+                                            <span class="shrink-0 tabular-nums font-medium {{ $txn['direction'] === 'debit' ? 'text-red-600 dark:text-red-400' : 'text-green-600 dark:text-green-400' }}">{{ $formatMoney($txn['amount']) }}</span>
+                                        </div>
+                                    @endforeach
+                                </div>
+                            @endif
+                        </div>
+                    @endforeach
+                </div>
+            @endforeach
+        </div>
+
+        <div class="md:hidden">
+            @php
+                $daysWithTransactions = collect($this->calendarData['weeks'])
+                    ->flatten(1)
+                    ->filter(fn ($day) => $day['isCurrentMonth'] && count($day['transactions']) > 0);
+            @endphp
+
+            @if($daysWithTransactions->isEmpty())
+                <div class="p-8 text-center">
+                    <flux:icon.calendar class="mx-auto size-12 text-zinc-400"/>
+                    <flux:heading size="lg" class="mt-4">No transactions</flux:heading>
+                    <flux:text class="mt-2">No transactions found for {{ $this->calendarData['monthLabel'] }}.</flux:text>
+                </div>
+            @else
+                <div class="divide-y divide-neutral-200 dark:divide-neutral-700">
+                    @foreach($daysWithTransactions as $day)
+                        <div wire:key="mobile-{{ $day['fullDate'] }}" class="px-4 py-3">
+                            <div class="mb-2 text-sm font-medium {{ $day['isToday'] ? 'text-indigo-600 dark:text-indigo-400' : 'text-zinc-700 dark:text-zinc-300' }}">
+                                {{ CarbonImmutable::parse($day['fullDate'])->format('D j M') }}
+                            </div>
+                            <div class="space-y-1">
+                                @foreach($day['transactions'] as $txn)
+                                    <div class="flex items-center justify-between text-sm">
+                                        <span class="truncate text-zinc-600 dark:text-zinc-400">{{ $txn['category'] }}</span>
+                                        <span class="shrink-0 tabular-nums font-medium {{ $txn['direction'] === 'debit' ? 'text-red-600 dark:text-red-400' : 'text-green-600 dark:text-green-400' }}">{{ $formatMoney($txn['amount']) }}</span>
+                                    </div>
+                                @endforeach
+                            </div>
+                        </div>
+                    @endforeach
+                </div>
+            @endif
+        </div>
+
+        @if(collect($this->calendarData['weeks'])->flatten(1)->every(fn ($day) => count($day['transactions']) === 0))
+            <div class="hidden p-8 text-center md:block">
+                <flux:icon.calendar class="mx-auto size-12 text-zinc-400"/>
+                <flux:heading size="lg" class="mt-4">No transactions</flux:heading>
+                <flux:text class="mt-2">No transactions found for {{ $this->calendarData['monthLabel'] }}.</flux:text>
+            </div>
+        @endif
+    </div>
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -18,6 +18,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::view('smoke-test', 'smoke-test')->name('smoke-test');
     Route::view('connect-bank', 'connect-bank')->name('connect-bank');
     Route::view('transactions', 'transactions')->name('transactions');
+    Route::view('calendar', 'calendar')->name('calendar');
     Route::view('accounts', 'accounts')->name('accounts');
     Route::get('basiq/callback', BasiqCallbackController::class)->name('basiq.callback');
 });

--- a/tests/Browser/Livewire/SpendingByCategoryBrowserTest.php
+++ b/tests/Browser/Livewire/SpendingByCategoryBrowserTest.php
@@ -26,7 +26,7 @@ test('spending chart renders donut with category data on dashboard', function ()
 
     $page->assertSee('Spending by Category')
         ->assertSee('Groceries');
-});
+})->skip('SpendingByCategory removed from dashboard in #78');
 
 test('period selector changes update the chart', function () {
     $user = User::factory()->create();
@@ -47,7 +47,7 @@ test('period selector changes update the chart', function () {
         ->assertSee('Recent Spend')
         ->select('[data-testid="spending-by-category"] [wire\\:model\\.live="period"]', '7d')
         ->assertSee('Recent Spend');
-});
+})->skip('SpendingByCategory removed from dashboard in #78');
 
 test('clicking category navigates to transaction list', function () {
     $user = User::factory()->create();
@@ -69,7 +69,7 @@ test('clicking category navigates to transaction list', function () {
         ->click('Groceries')
         ->assertPathBeginsWith('/transactions')
         ->assertQueryStringHas('category');
-});
+})->skip('SpendingByCategory removed from dashboard in #78');
 
 test('empty state displays when no transactions', function () {
     $user = User::factory()->create();
@@ -80,4 +80,4 @@ test('empty state displays when no transactions', function () {
 
     $page->assertSee('Spending by Category')
         ->assertSee('No spending data');
-});
+})->skip('SpendingByCategory removed from dashboard in #78');

--- a/tests/Feature/Livewire/CalendarViewTest.php
+++ b/tests/Feature/Livewire/CalendarViewTest.php
@@ -1,0 +1,281 @@
+<?php
+
+/** @noinspection StaticClosureCanBeUsedInspection */
+
+declare(strict_types=1);
+
+use App\Livewire\CalendarView;
+use App\Models\Account;
+use App\Models\Category;
+use App\Models\Transaction;
+use App\Models\User;
+use Livewire\Livewire;
+
+test('component renders for authenticated user', function () {
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(CalendarView::class)
+        ->assertSuccessful();
+});
+
+test('defaults to current month', function () {
+    $user = User::factory()->create();
+
+    $component = Livewire::actingAs($user)
+        ->test(CalendarView::class);
+
+    $data = $component->get('calendarData');
+
+    expect($data['monthLabel'])->toBe(now()->format('F Y'))
+        ->and($data['isCurrentMonth'])->toBeTrue();
+});
+
+test('shows transactions for current month', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $category = Category::factory()->create(['name' => 'Groceries']);
+
+    Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'category_id' => $category->id,
+        'amount' => -4250,
+        'post_date' => now()->startOfMonth()->addDays(5),
+    ]);
+
+    $component = Livewire::actingAs($user)
+        ->test(CalendarView::class);
+
+    $data = $component->get('calendarData');
+    $allTransactions = collect($data['weeks'])->flatten(1)
+        ->flatMap(fn (array $day) => $day['transactions']);
+
+    expect($allTransactions)->toHaveCount(1)
+        ->and($allTransactions->first()['category'])->toBe('Groceries')
+        ->and($allTransactions->first()['amount'])->toBe(-4250)
+        ->and($allTransactions->first()['direction'])->toBe('debit');
+});
+
+test('only shows current user transactions', function () {
+    $user = User::factory()->create();
+    $otherUser = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $otherAccount = Account::factory()->for($otherUser)->create();
+
+    Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'amount' => -3000,
+        'post_date' => now()->startOfMonth()->addDays(3),
+    ]);
+
+    Transaction::factory()->for($otherUser)->debit()->create([
+        'account_id' => $otherAccount->id,
+        'amount' => -8000,
+        'post_date' => now()->startOfMonth()->addDays(3),
+    ]);
+
+    $component = Livewire::actingAs($user)
+        ->test(CalendarView::class);
+
+    $data = $component->get('calendarData');
+    $allTransactions = collect($data['weeks'])->flatten(1)
+        ->flatMap(fn (array $day) => $day['transactions']);
+
+    expect($allTransactions)->toHaveCount(1)
+        ->and($allTransactions->first()['amount'])->toBe(-3000);
+});
+
+test('groups transactions by date correctly', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+
+    $dateA = now()->startOfMonth()->addDays(2);
+    $dateB = now()->startOfMonth()->addDays(5);
+
+    Transaction::factory()->for($user)->debit()->count(2)->create([
+        'account_id' => $account->id,
+        'amount' => -1000,
+        'post_date' => $dateA,
+    ]);
+
+    Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'amount' => -2000,
+        'post_date' => $dateB,
+    ]);
+
+    $component = Livewire::actingAs($user)
+        ->test(CalendarView::class);
+
+    $data = $component->get('calendarData');
+    $days = collect($data['weeks'])->flatten(1);
+
+    $dayA = $days->firstWhere('fullDate', $dateA->format('Y-m-d'));
+    $dayB = $days->firstWhere('fullDate', $dateB->format('Y-m-d'));
+
+    expect($dayA['transactions'])->toHaveCount(2)
+        ->and($dayB['transactions'])->toHaveCount(1);
+});
+
+test('previous month navigation works', function () {
+    $user = User::factory()->create();
+
+    $component = Livewire::actingAs($user)
+        ->test(CalendarView::class)
+        ->call('previousMonth');
+
+    $data = $component->get('calendarData');
+    $expectedLabel = now()->subMonth()->format('F Y');
+
+    expect($data['monthLabel'])->toBe($expectedLabel)
+        ->and($data['isCurrentMonth'])->toBeFalse();
+});
+
+test('next month navigation works', function () {
+    $user = User::factory()->create();
+
+    $component = Livewire::actingAs($user)
+        ->test(CalendarView::class)
+        ->call('nextMonth');
+
+    $data = $component->get('calendarData');
+    $expectedLabel = now()->addMonth()->format('F Y');
+
+    expect($data['monthLabel'])->toBe($expectedLabel)
+        ->and($data['isCurrentMonth'])->toBeFalse();
+});
+
+test('today button resets to current month', function () {
+    $user = User::factory()->create();
+
+    $component = Livewire::actingAs($user)
+        ->test(CalendarView::class)
+        ->call('previousMonth')
+        ->call('previousMonth')
+        ->call('goToToday');
+
+    $data = $component->get('calendarData');
+
+    expect($data['monthLabel'])->toBe(now()->format('F Y'))
+        ->and($data['isCurrentMonth'])->toBeTrue();
+});
+
+test('transactions include category names', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $category = Category::factory()->create(['name' => 'Transport']);
+
+    Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'category_id' => $category->id,
+        'amount' => -1500,
+        'post_date' => now()->startOfMonth()->addDays(1),
+    ]);
+
+    $component = Livewire::actingAs($user)
+        ->test(CalendarView::class);
+
+    $data = $component->get('calendarData');
+    $txn = collect($data['weeks'])->flatten(1)
+        ->flatMap(fn (array $day) => $day['transactions'])
+        ->first();
+
+    expect($txn['category'])->toBe('Transport');
+});
+
+test('uncategorised transactions show description as fallback', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+
+    Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'category_id' => null,
+        'description' => 'WOOLWORTHS 1234 SYDNEY',
+        'amount' => -500,
+        'post_date' => now()->startOfMonth()->addDays(1),
+    ]);
+
+    $component = Livewire::actingAs($user)
+        ->test(CalendarView::class);
+
+    $data = $component->get('calendarData');
+    $txn = collect($data['weeks'])->flatten(1)
+        ->flatMap(fn (array $day) => $day['transactions'])
+        ->first();
+
+    expect($txn['category'])->toBe('WOOLWORTHS 1234 SYDNEY');
+});
+
+test('empty state when no transactions', function () {
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(CalendarView::class)
+        ->assertSee('No transactions');
+});
+
+test('credit transactions have credit direction', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+
+    Transaction::factory()->for($user)->credit()->create([
+        'account_id' => $account->id,
+        'amount' => 5000,
+        'post_date' => now()->startOfMonth()->addDays(1),
+    ]);
+
+    $component = Livewire::actingAs($user)
+        ->test(CalendarView::class);
+
+    $data = $component->get('calendarData');
+    $txn = collect($data['weeks'])->flatten(1)
+        ->flatMap(fn (array $day) => $day['transactions'])
+        ->first();
+
+    expect($txn['direction'])->toBe('credit')
+        ->and($txn['amount'])->toBe(5000);
+});
+
+test('overflow days from adjacent months are marked', function () {
+    $user = User::factory()->create();
+
+    $component = Livewire::actingAs($user)
+        ->test(CalendarView::class);
+
+    $data = $component->get('calendarData');
+    $allDays = collect($data['weeks'])->flatten(1);
+
+    $overflowDays = $allDays->filter(fn (array $day) => ! $day['isCurrentMonth']);
+    $currentMonthDays = $allDays->filter(fn (array $day) => $day['isCurrentMonth']);
+
+    expect($overflowDays->isNotEmpty())->toBeTrue()
+        ->and($currentMonthDays->isNotEmpty())->toBeTrue();
+});
+
+test('calendar weeks always have 7 days', function () {
+    $user = User::factory()->create();
+
+    $component = Livewire::actingAs($user)
+        ->test(CalendarView::class);
+
+    $data = $component->get('calendarData');
+
+    foreach ($data['weeks'] as $week) {
+        expect($week)->toHaveCount(7);
+    }
+});
+
+test('today is marked in current month', function () {
+    $user = User::factory()->create();
+
+    $component = Livewire::actingAs($user)
+        ->test(CalendarView::class);
+
+    $data = $component->get('calendarData');
+    $todayCell = collect($data['weeks'])->flatten(1)
+        ->first(fn (array $day) => $day['isToday']);
+
+    expect($todayCell)->not->toBeNull()
+        ->and($todayCell['date'])->toBe((int) now()->format('j'))
+        ->and($todayCell['isCurrentMonth'])->toBeTrue();
+});


### PR DESCRIPTION
## Summary
- Moved "Spending Over Time" chart to full-width on dashboard, removed "Spending by Category" card
- Created new **CalendarView** Livewire component showing transactions per day in a monthly grid
- Calendar lives on its own `/calendar` page with sidebar navigation
- Transactions color-coded: red (debit), green (credit); shows description as fallback when no category assigned
- Month navigation with prev/next arrows and "Today" button
- Responsive: 7-column grid on desktop, date-grouped list on mobile

Closes #78

## Test plan
- [x] 15 CalendarView feature tests pass (rendering, navigation, grouping, isolation, fallback, empty state)
- [x] Existing SpendingOverTime tests unaffected
- [x] SpendingByCategory browser tests skipped (component removed from dashboard, preserved for reuse)
- [x] PHPStan clean, Pint clean
- [x] Full CI: 512 passed, 4 skipped
- [x] Visual verification via Playwright

🤖 Generated with [Claude Code](https://claude.com/claude-code)