### PR TITLE
feat: [87] Implement edit mode in TransactionModal

### DIFF
--- a/app/Livewire/TransactionModal.php
+++ b/app/Livewire/TransactionModal.php
@@ -20,6 +20,10 @@ final class TransactionModal extends Component
 {
     public bool $showModal = false;
 
+    public ?int $editingTransactionId = null;
+
+    public bool $isBasiqTransaction = false;
+
     public string $transactionType = 'expense';
 
     public string $descriptionInput = '';
@@ -30,6 +34,10 @@ final class TransactionModal extends Component
 
     public string $date = '';
 
+    public string $notes = '';
+
+    public string $cleanDescription = '';
+
     #[On('open-transaction-modal')]
     public function openForAdd(string $date): void
     {
@@ -38,31 +46,55 @@ final class TransactionModal extends Component
         $this->showModal = true;
     }
 
+    #[On('edit-transaction')]
+    public function openForEdit(int $id): void
+    {
+        $transaction = Transaction::query()
+            ->where('user_id', auth()->id())
+            ->find($id);
+
+        if (! $transaction) {
+            return;
+        }
+
+        $this->resetForm();
+
+        $this->editingTransactionId = $transaction->id;
+        $this->isBasiqTransaction = $transaction->source === TransactionSource::Basiq;
+
+        $this->transactionType = $transaction->direction === TransactionDirection::Debit
+            ? 'expense'
+            : 'income';
+
+        $dollars = number_format($transaction->amount / 100, 2, '.', '');
+        $description = $transaction->description ?? '';
+        $this->descriptionInput = $description !== '' ? "{$dollars} {$description}" : $dollars;
+
+        if ($this->isBasiqTransaction) {
+            $this->cleanDescription = $transaction->clean_description ?? '';
+        }
+
+        $this->accountId = $transaction->account_id;
+        $this->categoryId = $transaction->category_id;
+        $this->date = $transaction->post_date->format('Y-m-d');
+        $this->notes = $transaction->notes ?? '';
+
+        $this->showModal = true;
+    }
+
     public function save(): void
     {
         $this->validate($this->formRules());
 
-        $parsed = AmountParser::parse($this->descriptionInput);
-
-        if ($parsed->amount <= 0) {
-            $this->addError('descriptionInput', __('The amount must be greater than zero.'));
-
-            return;
+        if ($this->editingTransactionId) {
+            $saved = $this->updateTransaction();
+        } else {
+            $saved = $this->createTransaction();
         }
 
-        Transaction::query()->create([
-            'user_id' => auth()->id(),
-            'account_id' => $this->accountId,
-            'category_id' => $this->categoryId,
-            'amount' => $parsed->amount,
-            'direction' => $this->transactionType === 'expense'
-                ? TransactionDirection::Debit
-                : TransactionDirection::Credit,
-            'description' => $parsed->description,
-            'post_date' => $this->date,
-            'status' => TransactionStatus::Posted,
-            'source' => TransactionSource::Manual,
-        ]);
+        if (! $saved) {
+            return;
+        }
 
         $this->showModal = false;
         $this->resetForm();
@@ -94,13 +126,88 @@ final class TransactionModal extends Component
         ]);
     }
 
+    private function createTransaction(): bool
+    {
+        $parsed = AmountParser::parse($this->descriptionInput);
+
+        if ($parsed->amount <= 0) {
+            $this->addError('descriptionInput', __('The amount must be greater than zero.'));
+
+            return false;
+        }
+
+        Transaction::query()->create([
+            'user_id' => auth()->id(),
+            'account_id' => $this->accountId,
+            'category_id' => $this->categoryId,
+            'amount' => $parsed->amount,
+            'direction' => $this->transactionType === 'expense'
+                ? TransactionDirection::Debit
+                : TransactionDirection::Credit,
+            'description' => $parsed->description,
+            'post_date' => $this->date,
+            'status' => TransactionStatus::Posted,
+            'source' => TransactionSource::Manual,
+            'notes' => $this->notes !== '' ? $this->notes : null,
+        ]);
+
+        return true;
+    }
+
+    private function updateTransaction(): bool
+    {
+        $transaction = Transaction::query()
+            ->where('user_id', auth()->id())
+            ->find($this->editingTransactionId);
+
+        if (! $transaction) {
+            return false;
+        }
+
+        if ($transaction->source === TransactionSource::Basiq) {
+            $transaction->update([
+                'category_id' => $this->categoryId,
+                'notes' => $this->notes !== '' ? $this->notes : null,
+                'clean_description' => $this->cleanDescription !== '' ? $this->cleanDescription : null,
+            ]);
+
+            return true;
+        }
+
+        $parsed = AmountParser::parse($this->descriptionInput);
+
+        if ($parsed->amount <= 0) {
+            $this->addError('descriptionInput', __('The amount must be greater than zero.'));
+
+            return false;
+        }
+
+        $transaction->update([
+            'account_id' => $this->accountId,
+            'category_id' => $this->categoryId,
+            'amount' => $parsed->amount,
+            'direction' => $this->transactionType === 'expense'
+                ? TransactionDirection::Debit
+                : TransactionDirection::Credit,
+            'description' => $parsed->description,
+            'post_date' => $this->date,
+            'notes' => $this->notes !== '' ? $this->notes : null,
+        ]);
+
+        return true;
+    }
+
     private function resetForm(): void
     {
+        $this->editingTransactionId = null;
+        $this->isBasiqTransaction = false;
         $this->transactionType = 'expense';
         $this->descriptionInput = '';
         $this->accountId = null;
         $this->categoryId = null;
         $this->date = '';
+        $this->notes = '';
+        $this->cleanDescription = '';
         $this->resetValidation();
     }
 
@@ -119,6 +226,8 @@ final class TransactionModal extends Component
                 Rule::exists('categories', 'id')->where('is_hidden', 0),
             ],
             'date' => ['required', 'date_format:Y-m-d'],
+            'notes' => ['nullable', 'string', 'max:1000'],
+            'cleanDescription' => ['nullable', 'string', 'max:255'],
         ];
     }
 }

--- a/resources/views/livewire/transaction-modal.blade.php
+++ b/resources/views/livewire/transaction-modal.blade.php
@@ -4,13 +4,24 @@
         <form wire:submit="save" class="space-y-6">
             <div class="flex items-center justify-between">
                 <flux:heading size="lg">
-                    {{ $transactionType === 'expense' ? __('Add Expense') : __('Add Income') }}
+                    @if($editingTransactionId)
+                        {{ $transactionType === 'expense' ? __('Edit Expense') : __('Edit Income') }}
+                    @else
+                        {{ $transactionType === 'expense' ? __('Add Expense') : __('Add Income') }}
+                    @endif
                 </flux:heading>
-                @if($date)
-                    <flux:badge color="zinc">
-                        {{ CarbonImmutable::parse($date)->format('D j M Y') }}
-                    </flux:badge>
-                @endif
+                <div class="flex items-center gap-2">
+                    @if($isBasiqTransaction)
+                        <flux:badge color="blue" size="sm" icon="cloud-arrow-down">
+                            {{ __('Synced from bank') }}
+                        </flux:badge>
+                    @endif
+                    @if($date)
+                        <flux:badge color="zinc">
+                            {{ CarbonImmutable::parse($date)->format('D j M Y') }}
+                        </flux:badge>
+                    @endif
+                </div>
             </div>
 
             <div class="flex gap-2">
@@ -19,6 +30,7 @@
                     wire:click="$set('transactionType', 'expense')"
                     type="button"
                     class="flex-1"
+                    :disabled="$isBasiqTransaction"
                 >
                     {{ __('Expense') }}
                 </flux:button>
@@ -27,6 +39,7 @@
                     wire:click="$set('transactionType', 'income')"
                     type="button"
                     class="flex-1"
+                    :disabled="$isBasiqTransaction"
                 >
                     {{ __('Income') }}
                 </flux:button>
@@ -37,7 +50,16 @@
                 :label="__('Amount with description')"
                 placeholder="4*15 zoo tickets (tip is ignored)"
                 required
+                :disabled="$isBasiqTransaction"
             />
+
+            @if($isBasiqTransaction)
+                <flux:input
+                    wire:model.blur="cleanDescription"
+                    :label="__('Clean description')"
+                    :placeholder="__('Your description for this transaction')"
+                />
+            @endif
 
             <div class="rounded-lg bg-zinc-50 px-4 py-3 dark:bg-zinc-800">
                 <flux:text size="sm" class="text-zinc-500">{{ __('Parsed amount') }}</flux:text>
@@ -46,7 +68,7 @@
                 </div>
             </div>
 
-            <flux:select wire:model="accountId" :label="__('Account')" required>
+            <flux:select wire:model="accountId" :label="__('Account')" required :disabled="$isBasiqTransaction">
                 <flux:select.option value="">{{ __('Select account') }}</flux:select.option>
                 @foreach($accounts as $account)
                     <flux:select.option value="{{ $account->id }}">
@@ -64,10 +86,29 @@
                 @endforeach
             </flux:select>
 
+            <flux:input
+                wire:model="date"
+                :label="__('Date')"
+                type="date"
+                required
+                :disabled="$isBasiqTransaction"
+            />
+
+            <flux:textarea
+                wire:model="notes"
+                :label="__('Notes')"
+                :placeholder="__('Optional notes')"
+                rows="2"
+            />
+
             <div class="flex">
                 <flux:spacer/>
                 <flux:button type="submit" variant="primary">
-                    {{ $transactionType === 'expense' ? __('Enter expense') : __('Enter income') }}
+                    @if($editingTransactionId)
+                        {{ $transactionType === 'expense' ? __('Update expense') : __('Update income') }}
+                    @else
+                        {{ $transactionType === 'expense' ? __('Enter expense') : __('Enter income') }}
+                    @endif
                 </flux:button>
             </div>
         </form>

--- a/tests/Feature/Livewire/TransactionModalTest.php
+++ b/tests/Feature/Livewire/TransactionModalTest.php
@@ -278,3 +278,198 @@ test('rejects hidden category via crafted request', function () {
         ->call('save')
         ->assertHasErrors(['categoryId']);
 });
+
+test('opens for edit with pre-filled data from manual transaction', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $category = Category::factory()->create(['is_hidden' => false]);
+    $transaction = Transaction::factory()->for($user)->for($account)->create([
+        'amount' => 4250,
+        'direction' => TransactionDirection::Debit,
+        'description' => 'coffee and cake',
+        'post_date' => '2026-03-15',
+        'category_id' => $category->id,
+        'source' => TransactionSource::Manual,
+        'notes' => 'Meeting with client',
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('edit-transaction', id: $transaction->id)
+        ->assertSet('showModal', true)
+        ->assertSet('editingTransactionId', $transaction->id)
+        ->assertSet('isBasiqTransaction', false)
+        ->assertSet('transactionType', 'expense')
+        ->assertSet('descriptionInput', '42.50 coffee and cake')
+        ->assertSet('accountId', $account->id)
+        ->assertSet('categoryId', $category->id)
+        ->assertSet('date', '2026-03-15')
+        ->assertSet('notes', 'Meeting with client');
+});
+
+test('cannot edit another user transaction', function () {
+    $user = User::factory()->create();
+    $otherUser = User::factory()->create();
+    $otherTransaction = Transaction::factory()->for($otherUser)->create();
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('edit-transaction', id: $otherTransaction->id)
+        ->assertSet('showModal', false)
+        ->assertSet('editingTransactionId', null);
+});
+
+test('basiq transaction sets read-only flag', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $transaction = Transaction::factory()->for($user)->for($account)->fromBasiq()->create();
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('edit-transaction', id: $transaction->id)
+        ->assertSet('isBasiqTransaction', true)
+        ->assertSet('editingTransactionId', $transaction->id);
+});
+
+test('basiq transaction allows updating category and notes', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $category = Category::factory()->create(['is_hidden' => false]);
+    $transaction = Transaction::factory()->for($user)->for($account)->fromBasiq()->create([
+        'category_id' => null,
+        'notes' => null,
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('edit-transaction', id: $transaction->id)
+        ->set('categoryId', $category->id)
+        ->set('notes', 'Groceries for the week')
+        ->set('cleanDescription', 'Woolworths groceries')
+        ->call('save')
+        ->assertSet('showModal', false)
+        ->assertDispatched('transaction-saved');
+
+    $transaction->refresh();
+    expect($transaction)
+        ->category_id->toBe($category->id)
+        ->notes->toBe('Groceries for the week')
+        ->clean_description->toBe('Woolworths groceries');
+});
+
+test('manual transaction allows updating all fields', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $newAccount = Account::factory()->for($user)->create();
+    $category = Category::factory()->create(['is_hidden' => false]);
+    $transaction = Transaction::factory()->for($user)->for($account)->manual()->create([
+        'amount' => 4250,
+        'direction' => TransactionDirection::Debit,
+        'description' => 'coffee',
+        'post_date' => '2026-03-15',
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('edit-transaction', id: $transaction->id)
+        ->set('descriptionInput', '99.99 fancy dinner')
+        ->set('transactionType', 'income')
+        ->set('accountId', $newAccount->id)
+        ->set('categoryId', $category->id)
+        ->set('date', '2026-03-20')
+        ->set('notes', 'Anniversary dinner')
+        ->call('save')
+        ->assertSet('showModal', false);
+
+    $transaction->refresh();
+    expect($transaction)
+        ->amount->toBe(9999)
+        ->direction->toBe(TransactionDirection::Credit)
+        ->description->toBe('fancy dinner')
+        ->account_id->toBe($newAccount->id)
+        ->category_id->toBe($category->id)
+        ->post_date->format('Y-m-d')->toBe('2026-03-20')
+        ->notes->toBe('Anniversary dinner');
+});
+
+test('updates existing transaction instead of creating new', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $transaction = Transaction::factory()->for($user)->for($account)->manual()->create([
+        'amount' => 1000,
+        'description' => 'original',
+    ]);
+
+    $originalCount = Transaction::query()->where('user_id', $user->id)->count();
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('edit-transaction', id: $transaction->id)
+        ->set('descriptionInput', '20.00 updated')
+        ->call('save');
+
+    expect(Transaction::query()->where('user_id', $user->id)->count())
+        ->toBe($originalCount)
+        ->and($transaction->fresh()->description)->toBe('updated');
+});
+
+test('dispatches transaction-saved event on update', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $transaction = Transaction::factory()->for($user)->for($account)->manual()->create([
+        'amount' => 1000,
+        'description' => 'test',
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('edit-transaction', id: $transaction->id)
+        ->set('descriptionInput', '10.00 test')
+        ->call('save')
+        ->assertDispatched('transaction-saved');
+});
+
+test('basiq transaction does not modify amount or account on save', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $transaction = Transaction::factory()->for($user)->for($account)->fromBasiq()->create([
+        'amount' => 5000,
+        'post_date' => '2026-03-10',
+    ]);
+
+    $originalAmount = $transaction->amount;
+    $originalDate = $transaction->post_date->format('Y-m-d');
+    $originalAccountId = $transaction->account_id;
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('edit-transaction', id: $transaction->id)
+        ->set('notes', 'Updated note')
+        ->call('save');
+
+    $transaction->refresh();
+    expect($transaction)
+        ->amount->toBe($originalAmount)
+        ->post_date->format('Y-m-d')->toBe($originalDate)
+        ->account_id->toBe($originalAccountId)
+        ->notes->toBe('Updated note');
+});
+
+test('resets form after edit save including edit-specific properties', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $transaction = Transaction::factory()->for($user)->for($account)->manual()->create([
+        'amount' => 1000,
+        'description' => 'test',
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('edit-transaction', id: $transaction->id)
+        ->set('descriptionInput', '10.00 test')
+        ->call('save')
+        ->assertSet('editingTransactionId', null)
+        ->assertSet('isBasiqTransaction', false)
+        ->assertSet('notes', '')
+        ->assertSet('cleanDescription', '');
+});


### PR DESCRIPTION
## Summary
- Add edit functionality to TransactionModal so users can click existing transactions on the calendar to modify them
- Basiq (bank-synced) transactions restrict editing to category, notes, and clean description — amount, date, account, and direction remain read-only
- Manual transactions are fully editable with all fields updatable

## Changes
- **`TransactionModal.php`** — Added `openForEdit()` method listening to `edit-transaction` event, refactored `save()` into `createTransaction()`/`updateTransaction()` paths, added properties for edit state (`editingTransactionId`, `isBasiqTransaction`, `notes`, `cleanDescription`)
- **`transaction-modal.blade.php`** — Conditional Edit/Add headings, "Synced from bank" badge, disabled fields for Basiq transactions, new date input, notes textarea, clean description input, Update/Enter submit labels
- **`TransactionModalTest.php`** — 9 new tests covering edit pre-fill, authorization, Basiq restrictions, manual full edit, update-not-create, event dispatch, and form reset

## Test plan
- [x] All 27 TransactionModal tests pass (17 existing + 9 new)
- [x] PHPStan passes with no errors
- [x] Pint formatting clean
- [x] Full `op ci` passes (695 tests, 0 failures)
- [ ] Manual: click transaction on calendar → edit modal opens with pre-filled data
- [ ] Manual: Basiq transaction shows locked fields + "Synced from bank" badge
- [ ] Manual: Manual transaction allows editing all fields

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)