### PR TITLE
feat: [82] Add source, transfer_pair_id, and notes columns to transactions table

### DIFF
--- a/app/Models/Transaction.php
+++ b/app/Models/Transaction.php
@@ -6,6 +6,7 @@ namespace App\Models;
 
 use App\Casts\MoneyCast;
 use App\Enums\TransactionDirection;
+use App\Enums\TransactionSource;
 use App\Enums\TransactionStatus;
 use Carbon\CarbonImmutable;
 use Database\Factories\TransactionFactory;
@@ -31,6 +32,10 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property string|null $merchant_name
  * @property string|null $anzsic_code
  * @property array<string, mixed>|null $enrich_data
+ * @property TransactionSource $source
+ * @property int|null $transfer_pair_id
+ * @property int|null $planned_transaction_id
+ * @property string|null $notes
  * @property CarbonImmutable $created_at
  * @property CarbonImmutable $updated_at
  */
@@ -58,6 +63,10 @@ final class Transaction extends Model
         'merchant_name',
         'anzsic_code',
         'enrich_data',
+        'source',
+        'transfer_pair_id',
+        'planned_transaction_id',
+        'notes',
     ];
 
     /** @return BelongsTo<User, $this> */
@@ -78,6 +87,12 @@ final class Transaction extends Model
         return $this->belongsTo(Category::class);
     }
 
+    /** @return BelongsTo<self, $this> */
+    public function transferPair(): BelongsTo
+    {
+        return $this->belongsTo(self::class, 'transfer_pair_id');
+    }
+
     /**
      * @param  Builder<self>  $query
      * @return Builder<self>
@@ -93,6 +108,7 @@ final class Transaction extends Model
     protected function casts(): array
     {
         return [
+            'source' => TransactionSource::class,
             'direction' => TransactionDirection::class,
             'status' => TransactionStatus::class,
             'amount' => MoneyCast::class,

--- a/database/factories/TransactionFactory.php
+++ b/database/factories/TransactionFactory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Database\Factories;
 
 use App\Enums\TransactionDirection;
+use App\Enums\TransactionSource;
 use App\Enums\TransactionStatus;
 use App\Models\Account;
 use App\Models\Category;
@@ -37,6 +38,7 @@ final class TransactionFactory extends Factory
             ]),
             'post_date' => fake()->dateTimeBetween('-3 months', 'now'),
             'status' => TransactionStatus::Posted,
+            'source' => TransactionSource::Manual,
         ];
     }
 
@@ -65,6 +67,7 @@ final class TransactionFactory extends Factory
     public function fromBasiq(): self
     {
         return $this->state(fn (array $attributes) => [
+            'source' => TransactionSource::Basiq,
             'basiq_id' => fake()->uuid(),
             'basiq_account_id' => fake()->uuid(),
             'merchant_name' => fake()->randomElement(['Woolworths', 'Coles', 'Aldi', 'Kmart', 'Bunnings', 'JB Hi-Fi']),
@@ -80,6 +83,27 @@ final class TransactionFactory extends Factory
     {
         return $this->state(fn (array $attributes) => [
             'status' => TransactionStatus::Pending,
+        ]);
+    }
+
+    public function manual(): self
+    {
+        return $this->state(fn (array $attributes) => [
+            'source' => TransactionSource::Manual,
+        ]);
+    }
+
+    public function transfer(): self
+    {
+        return $this->state(fn (array $attributes) => [
+            'transfer_pair_id' => Transaction::factory(),
+        ]);
+    }
+
+    public function withNotes(): self
+    {
+        return $this->state(fn (array $attributes) => [
+            'notes' => fake()->sentence(),
         ]);
     }
 }

--- a/database/migrations/2026_03_26_125156_add_source_and_transfer_columns_to_transactions_table.php
+++ b/database/migrations/2026_03_26_125156_add_source_and_transfer_columns_to_transactions_table.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('transactions', function (Blueprint $table) {
+            $table->string('source')->default('manual')->after('enrich_data');
+            $table->foreignId('transfer_pair_id')->nullable()->after('source')
+                ->constrained('transactions')->nullOnDelete();
+            $table->foreignId('planned_transaction_id')->nullable()->after('transfer_pair_id');
+            $table->text('notes')->nullable()->after('planned_transaction_id');
+        });
+
+        DB::table('transactions')
+            ->whereNotNull('basiq_id')
+            ->update(['source' => 'basiq']);
+    }
+
+    public function down(): void
+    {
+        Schema::table('transactions', function (Blueprint $table) {
+            $table->dropForeign(['transfer_pair_id']);
+            $table->dropColumn(['source', 'transfer_pair_id', 'planned_transaction_id', 'notes']);
+        });
+    }
+};

--- a/tests/Feature/Models/TransactionTest.php
+++ b/tests/Feature/Models/TransactionTest.php
@@ -5,12 +5,14 @@
 declare(strict_types=1);
 
 use App\Enums\TransactionDirection;
+use App\Enums\TransactionSource;
 use App\Enums\TransactionStatus;
 use App\Models\Account;
 use App\Models\Category;
 use App\Models\Transaction;
 use App\Models\User;
 use Illuminate\Database\QueryException;
+use Illuminate\Support\Facades\DB;
 
 test('factory creates a valid transaction', function () {
     $transaction = Transaction::factory()->create();
@@ -169,4 +171,92 @@ test('amount is stored as integer cents', function () {
 
     expect($transaction->amount)->toBe(4599)
         ->and($transaction->amount)->toBeInt();
+});
+
+test('source defaults to manual for new transactions', function () {
+    $attributes = Transaction::factory()->make()->getAttributes();
+    unset($attributes['source']);
+
+    $id = DB::table('transactions')->insertGetId($attributes);
+    $transaction = Transaction::query()->findOrFail($id);
+
+    expect($transaction->source)->toBe(TransactionSource::Manual);
+});
+
+test('source is cast to TransactionSource enum', function () {
+    $transaction = Transaction::factory()->create();
+
+    expect($transaction->source)->toBeInstanceOf(TransactionSource::class);
+});
+
+test('fromBasiq factory state sets source to basiq', function () {
+    $transaction = Transaction::factory()->fromBasiq()->create();
+
+    expect($transaction->source)->toBe(TransactionSource::Basiq);
+});
+
+test('manual factory state sets source to manual', function () {
+    $transaction = Transaction::factory()->manual()->create();
+
+    expect($transaction->source)->toBe(TransactionSource::Manual);
+});
+
+test('transfer factory state links transfer pair', function () {
+    $transaction = Transaction::factory()->transfer()->create();
+
+    expect($transaction->transfer_pair_id)->not->toBeNull();
+});
+
+test('transfer pair relationship returns a transaction', function () {
+    $pair = Transaction::factory()->create();
+    $transaction = Transaction::factory()->create(['transfer_pair_id' => $pair->id]);
+
+    expect($transaction->transferPair)->toBeInstanceOf(Transaction::class)
+        ->and($transaction->transferPair->id)->toBe($pair->id);
+});
+
+test('deleting transfer pair nullifies transfer_pair_id', function () {
+    $pair = Transaction::factory()->create();
+    $transaction = Transaction::factory()->create(['transfer_pair_id' => $pair->id]);
+
+    $pair->delete();
+
+    expect($transaction->fresh()->transfer_pair_id)->toBeNull();
+});
+
+test('planned_transaction_id is nullable', function () {
+    $transaction = Transaction::factory()->create();
+
+    expect($transaction->planned_transaction_id)->toBeNull();
+});
+
+test('notes column is nullable', function () {
+    $transaction = Transaction::factory()->create();
+
+    expect($transaction->notes)->toBeNull();
+});
+
+test('withNotes factory state populates notes', function () {
+    $transaction = Transaction::factory()->withNotes()->create();
+
+    expect($transaction->notes)->not->toBeNull()
+        ->and($transaction->notes)->toBeString();
+});
+
+test('backfill sets source to basiq for transactions with basiq_id', function () {
+    $basiqTransaction = Transaction::factory()->create([
+        'basiq_id' => 'test-basiq-id',
+        'source' => 'manual',
+    ]);
+    $manualTransaction = Transaction::factory()->create([
+        'basiq_id' => null,
+        'source' => 'manual',
+    ]);
+
+    DB::table('transactions')
+        ->whereNotNull('basiq_id')
+        ->update(['source' => 'basiq']);
+
+    expect($basiqTransaction->fresh()->source)->toBe(TransactionSource::Basiq)
+        ->and($manualTransaction->fresh()->source)->toBe(TransactionSource::Manual);
 });


### PR DESCRIPTION
## Summary
- Add migration with `source` (default `manual`), `transfer_pair_id` (FK to self), `planned_transaction_id`, and `notes` columns to transactions table
- Backfill existing Basiq-synced rows (`basiq_id IS NOT NULL`) with `source = 'basiq'`
- Extend Transaction model with `source` cast to `TransactionSource` enum, `transferPair()` relationship, and new fillable fields
- Add factory states: `manual()`, `transfer()`, `withNotes()`, and update `fromBasiq()` to set source

## Test plan
- [x] Source defaults to `manual` for new transactions
- [x] Source cast to `TransactionSource` enum
- [x] Factory states: `fromBasiq`, `manual`, `transfer`, `withNotes`
- [x] Transfer pair relationship returns linked transaction
- [x] Deleting transfer pair nullifies `transfer_pair_id` (cascading null)
- [x] Backfill logic sets source to `basiq` for transactions with `basiq_id`
- [x] `planned_transaction_id` and `notes` are nullable

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)