### PR TITLE
feat: [83] Create PlannedTransaction model and migration

### DIFF
--- a/app/Models/PlannedTransaction.php
+++ b/app/Models/PlannedTransaction.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Casts\MoneyCast;
+use App\Enums\RecurrenceFrequency;
+use App\Enums\TransactionDirection;
+use Carbon\CarbonImmutable;
+use Database\Factories\PlannedTransactionFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Collection;
+
+/**
+ * @property int $id
+ * @property int $user_id
+ * @property int $account_id
+ * @property int|null $category_id
+ * @property int $amount
+ * @property TransactionDirection $direction
+ * @property string $description
+ * @property CarbonImmutable $start_date
+ * @property RecurrenceFrequency $frequency
+ * @property CarbonImmutable|null $until_date
+ * @property bool $is_active
+ * @property CarbonImmutable|null $last_generated_date
+ * @property CarbonImmutable $created_at
+ * @property CarbonImmutable $updated_at
+ */
+final class PlannedTransaction extends Model
+{
+    /** @use HasFactory<PlannedTransactionFactory> */
+    use HasFactory;
+
+    /**
+     * @var list<string>
+     */
+    protected $fillable = [
+        'user_id',
+        'account_id',
+        'category_id',
+        'amount',
+        'direction',
+        'description',
+        'start_date',
+        'frequency',
+        'until_date',
+        'is_active',
+        'last_generated_date',
+    ];
+
+    /** @return BelongsTo<User, $this> */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /** @return BelongsTo<Account, $this> */
+    public function account(): BelongsTo
+    {
+        return $this->belongsTo(Account::class);
+    }
+
+    /** @return BelongsTo<Category, $this> */
+    public function category(): BelongsTo
+    {
+        return $this->belongsTo(Category::class);
+    }
+
+    /** @return HasMany<Transaction, $this> */
+    public function transactions(): HasMany
+    {
+        return $this->hasMany(Transaction::class);
+    }
+
+    /** @return Collection<int, CarbonImmutable> */
+    public function occurrencesBetween(CarbonImmutable $start, CarbonImmutable $end): Collection
+    {
+        if (! $this->is_active) {
+            return collect();
+        }
+
+        $dates = collect();
+        $current = $this->start_date;
+        $limit = $this->until_date;
+        $maxIterations = 1000;
+
+        if ($this->frequency === RecurrenceFrequency::DontRepeat) {
+            if ($current->between($start, $end) && ($limit === null || $current->lte($limit))) {
+                $dates->push($current);
+            }
+
+            return $dates;
+        }
+
+        for ($i = 0; $i < $maxIterations; $i++) {
+            if ($current->greaterThan($end)) {
+                break;
+            }
+
+            if ($limit !== null && $current->greaterThan($limit)) {
+                break;
+            }
+
+            if ($current->between($start, $end)) {
+                $dates->push($current);
+            }
+
+            $next = $this->frequency->nextOccurrence($current);
+
+            if ($next === null) {
+                break;
+            }
+
+            $current = $next;
+        }
+
+        return $dates;
+    }
+
+    /** @return array<string, string> */
+    protected function casts(): array
+    {
+        return [
+            'direction' => TransactionDirection::class,
+            'frequency' => RecurrenceFrequency::class,
+            'amount' => MoneyCast::class,
+            'start_date' => 'date',
+            'until_date' => 'date',
+            'last_generated_date' => 'date',
+            'is_active' => 'boolean',
+        ];
+    }
+}

--- a/app/Models/Transaction.php
+++ b/app/Models/Transaction.php
@@ -87,6 +87,12 @@ final class Transaction extends Model
         return $this->belongsTo(Category::class);
     }
 
+    /** @return BelongsTo<PlannedTransaction, $this> */
+    public function plannedTransaction(): BelongsTo
+    {
+        return $this->belongsTo(PlannedTransaction::class);
+    }
+
     /** @return BelongsTo<self, $this> */
     public function transferPair(): BelongsTo
     {

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -86,6 +86,12 @@ final class User extends Authenticatable
         return $this->hasMany(Budget::class);
     }
 
+    /** @return HasMany<PlannedTransaction, $this> */
+    public function plannedTransactions(): HasMany
+    {
+        return $this->hasMany(PlannedTransaction::class);
+    }
+
     public function hasPayCycleConfigured(): bool
     {
         return $this->pay_amount !== null

--- a/database/factories/PlannedTransactionFactory.php
+++ b/database/factories/PlannedTransactionFactory.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Enums\RecurrenceFrequency;
+use App\Enums\TransactionDirection;
+use App\Models\Account;
+use App\Models\PlannedTransaction;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<PlannedTransaction>
+ */
+final class PlannedTransactionFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $user = User::factory();
+
+        return [
+            'user_id' => $user,
+            'account_id' => Account::factory()->for($user),
+            'amount' => fake()->numberBetween(100, 50000),
+            'direction' => TransactionDirection::Debit,
+            'description' => fake()->randomElement([
+                'Rent Payment', 'Electricity Bill', 'Internet Subscription', 'Phone Plan',
+                'Gym Membership', 'Streaming Service', 'Insurance Premium', 'Car Loan',
+                'Savings Transfer', 'Grocery Budget', 'Salary Deposit', 'Mortgage Payment',
+            ]),
+            'start_date' => fake()->dateTimeBetween('-1 month', 'now'),
+            'frequency' => RecurrenceFrequency::EveryMonth,
+            'is_active' => true,
+        ];
+    }
+
+    public function weekly(): self
+    {
+        return $this->state(fn (array $attributes) => [
+            'frequency' => RecurrenceFrequency::EveryWeek,
+        ]);
+    }
+
+    public function monthly(): self
+    {
+        return $this->state(fn (array $attributes) => [
+            'frequency' => RecurrenceFrequency::EveryMonth,
+        ]);
+    }
+
+    public function noRepeat(): self
+    {
+        return $this->state(fn (array $attributes) => [
+            'frequency' => RecurrenceFrequency::DontRepeat,
+        ]);
+    }
+
+    public function withEndDate(): self
+    {
+        return $this->state(fn (array $attributes) => [
+            'until_date' => now()->addMonths(6),
+        ]);
+    }
+
+    public function inactive(): self
+    {
+        return $this->state(fn (array $attributes) => [
+            'is_active' => false,
+        ]);
+    }
+}

--- a/database/migrations/2026_03_26_132959_create_planned_transactions_table.php
+++ b/database/migrations/2026_03_26_132959_create_planned_transactions_table.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('planned_transactions', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('account_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('category_id')->nullable()->constrained()->nullOnDelete();
+            $table->bigInteger('amount');
+            $table->string('direction');
+            $table->string('description');
+            $table->date('start_date');
+            $table->string('frequency');
+            $table->date('until_date')->nullable();
+            $table->boolean('is_active')->default(true);
+            $table->date('last_generated_date')->nullable();
+            $table->timestamps();
+
+            $table->index(['user_id', 'start_date']);
+            $table->index(['user_id', 'is_active']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('planned_transactions');
+    }
+};

--- a/database/migrations/2026_03_26_133108_add_planned_transaction_foreign_key_to_transactions_table.php
+++ b/database/migrations/2026_03_26_133108_add_planned_transaction_foreign_key_to_transactions_table.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('transactions', function (Blueprint $table) {
+            $table->foreign('planned_transaction_id')
+                ->references('id')->on('planned_transactions')
+                ->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('transactions', function (Blueprint $table) {
+            $table->dropForeign(['planned_transaction_id']);
+        });
+    }
+};

--- a/database/seeders/PlannedTransactionSeeder.php
+++ b/database/seeders/PlannedTransactionSeeder.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+
+final class PlannedTransactionSeeder extends Seeder
+{
+    public function run(): void {}
+}

--- a/tests/Feature/Models/PlannedTransactionTest.php
+++ b/tests/Feature/Models/PlannedTransactionTest.php
@@ -1,0 +1,402 @@
+<?php
+
+/** @noinspection StaticClosureCanBeUsedInspection */
+
+declare(strict_types=1);
+
+use App\Enums\RecurrenceFrequency;
+use App\Enums\TransactionDirection;
+use App\Models\Account;
+use App\Models\Category;
+use App\Models\PlannedTransaction;
+use App\Models\Transaction;
+use App\Models\User;
+use Carbon\CarbonImmutable;
+
+// ── Factory & Basics ──────────────────────────────────────────────
+
+test('factory creates a valid planned transaction', function () {
+    $planned = PlannedTransaction::factory()->create();
+
+    expect($planned)->toBeInstanceOf(PlannedTransaction::class)
+        ->and($planned->exists)->toBeTrue();
+});
+
+test('default factory creates monthly frequency', function () {
+    $planned = PlannedTransaction::factory()->create();
+
+    expect($planned->frequency)->toBe(RecurrenceFrequency::EveryMonth);
+});
+
+test('default factory creates active planned transaction', function () {
+    $planned = PlannedTransaction::factory()->create();
+
+    expect($planned->is_active)->toBeTrue();
+});
+
+// ── Relationships ─────────────────────────────────────────────────
+
+test('planned transaction belongs to a user', function () {
+    $planned = PlannedTransaction::factory()->create();
+
+    expect($planned->user)->toBeInstanceOf(User::class);
+});
+
+test('planned transaction belongs to an account', function () {
+    $planned = PlannedTransaction::factory()->create();
+
+    expect($planned->account)->toBeInstanceOf(Account::class);
+});
+
+test('planned transaction belongs to a category', function () {
+    $planned = PlannedTransaction::factory()->create([
+        'category_id' => Category::factory(),
+    ]);
+
+    expect($planned->category)->toBeInstanceOf(Category::class);
+});
+
+test('category_id is nullable', function () {
+    $planned = PlannedTransaction::factory()->create();
+
+    expect($planned->category_id)->toBeNull();
+});
+
+test('planned transaction has many transactions', function () {
+    $planned = PlannedTransaction::factory()->create();
+    Transaction::factory()->count(3)
+        ->for($planned->user)
+        ->for($planned->account)
+        ->create(['planned_transaction_id' => $planned->id]);
+
+    expect($planned->transactions)->toHaveCount(3)
+        ->each(fn (Pest\Expectation $transaction) => $transaction->toBeInstanceOf(Transaction::class));
+});
+
+test('transaction belongs to planned transaction', function () {
+    $planned = PlannedTransaction::factory()->create();
+    $transaction = Transaction::factory()
+        ->for($planned->user)
+        ->for($planned->account)
+        ->create(['planned_transaction_id' => $planned->id]);
+
+    expect($transaction->plannedTransaction)->toBeInstanceOf(PlannedTransaction::class)
+        ->and($transaction->plannedTransaction->id)->toBe($planned->id);
+});
+
+test('user has many planned transactions', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    PlannedTransaction::factory()->count(3)->for($user)->for($account)->create();
+
+    expect($user->plannedTransactions)->toHaveCount(3)
+        ->each(fn (Pest\Expectation $pt) => $pt->toBeInstanceOf(PlannedTransaction::class));
+});
+
+// ── Cascade Behavior ──────────────────────────────────────────────
+
+test('deleting a user cascades to planned transactions', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    PlannedTransaction::factory()->count(2)->for($user)->for($account)->create();
+
+    $user->delete();
+
+    expect(PlannedTransaction::where('user_id', $user->id)->count())->toBe(0);
+});
+
+test('deleting an account cascades to planned transactions', function () {
+    $account = Account::factory()->create();
+    PlannedTransaction::factory()->count(2)->for($account->user)->for($account)->create();
+
+    $account->delete();
+
+    expect(PlannedTransaction::where('account_id', $account->id)->count())->toBe(0);
+});
+
+test('deleting a category nullifies planned transaction category_id', function () {
+    $category = Category::factory()->create();
+    $planned = PlannedTransaction::factory()->create(['category_id' => $category->id]);
+
+    $category->delete();
+
+    expect($planned->fresh()->category_id)->toBeNull();
+});
+
+// ── Casts ─────────────────────────────────────────────────────────
+
+test('direction is cast to TransactionDirection enum', function () {
+    $planned = PlannedTransaction::factory()->create();
+
+    expect($planned->direction)->toBeInstanceOf(TransactionDirection::class);
+});
+
+test('frequency is cast to RecurrenceFrequency enum', function () {
+    $planned = PlannedTransaction::factory()->create();
+
+    expect($planned->frequency)->toBeInstanceOf(RecurrenceFrequency::class);
+});
+
+test('amount is stored as integer cents', function () {
+    $planned = PlannedTransaction::factory()->create(['amount' => 4599]);
+
+    expect($planned->amount)->toBe(4599)
+        ->and($planned->amount)->toBeInt();
+});
+
+test('start_date is cast to date', function () {
+    $planned = PlannedTransaction::factory()->create(['start_date' => '2026-03-01']);
+
+    expect($planned->start_date)
+        ->toBeInstanceOf(CarbonImmutable::class)
+        ->and($planned->start_date->toDateString())->toBe('2026-03-01');
+});
+
+test('until_date is cast to date', function () {
+    $planned = PlannedTransaction::factory()->withEndDate()->create();
+
+    expect($planned->until_date)->toBeInstanceOf(CarbonImmutable::class);
+});
+
+test('is_active is cast to boolean', function () {
+    $planned = PlannedTransaction::factory()->create();
+
+    expect($planned->is_active)->toBeBool();
+});
+
+// ── Factory States ────────────────────────────────────────────────
+
+test('weekly state sets frequency to every week', function () {
+    $planned = PlannedTransaction::factory()->weekly()->create();
+
+    expect($planned->frequency)->toBe(RecurrenceFrequency::EveryWeek);
+});
+
+test('monthly state sets frequency to every month', function () {
+    $planned = PlannedTransaction::factory()->monthly()->create();
+
+    expect($planned->frequency)->toBe(RecurrenceFrequency::EveryMonth);
+});
+
+test('noRepeat state sets frequency to dont repeat', function () {
+    $planned = PlannedTransaction::factory()->noRepeat()->create();
+
+    expect($planned->frequency)->toBe(RecurrenceFrequency::DontRepeat);
+});
+
+test('withEndDate state sets until_date', function () {
+    $planned = PlannedTransaction::factory()->withEndDate()->create();
+
+    expect($planned->until_date)->not->toBeNull()
+        ->and($planned->until_date)->toBeInstanceOf(CarbonImmutable::class);
+});
+
+test('inactive state sets is_active to false', function () {
+    $planned = PlannedTransaction::factory()->inactive()->create();
+
+    expect($planned->is_active)->toBeFalse();
+});
+
+// ── occurrencesBetween() ──────────────────────────────────────────
+
+test('monthly occurrences returns correct dates for a 3-month window', function () {
+    $planned = PlannedTransaction::factory()->create([
+        'start_date' => '2026-01-15',
+        'frequency' => RecurrenceFrequency::EveryMonth,
+    ]);
+
+    $dates = $planned->occurrencesBetween(
+        CarbonImmutable::parse('2026-01-01'),
+        CarbonImmutable::parse('2026-03-31'),
+    );
+
+    expect($dates)->toHaveCount(3)
+        ->and($dates[0]->toDateString())->toBe('2026-01-15')
+        ->and($dates[1]->toDateString())->toBe('2026-02-15')
+        ->and($dates[2]->toDateString())->toBe('2026-03-15');
+});
+
+test('weekly occurrences returns correct dates', function () {
+    $planned = PlannedTransaction::factory()->create([
+        'start_date' => '2026-03-02',
+        'frequency' => RecurrenceFrequency::EveryWeek,
+    ]);
+
+    $dates = $planned->occurrencesBetween(
+        CarbonImmutable::parse('2026-03-01'),
+        CarbonImmutable::parse('2026-03-22'),
+    );
+
+    expect($dates)->toHaveCount(3)
+        ->and($dates[0]->toDateString())->toBe('2026-03-02')
+        ->and($dates[1]->toDateString())->toBe('2026-03-09')
+        ->and($dates[2]->toDateString())->toBe('2026-03-16');
+});
+
+test('everyday occurrences returns correct dates', function () {
+    $planned = PlannedTransaction::factory()->create([
+        'start_date' => '2026-03-01',
+        'frequency' => RecurrenceFrequency::Everyday,
+    ]);
+
+    $dates = $planned->occurrencesBetween(
+        CarbonImmutable::parse('2026-03-01'),
+        CarbonImmutable::parse('2026-03-03'),
+    );
+
+    expect($dates)->toHaveCount(3)
+        ->and($dates[0]->toDateString())->toBe('2026-03-01')
+        ->and($dates[1]->toDateString())->toBe('2026-03-02')
+        ->and($dates[2]->toDateString())->toBe('2026-03-03');
+});
+
+test('dont repeat returns single date if in range', function () {
+    $planned = PlannedTransaction::factory()->create([
+        'start_date' => '2026-03-15',
+        'frequency' => RecurrenceFrequency::DontRepeat,
+    ]);
+
+    $dates = $planned->occurrencesBetween(
+        CarbonImmutable::parse('2026-03-01'),
+        CarbonImmutable::parse('2026-03-31'),
+    );
+
+    expect($dates)->toHaveCount(1)
+        ->and($dates[0]->toDateString())->toBe('2026-03-15');
+});
+
+test('dont repeat returns empty if not in range', function () {
+    $planned = PlannedTransaction::factory()->create([
+        'start_date' => '2026-04-15',
+        'frequency' => RecurrenceFrequency::DontRepeat,
+    ]);
+
+    $dates = $planned->occurrencesBetween(
+        CarbonImmutable::parse('2026-03-01'),
+        CarbonImmutable::parse('2026-03-31'),
+    );
+
+    expect($dates)->toBeEmpty();
+});
+
+test('respects until_date boundary', function () {
+    $planned = PlannedTransaction::factory()->create([
+        'start_date' => '2026-01-15',
+        'frequency' => RecurrenceFrequency::EveryMonth,
+        'until_date' => '2026-03-01',
+    ]);
+
+    $dates = $planned->occurrencesBetween(
+        CarbonImmutable::parse('2026-01-01'),
+        CarbonImmutable::parse('2026-06-30'),
+    );
+
+    expect($dates)->toHaveCount(2)
+        ->and($dates[0]->toDateString())->toBe('2026-01-15')
+        ->and($dates[1]->toDateString())->toBe('2026-02-15');
+});
+
+test('respects is_active flag', function () {
+    $planned = PlannedTransaction::factory()->inactive()->create([
+        'start_date' => '2026-03-01',
+        'frequency' => RecurrenceFrequency::EveryMonth,
+    ]);
+
+    $dates = $planned->occurrencesBetween(
+        CarbonImmutable::parse('2026-03-01'),
+        CarbonImmutable::parse('2026-06-30'),
+    );
+
+    expect($dates)->toBeEmpty();
+});
+
+test('start date after range returns empty collection', function () {
+    $planned = PlannedTransaction::factory()->create([
+        'start_date' => '2026-06-01',
+        'frequency' => RecurrenceFrequency::EveryMonth,
+    ]);
+
+    $dates = $planned->occurrencesBetween(
+        CarbonImmutable::parse('2026-03-01'),
+        CarbonImmutable::parse('2026-03-31'),
+    );
+
+    expect($dates)->toBeEmpty();
+});
+
+test('start date before range skips dates before range start', function () {
+    $planned = PlannedTransaction::factory()->create([
+        'start_date' => '2025-12-15',
+        'frequency' => RecurrenceFrequency::EveryMonth,
+    ]);
+
+    $dates = $planned->occurrencesBetween(
+        CarbonImmutable::parse('2026-03-01'),
+        CarbonImmutable::parse('2026-05-31'),
+    );
+
+    expect($dates)->toHaveCount(3)
+        ->and($dates[0]->toDateString())->toBe('2026-03-15')
+        ->and($dates[1]->toDateString())->toBe('2026-04-15')
+        ->and($dates[2]->toDateString())->toBe('2026-05-15');
+});
+
+test('monthly on 31st handles short months', function () {
+    $planned = PlannedTransaction::factory()->create([
+        'start_date' => '2026-01-31',
+        'frequency' => RecurrenceFrequency::EveryMonth,
+    ]);
+
+    $dates = $planned->occurrencesBetween(
+        CarbonImmutable::parse('2026-01-01'),
+        CarbonImmutable::parse('2026-04-30'),
+    );
+
+    expect($dates)->toHaveCount(4)
+        ->and($dates[0]->toDateString())->toBe('2026-01-31')
+        ->and($dates[1]->toDateString())->toBe('2026-02-28')
+        ->and($dates[2]->toDateString())->toBe('2026-03-28')
+        ->and($dates[3]->toDateString())->toBe('2026-04-28');
+});
+
+test('occurrence on exact range boundary dates are included', function () {
+    $planned = PlannedTransaction::factory()->create([
+        'start_date' => '2026-03-15',
+        'frequency' => RecurrenceFrequency::DontRepeat,
+    ]);
+
+    $startBoundary = $planned->occurrencesBetween(
+        CarbonImmutable::parse('2026-03-15'),
+        CarbonImmutable::parse('2026-03-31'),
+    );
+
+    $endBoundary = $planned->occurrencesBetween(
+        CarbonImmutable::parse('2026-03-01'),
+        CarbonImmutable::parse('2026-03-15'),
+    );
+
+    expect($startBoundary)->toHaveCount(1)
+        ->and($endBoundary)->toHaveCount(1);
+});
+
+test('every workday skips weekends in occurrences', function () {
+    $planned = PlannedTransaction::factory()->create([
+        'start_date' => '2026-03-26',
+        'frequency' => RecurrenceFrequency::EveryWorkday,
+    ]);
+
+    $dates = $planned->occurrencesBetween(
+        CarbonImmutable::parse('2026-03-26'),
+        CarbonImmutable::parse('2026-04-01'),
+    );
+
+    $dateStrings = $dates->map(fn (CarbonImmutable $d) => $d->toDateString())->all();
+
+    expect($dateStrings)->toBe([
+        '2026-03-26',
+        '2026-03-27',
+        '2026-03-30',
+        '2026-03-31',
+        '2026-04-01',
+    ]);
+});


### PR DESCRIPTION
## Summary
- Create `PlannedTransaction` model — a recurring/planned transaction template that generates virtual calendar entries across future dates, separate from actual `Transaction` records
- Add migration with full schema (columns, indexes, FK constraints) including a follow-up migration to add the foreign key constraint for `planned_transaction_id` on the existing `transactions` table
- Implement `occurrencesBetween(CarbonImmutable $start, CarbonImmutable $end)` method that iterates using `RecurrenceFrequency::nextOccurrence()` to generate date occurrences within a range
- Add factory with `weekly()`, `monthly()`, `noRepeat()`, `withEndDate()`, and `inactive()` states
- Wire up relationships: `Transaction.plannedTransaction()` BelongsTo, `User.plannedTransactions()` HasMany

## Test plan
- [x] 36 feature tests covering factory defaults, relationships, cascade behavior, casts, factory states, and `occurrencesBetween()` logic
- [x] `occurrencesBetween()` edge cases: `DontRepeat`, `until_date` boundary, inactive flag, start before/after range, monthly on 31st (short months), workday skipping weekends
- [x] `op migrate.fresh` runs clean
- [x] `op ci` passes (lint, PHPStan, 644 tests)

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)