### PR TITLE
feat: [86] Wire CalendarView day cells to open transaction modal

### DIFF
--- a/app/Livewire/CalendarView.php
+++ b/app/Livewire/CalendarView.php
@@ -47,7 +47,7 @@ final class CalendarView extends Component
         unset($this->calendarData); // @phpstan-ignore property.notFound
     }
 
-    /** @return array{monthLabel: string, weeks: list<list<array{date: int, fullDate: string, isCurrentMonth: bool, isToday: bool, transactions: list<array{category: string, amount: int, direction: string}>}>>, isCurrentMonth: bool} */
+    /** @return array{monthLabel: string, weeks: list<list<array{date: int, fullDate: string, isCurrentMonth: bool, isToday: bool, transactions: list<array{id: int, category: string, amount: int, direction: string, source: string}>}>>, isCurrentMonth: bool} */
     #[Computed(persist: true)]
     public function calendarData(): array
     {
@@ -82,9 +82,11 @@ final class CalendarView extends Component
                     'isCurrentMonth' => $current->month === $monthStart->month && $current->year === $monthStart->year,
                     'isToday' => $current->isSameDay($today),
                     'transactions' => $dayTransactions->map(fn (Transaction $t) => [
+                        'id' => $t->id,
                         'category' => $t->category?->name ?? $t->description, // @phpstan-ignore nullsafe.neverNull
                         'amount' => $t->amount,
                         'direction' => $t->direction->value,
+                        'source' => $t->source->value,
                     ])->values()->all(),
                 ];
 
@@ -103,13 +105,13 @@ final class CalendarView extends Component
     public function placeholder(): string
     {
         return <<<'HTML'
-        <div>
-            <div class="space-y-4">
-                <div class="animate-pulse rounded-xl bg-zinc-100 dark:bg-zinc-800 h-10 w-48"></div>
-                <div class="animate-pulse rounded-xl bg-zinc-100 dark:bg-zinc-800 h-96"></div>
+            <div>
+                <div class="space-y-4">
+                    <div class="animate-pulse rounded-xl bg-zinc-100 dark:bg-zinc-800 h-10 w-48"></div>
+                    <div class="animate-pulse rounded-xl bg-zinc-100 dark:bg-zinc-800 h-96"></div>
+                </div>
             </div>
-        </div>
-        HTML;
+            HTML;
     }
 
     public function render(): View

--- a/resources/views/livewire/calendar-view.blade.php
+++ b/resources/views/livewire/calendar-view.blade.php
@@ -41,10 +41,14 @@
                             @if(count($day['transactions']) > 0)
                                 <div class="max-h-24 space-y-0.5 overflow-y-auto">
                                     @foreach($day['transactions'] as $txn)
-                                        <div class="flex items-center justify-between gap-1 rounded px-1 py-0.5 text-xs {{ $txn['direction'] === 'debit' ? 'bg-red-50 dark:bg-red-950/30' : 'bg-green-50 dark:bg-green-950/30' }}">
+                                        <button
+                                            type="button"
+                                            wire:click.stop="$dispatch('edit-transaction', { id: {{ $txn['id'] }} })"
+                                            class="flex w-full cursor-pointer items-center justify-between gap-1 rounded px-1 py-0.5 text-xs hover:ring-1 hover:ring-indigo-300 dark:hover:ring-indigo-600 {{ $txn['direction'] === 'debit' ? 'bg-red-50 dark:bg-red-950/30' : 'bg-green-50 dark:bg-green-950/30' }}"
+                                        >
                                             <span class="truncate {{ !$day['isCurrentMonth'] ? 'text-zinc-400 dark:text-zinc-600' : 'text-zinc-600 dark:text-zinc-400' }}">{{ $txn['category'] }}</span>
                                             <span class="shrink-0 tabular-nums font-medium {{ $txn['direction'] === 'debit' ? 'text-red-600 dark:text-red-400' : 'text-green-600 dark:text-green-400' }}">{{ $formatMoney($txn['amount']) }}</span>
-                                        </div>
+                                        </button>
                                     @endforeach
                                 </div>
                             @endif
@@ -70,16 +74,24 @@
             @else
                 <div class="divide-y divide-neutral-200 dark:divide-neutral-700">
                     @foreach($daysWithTransactions as $day)
-                        <div wire:key="mobile-{{ $day['fullDate'] }}" class="px-4 py-3">
+                        <div
+                            wire:key="mobile-{{ $day['fullDate'] }}"
+                            wire:click="$dispatch('open-transaction-modal', { date: '{{ $day['fullDate'] }}' })"
+                            class="cursor-pointer px-4 py-3"
+                        >
                             <div class="mb-2 text-sm font-medium {{ $day['isToday'] ? 'text-indigo-600 dark:text-indigo-400' : 'text-zinc-700 dark:text-zinc-300' }}">
                                 {{ CarbonImmutable::parse($day['fullDate'])->format('D j M') }}
                             </div>
                             <div class="space-y-1">
                                 @foreach($day['transactions'] as $txn)
-                                    <div class="flex items-center justify-between text-sm">
+                                    <button
+                                        type="button"
+                                        wire:click.stop="$dispatch('edit-transaction', { id: {{ $txn['id'] }} })"
+                                        class="flex w-full cursor-pointer items-center justify-between rounded-md px-2 py-1 text-left text-sm hover:bg-zinc-100 dark:hover:bg-zinc-800"
+                                    >
                                         <span class="truncate text-zinc-600 dark:text-zinc-400">{{ $txn['category'] }}</span>
                                         <span class="shrink-0 tabular-nums font-medium {{ $txn['direction'] === 'debit' ? 'text-red-600 dark:text-red-400' : 'text-green-600 dark:text-green-400' }}">{{ $formatMoney($txn['amount']) }}</span>
-                                    </div>
+                                    </button>
                                 @endforeach
                             </div>
                         </div>

--- a/tests/Feature/Livewire/CalendarViewTest.php
+++ b/tests/Feature/Livewire/CalendarViewTest.php
@@ -293,6 +293,50 @@ test('calendar refreshes after transaction-saved event', function () {
     expect($allAfter)->toHaveCount(1);
 });
 
+test('transaction data includes id and source fields', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+
+    $transaction = Transaction::factory()->for($user)->manual()->debit()->create([
+        'account_id' => $account->id,
+        'amount' => -3000,
+        'post_date' => now()->startOfMonth()->addDays(2),
+    ]);
+
+    $component = Livewire::actingAs($user)
+        ->test(CalendarView::class);
+
+    $data = $component->get('calendarData');
+    $txn = collect($data['weeks'])->flatten(1)
+        ->flatMap(fn (array $day) => $day['transactions'])
+        ->first();
+
+    expect($txn)
+        ->toHaveKey('id', $transaction->id)
+        ->toHaveKey('source', 'manual');
+});
+
+test('transaction data includes source for basiq transactions', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+
+    Transaction::factory()->for($user)->fromBasiq()->debit()->create([
+        'account_id' => $account->id,
+        'amount' => -5000,
+        'post_date' => now()->startOfMonth()->addDays(4),
+    ]);
+
+    $component = Livewire::actingAs($user)
+        ->test(CalendarView::class);
+
+    $data = $component->get('calendarData');
+    $txn = collect($data['weeks'])->flatten(1)
+        ->flatMap(fn (array $day) => $day['transactions'])
+        ->first();
+
+    expect($txn['source'])->toBe('basiq');
+});
+
 test('today is marked in current month', function () {
     $user = User::factory()->create();
 


### PR DESCRIPTION
## Summary
- Add `id` and `source` fields to calendar transaction data for future edit support
- Add `wire:click.stop` handlers on transaction items (desktop + mobile) to dispatch `edit-transaction` event
- Add `wire:click` on mobile day sections to dispatch `open-transaction-modal` with the correct date
- Add hover feedback styles on clickable transaction rows

## Changes
- **`app/Livewire/CalendarView.php`** — Include `id` and `source` in `calendarData()` transaction map; update PHPDoc return type
- **`resources/views/livewire/calendar-view.blade.php`** — Desktop: `wire:click.stop` on transaction rows; Mobile: day-cell click + transaction click handlers with hover styles
- **`tests/Feature/Livewire/CalendarViewTest.php`** — 2 new tests verifying `id`/`source` for manual and basiq transactions

## Test plan
- [x] `op test.filter CalendarViewTest` — 18 tests pass (40 assertions)
- [x] `op ci` — 686 tests pass, PHPStan clean, Pint clean
- [ ] Manual: clicking empty day cell opens modal with correct date (desktop + mobile)
- [ ] Manual: clicking transaction row dispatches `edit-transaction` without also opening modal
- [ ] Manual: mobile view has same interactive behaviors as desktop

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)