### PR TITLE
feat: [80] Add TransactionSource and TransactionType enums

### DIFF
--- a/app/Enums/TransactionSource.php
+++ b/app/Enums/TransactionSource.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+enum TransactionSource: string
+{
+    case Manual = 'manual';
+    case Basiq = 'basiq';
+    case Planned = 'planned';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Manual => 'Manual',
+            self::Basiq => 'Basiq',
+            self::Planned => 'Planned',
+        };
+    }
+}

--- a/app/Enums/TransactionType.php
+++ b/app/Enums/TransactionType.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+enum TransactionType: string
+{
+    case Expense = 'expense';
+    case Income = 'income';
+    case Transfer = 'transfer';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Expense => 'Expense',
+            self::Income => 'Income',
+            self::Transfer => 'Transfer',
+        };
+    }
+}

--- a/tests/Unit/Enums/TransactionSourceTest.php
+++ b/tests/Unit/Enums/TransactionSourceTest.php
@@ -1,0 +1,29 @@
+<?php
+
+/** @noinspection StaticClosureCanBeUsedInspection */
+
+declare(strict_types=1);
+
+use App\Enums\TransactionSource;
+
+test('all transaction source cases exist', function () {
+    expect(TransactionSource::cases())->toHaveCount(3);
+});
+
+test('transaction source has correct backing values', function () {
+    expect(TransactionSource::Manual->value)->toBe('manual')
+        ->and(TransactionSource::Basiq->value)->toBe('basiq')
+        ->and(TransactionSource::Planned->value)->toBe('planned');
+});
+
+test('transaction source resolves from backing value', function () {
+    expect(TransactionSource::from('manual'))->toBe(TransactionSource::Manual)
+        ->and(TransactionSource::from('basiq'))->toBe(TransactionSource::Basiq)
+        ->and(TransactionSource::from('planned'))->toBe(TransactionSource::Planned);
+});
+
+test('transaction source has labels', function () {
+    expect(TransactionSource::Manual->label())->toBe('Manual')
+        ->and(TransactionSource::Basiq->label())->toBe('Basiq')
+        ->and(TransactionSource::Planned->label())->toBe('Planned');
+});

--- a/tests/Unit/Enums/TransactionTypeTest.php
+++ b/tests/Unit/Enums/TransactionTypeTest.php
@@ -1,0 +1,29 @@
+<?php
+
+/** @noinspection StaticClosureCanBeUsedInspection */
+
+declare(strict_types=1);
+
+use App\Enums\TransactionType;
+
+test('all transaction type cases exist', function () {
+    expect(TransactionType::cases())->toHaveCount(3);
+});
+
+test('transaction type has correct backing values', function () {
+    expect(TransactionType::Expense->value)->toBe('expense')
+        ->and(TransactionType::Income->value)->toBe('income')
+        ->and(TransactionType::Transfer->value)->toBe('transfer');
+});
+
+test('transaction type resolves from backing value', function () {
+    expect(TransactionType::from('expense'))->toBe(TransactionType::Expense)
+        ->and(TransactionType::from('income'))->toBe(TransactionType::Income)
+        ->and(TransactionType::from('transfer'))->toBe(TransactionType::Transfer);
+});
+
+test('transaction type has labels', function () {
+    expect(TransactionType::Expense->label())->toBe('Expense')
+        ->and(TransactionType::Income->label())->toBe('Income')
+        ->and(TransactionType::Transfer->label())->toBe('Transfer');
+});


### PR DESCRIPTION
## Summary
- Add `TransactionSource` enum (`Manual`, `Basiq`, `Planned`) to distinguish where transactions originate
- Add `TransactionType` enum (`Expense`, `Income`, `Transfer`) for the UI-level transaction type selector
- Both include `label()` methods following existing `PayFrequency` convention
- Unit tests for both enums (8 tests, 20 assertions)

Closes #80

## Test plan
- [x] `op test.filter TransactionSourceTest` — 4 tests pass
- [x] `op test.filter TransactionTypeTest` — 4 tests pass
- [x] `op ci` — full suite passes (520 tests, PHPStan clean, Pint clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)