### PR TITLE
feat: [88] Implement transfer transaction type in modal

### DIFF
--- a/app/Livewire/CalendarView.php
+++ b/app/Livewire/CalendarView.php
@@ -47,7 +47,7 @@ final class CalendarView extends Component
         unset($this->calendarData); // @phpstan-ignore property.notFound
     }
 
-    /** @return array{monthLabel: string, weeks: list<list<array{date: int, fullDate: string, isCurrentMonth: bool, isToday: bool, transactions: list<array{id: int, category: string, amount: int, direction: string, source: string}>}>>, isCurrentMonth: bool} */
+    /** @return array{monthLabel: string, weeks: list<list<array{date: int, fullDate: string, isCurrentMonth: bool, isToday: bool, transactions: list<array{id: int, category: string, amount: int, direction: string, source: string, isTransfer: bool}>}>>, isCurrentMonth: bool} */
     #[Computed(persist: true)]
     public function calendarData(): array
     {
@@ -87,6 +87,7 @@ final class CalendarView extends Component
                         'amount' => $t->amount,
                         'direction' => $t->direction->value,
                         'source' => $t->source->value,
+                        'isTransfer' => $t->transfer_pair_id !== null,
                     ])->values()->all(),
                 ];
 

--- a/app/Livewire/TransactionModal.php
+++ b/app/Livewire/TransactionModal.php
@@ -11,10 +11,12 @@ use App\Enums\TransactionStatus;
 use App\Models\Category;
 use App\Models\Transaction;
 use App\Support\AmountParser;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\Rule;
 use Illuminate\View\View;
 use Livewire\Attributes\On;
 use Livewire\Component;
+use Throwable;
 
 final class TransactionModal extends Component
 {
@@ -38,6 +40,8 @@ final class TransactionModal extends Component
 
     public string $cleanDescription = '';
 
+    public ?int $transferToAccountId = null;
+
     #[On('open-transaction-modal')]
     public function openForAdd(string $date): void
     {
@@ -57,14 +61,42 @@ final class TransactionModal extends Component
             return;
         }
 
+        if ($transaction->transfer_pair_id && $transaction->direction === TransactionDirection::Credit) {
+            $debitSide = Transaction::query()
+                ->where('user_id', auth()->id())
+                ->find($transaction->transfer_pair_id);
+
+            if ($debitSide) {
+                $transaction = $debitSide;
+            }
+        }
+
         $this->resetForm();
 
         $this->editingTransactionId = $transaction->id;
         $this->isBasiqTransaction = $transaction->source === TransactionSource::Basiq;
 
-        $this->transactionType = $transaction->direction === TransactionDirection::Debit
-            ? 'expense'
-            : 'income';
+        if ($transaction->transfer_pair_id) {
+            $this->transactionType = 'transfer';
+
+            $pair = Transaction::query()
+                ->where('user_id', auth()->id())
+                ->find($transaction->transfer_pair_id);
+
+            if ($pair) {
+                $debitSide = $transaction->direction === TransactionDirection::Debit ? $transaction : $pair;
+                $creditSide = $transaction->direction === TransactionDirection::Credit ? $transaction : $pair;
+
+                $this->accountId = $debitSide->account_id;
+                $this->transferToAccountId = $creditSide->account_id;
+            }
+        } else {
+            $this->transactionType = $transaction->direction === TransactionDirection::Debit
+                ? 'expense'
+                : 'income';
+
+            $this->accountId = $transaction->account_id;
+        }
 
         $dollars = number_format($transaction->amount / 100, 2, '.', '');
         $description = $transaction->description ?? '';
@@ -74,7 +106,6 @@ final class TransactionModal extends Component
             $this->cleanDescription = $transaction->clean_description ?? '';
         }
 
-        $this->accountId = $transaction->account_id;
         $this->categoryId = $transaction->category_id;
         $this->date = $transaction->post_date->format('Y-m-d');
         $this->notes = $transaction->notes ?? '';
@@ -82,19 +113,59 @@ final class TransactionModal extends Component
         $this->showModal = true;
     }
 
+    /**
+     * @throws Throwable
+     */
     public function save(): void
     {
         $this->validate($this->formRules());
 
         if ($this->editingTransactionId) {
-            $saved = $this->updateTransaction();
+            $saved = $this->isTransfer()
+                ? $this->updateTransfer()
+                : $this->updateTransaction();
         } else {
-            $saved = $this->createTransaction();
+            $saved = $this->transactionType === 'transfer'
+                ? $this->createTransfer()
+                : $this->createTransaction();
         }
 
         if (! $saved) {
             return;
         }
+
+        $this->showModal = false;
+        $this->resetForm();
+        $this->dispatch('transaction-saved');
+    }
+
+    /**
+     * @throws Throwable
+     */
+    public function deleteTransaction(): void
+    {
+        $transaction = Transaction::query()
+            ->where('user_id', auth()->id())
+            ->find($this->editingTransactionId);
+
+        if (! $transaction) {
+            return;
+        }
+
+        if ($transaction->source === TransactionSource::Basiq) {
+            return;
+        }
+
+        DB::transaction(static function () use ($transaction): void {
+            if ($transaction->transfer_pair_id) {
+                Transaction::query()
+                    ->where('id', $transaction->transfer_pair_id)
+                    ->where('user_id', auth()->id())
+                    ->delete();
+            }
+
+            $transaction->delete();
+        });
 
         $this->showModal = false;
         $this->resetForm();
@@ -154,6 +225,48 @@ final class TransactionModal extends Component
         return true;
     }
 
+    /**
+     * @throws Throwable
+     */
+    private function createTransfer(): bool
+    {
+        $parsed = AmountParser::parse($this->descriptionInput);
+
+        if ($parsed->amount <= 0) {
+            $this->addError('descriptionInput', __('The amount must be greater than zero.'));
+
+            return false;
+        }
+
+        DB::transaction(function () use ($parsed): void {
+            $shared = [
+                'user_id' => auth()->id(),
+                'category_id' => $this->categoryId,
+                'amount' => $parsed->amount,
+                'description' => $parsed->description,
+                'post_date' => $this->date,
+                'status' => TransactionStatus::Posted,
+                'source' => TransactionSource::Manual,
+                'notes' => $this->notes !== '' ? $this->notes : null,
+            ];
+
+            $debit = Transaction::query()->create($shared + [
+                'account_id' => $this->accountId,
+                'direction' => TransactionDirection::Debit,
+            ]);
+
+            $credit = Transaction::query()->create($shared + [
+                'account_id' => $this->transferToAccountId,
+                'direction' => TransactionDirection::Credit,
+            ]);
+
+            $debit->update(['transfer_pair_id' => $credit->id]);
+            $credit->update(['transfer_pair_id' => $debit->id]);
+        });
+
+        return true;
+    }
+
     private function updateTransaction(): bool
     {
         $transaction = Transaction::query()
@@ -197,6 +310,67 @@ final class TransactionModal extends Component
         return true;
     }
 
+    /**
+     * @throws Throwable
+     */
+    private function updateTransfer(): bool
+    {
+        $transaction = Transaction::query()
+            ->where('user_id', auth()->id())
+            ->find($this->editingTransactionId);
+
+        if (! $transaction || ! $transaction->transfer_pair_id) {
+            return false;
+        }
+
+        $pair = Transaction::query()
+            ->where('user_id', auth()->id())
+            ->find($transaction->transfer_pair_id);
+
+        if (! $pair) {
+            return false;
+        }
+
+        $parsed = AmountParser::parse($this->descriptionInput);
+
+        if ($parsed->amount <= 0) {
+            $this->addError('descriptionInput', __('The amount must be greater than zero.'));
+
+            return false;
+        }
+
+        DB::transaction(function () use ($transaction, $pair, $parsed): void {
+            $shared = [
+                'category_id' => $this->categoryId,
+                'amount' => $parsed->amount,
+                'description' => $parsed->description,
+                'post_date' => $this->date,
+                'notes' => $this->notes !== '' ? $this->notes : null,
+            ];
+
+            $debitSide = $transaction->direction === TransactionDirection::Debit ? $transaction : $pair;
+            $creditSide = $transaction->direction === TransactionDirection::Credit ? $transaction : $pair;
+
+            $debitSide->update($shared + ['account_id' => $this->accountId]);
+            $creditSide->update($shared + ['account_id' => $this->transferToAccountId]);
+        });
+
+        return true;
+    }
+
+    private function isTransfer(): bool
+    {
+        if (! $this->editingTransactionId) {
+            return $this->transactionType === 'transfer';
+        }
+
+        return Transaction::query()
+            ->where('id', $this->editingTransactionId)
+            ->where('user_id', auth()->id())
+            ->whereNotNull('transfer_pair_id')
+            ->exists();
+    }
+
     private function resetForm(): void
     {
         $this->editingTransactionId = null;
@@ -208,6 +382,7 @@ final class TransactionModal extends Component
         $this->date = '';
         $this->notes = '';
         $this->cleanDescription = '';
+        $this->transferToAccountId = null;
         $this->resetValidation();
     }
 
@@ -215,7 +390,7 @@ final class TransactionModal extends Component
     private function formRules(): array
     {
         return [
-            'transactionType' => ['required', Rule::in(['expense', 'income'])],
+            'transactionType' => ['required', Rule::in(['expense', 'income', 'transfer'])],
             'descriptionInput' => ['required', 'string', 'max:255'],
             'accountId' => [
                 'required',
@@ -228,6 +403,13 @@ final class TransactionModal extends Component
             'date' => ['required', 'date_format:Y-m-d'],
             'notes' => ['nullable', 'string', 'max:1000'],
             'cleanDescription' => ['nullable', 'string', 'max:255'],
+            'transferToAccountId' => $this->isTransfer()
+                ? [
+                    'required',
+                    Rule::exists('accounts', 'id')->where('user_id', auth()->id()),
+                    Rule::notIn([$this->accountId]),
+                ]
+                : ['nullable'],
         ];
     }
 }

--- a/resources/views/livewire/calendar-view.blade.php
+++ b/resources/views/livewire/calendar-view.blade.php
@@ -41,13 +41,25 @@
                             @if(count($day['transactions']) > 0)
                                 <div class="max-h-24 space-y-0.5 overflow-y-auto">
                                     @foreach($day['transactions'] as $txn)
+                                        @php
+                                            $bgColor = match(true) {
+                                                ($txn['isTransfer'] ?? false) => 'bg-blue-50 dark:bg-blue-950/30',
+                                                $txn['direction'] === 'debit' => 'bg-red-50 dark:bg-red-950/30',
+                                                default => 'bg-green-50 dark:bg-green-950/30',
+                                            };
+                                            $amountColor = match(true) {
+                                                ($txn['isTransfer'] ?? false) => 'text-blue-600 dark:text-blue-400',
+                                                $txn['direction'] === 'debit' => 'text-red-600 dark:text-red-400',
+                                                default => 'text-green-600 dark:text-green-400',
+                                            };
+                                        @endphp
                                         <button
                                             type="button"
                                             wire:click.stop="$dispatch('edit-transaction', { id: {{ $txn['id'] }} })"
-                                            class="flex w-full cursor-pointer items-center justify-between gap-1 rounded px-1 py-0.5 text-xs hover:ring-1 hover:ring-indigo-300 dark:hover:ring-indigo-600 {{ $txn['direction'] === 'debit' ? 'bg-red-50 dark:bg-red-950/30' : 'bg-green-50 dark:bg-green-950/30' }}"
+                                            class="flex w-full cursor-pointer items-center justify-between gap-1 rounded px-1 py-0.5 text-xs hover:ring-1 hover:ring-indigo-300 dark:hover:ring-indigo-600 {{ $bgColor }}"
                                         >
                                             <span class="truncate {{ !$day['isCurrentMonth'] ? 'text-zinc-400 dark:text-zinc-600' : 'text-zinc-600 dark:text-zinc-400' }}">{{ $txn['category'] }}</span>
-                                            <span class="shrink-0 tabular-nums font-medium {{ $txn['direction'] === 'debit' ? 'text-red-600 dark:text-red-400' : 'text-green-600 dark:text-green-400' }}">{{ $formatMoney($txn['amount']) }}</span>
+                                            <span class="shrink-0 tabular-nums font-medium {{ $amountColor }}">{{ $formatMoney($txn['amount']) }}</span>
                                         </button>
                                     @endforeach
                                 </div>
@@ -84,13 +96,20 @@
                             </div>
                             <div class="space-y-1">
                                 @foreach($day['transactions'] as $txn)
+                                    @php
+                                        $amountColor = match(true) {
+                                            ($txn['isTransfer'] ?? false) => 'text-blue-600 dark:text-blue-400',
+                                            $txn['direction'] === 'debit' => 'text-red-600 dark:text-red-400',
+                                            default => 'text-green-600 dark:text-green-400',
+                                        };
+                                    @endphp
                                     <button
                                         type="button"
                                         wire:click.stop="$dispatch('edit-transaction', { id: {{ $txn['id'] }} })"
                                         class="flex w-full cursor-pointer items-center justify-between rounded-md px-2 py-1 text-left text-sm hover:bg-zinc-100 dark:hover:bg-zinc-800"
                                     >
                                         <span class="truncate text-zinc-600 dark:text-zinc-400">{{ $txn['category'] }}</span>
-                                        <span class="shrink-0 tabular-nums font-medium {{ $txn['direction'] === 'debit' ? 'text-red-600 dark:text-red-400' : 'text-green-600 dark:text-green-400' }}">{{ $formatMoney($txn['amount']) }}</span>
+                                        <span class="shrink-0 tabular-nums font-medium {{ $amountColor }}">{{ $formatMoney($txn['amount']) }}</span>
                                     </button>
                                 @endforeach
                             </div>

--- a/resources/views/livewire/transaction-modal.blade.php
+++ b/resources/views/livewire/transaction-modal.blade.php
@@ -5,9 +5,21 @@
             <div class="flex items-center justify-between">
                 <flux:heading size="lg">
                     @if($editingTransactionId)
-                        {{ $transactionType === 'expense' ? __('Edit Expense') : __('Edit Income') }}
+                        @if($transactionType === 'transfer')
+                            {{ __('Edit Transfer') }}
+                        @elseif($transactionType === 'expense')
+                            {{ __('Edit Expense') }}
+                        @else
+                            {{ __('Edit Income') }}
+                        @endif
                     @else
-                        {{ $transactionType === 'expense' ? __('Add Expense') : __('Add Income') }}
+                        @if($transactionType === 'transfer')
+                            {{ __('Add Transfer') }}
+                        @elseif($transactionType === 'expense')
+                            {{ __('Add Expense') }}
+                        @else
+                            {{ __('Add Income') }}
+                        @endif
                     @endif
                 </flux:heading>
                 <div class="flex items-center gap-2">
@@ -43,6 +55,15 @@
                 >
                     {{ __('Income') }}
                 </flux:button>
+                <flux:button
+                    variant="{{ $transactionType === 'transfer' ? 'primary' : 'ghost' }}"
+                    wire:click="$set('transactionType', 'transfer')"
+                    type="button"
+                    class="flex-1"
+                    :disabled="$isBasiqTransaction"
+                >
+                    {{ __('Transfer') }}
+                </flux:button>
             </div>
 
             <flux:input
@@ -68,7 +89,12 @@
                 </div>
             </div>
 
-            <flux:select wire:model="accountId" :label="__('Account')" required :disabled="$isBasiqTransaction">
+            <flux:select
+                wire:model="accountId"
+                :label="$transactionType === 'transfer' ? __('From account') : __('Account')"
+                required
+                :disabled="$isBasiqTransaction"
+            >
                 <flux:select.option value="">{{ __('Select account') }}</flux:select.option>
                 @foreach($accounts as $account)
                     <flux:select.option value="{{ $account->id }}">
@@ -76,6 +102,17 @@
                     </flux:select.option>
                 @endforeach
             </flux:select>
+
+            @if($transactionType === 'transfer')
+                <flux:select wire:model="transferToAccountId" :label="__('To account')" required>
+                    <flux:select.option value="">{{ __('Select account') }}</flux:select.option>
+                    @foreach($accounts as $account)
+                        <flux:select.option value="{{ $account->id }}">
+                            {{ $account->name }} ({{ $formatMoney($account->balance) }})
+                        </flux:select.option>
+                    @endforeach
+                </flux:select>
+            @endif
 
             <flux:select wire:model="categoryId" :label="__('Category')">
                 <flux:select.option value="">{{ __('No category') }}</flux:select.option>
@@ -102,12 +139,34 @@
             />
 
             <div class="flex">
+                @if($editingTransactionId && !$isBasiqTransaction)
+                    <flux:button
+                        variant="danger"
+                        wire:click="deleteTransaction"
+                        wire:confirm="{{ __('Are you sure you want to delete this transaction?') }}"
+                        type="button"
+                    >
+                        {{ __('Delete') }}
+                    </flux:button>
+                @endif
                 <flux:spacer/>
                 <flux:button type="submit" variant="primary">
                     @if($editingTransactionId)
-                        {{ $transactionType === 'expense' ? __('Update expense') : __('Update income') }}
+                        @if($transactionType === 'transfer')
+                            {{ __('Update transfer') }}
+                        @elseif($transactionType === 'expense')
+                            {{ __('Update expense') }}
+                        @else
+                            {{ __('Update income') }}
+                        @endif
                     @else
-                        {{ $transactionType === 'expense' ? __('Enter expense') : __('Enter income') }}
+                        @if($transactionType === 'transfer')
+                            {{ __('Enter transfer') }}
+                        @elseif($transactionType === 'expense')
+                            {{ __('Enter expense') }}
+                        @else
+                            {{ __('Enter income') }}
+                        @endif
                     @endif
                 </flux:button>
             </div>

--- a/tests/Feature/Livewire/CalendarViewTest.php
+++ b/tests/Feature/Livewire/CalendarViewTest.php
@@ -337,6 +337,57 @@ test('transaction data includes source for basiq transactions', function () {
     expect($txn['source'])->toBe('basiq');
 });
 
+test('transaction data includes isTransfer flag for transfer transactions', function () {
+    $user = User::factory()->create();
+    $fromAccount = Account::factory()->for($user)->create();
+    $toAccount = Account::factory()->for($user)->create();
+
+    $debit = Transaction::factory()->for($user)->create([
+        'account_id' => $fromAccount->id,
+        'direction' => App\Enums\TransactionDirection::Debit,
+        'post_date' => now()->startOfMonth()->addDays(3),
+    ]);
+
+    $credit = Transaction::factory()->for($user)->create([
+        'account_id' => $toAccount->id,
+        'direction' => App\Enums\TransactionDirection::Credit,
+        'post_date' => now()->startOfMonth()->addDays(3),
+        'transfer_pair_id' => $debit->id,
+    ]);
+
+    $debit->update(['transfer_pair_id' => $credit->id]);
+
+    $component = Livewire::actingAs($user)
+        ->test(CalendarView::class);
+
+    $data = $component->get('calendarData');
+    $txns = collect($data['weeks'])->flatten(1)
+        ->flatMap(fn (array $day) => $day['transactions']);
+
+    $transferTxn = $txns->firstWhere('id', $debit->id);
+    expect($transferTxn['isTransfer'])->toBeTrue();
+});
+
+test('non-transfer transaction has isTransfer false', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+
+    Transaction::factory()->for($user)->manual()->create([
+        'account_id' => $account->id,
+        'post_date' => now()->startOfMonth()->addDays(3),
+    ]);
+
+    $component = Livewire::actingAs($user)
+        ->test(CalendarView::class);
+
+    $data = $component->get('calendarData');
+    $txn = collect($data['weeks'])->flatten(1)
+        ->flatMap(fn (array $day) => $day['transactions'])
+        ->first();
+
+    expect($txn['isTransfer'])->toBeFalse();
+});
+
 test('today is marked in current month', function () {
     $user = User::factory()->create();
 

--- a/tests/Feature/Livewire/TransactionModalTest.php
+++ b/tests/Feature/Livewire/TransactionModalTest.php
@@ -229,7 +229,7 @@ test('rejects invalid transaction type', function () {
     Livewire::actingAs($user)
         ->test(TransactionModal::class)
         ->dispatch('open-transaction-modal', date: '2026-03-15')
-        ->set('transactionType', 'transfer')
+        ->set('transactionType', 'refund')
         ->set('descriptionInput', '10 lunch')
         ->set('accountId', $account->id)
         ->call('save')
@@ -472,4 +472,258 @@ test('resets form after edit save including edit-specific properties', function 
         ->assertSet('isBasiqTransaction', false)
         ->assertSet('notes', '')
         ->assertSet('cleanDescription', '');
+});
+
+test('transfer creates two linked transactions', function () {
+    $user = User::factory()->create();
+    $fromAccount = Account::factory()->for($user)->create(['name' => 'Checking']);
+    $toAccount = Account::factory()->for($user)->create(['name' => 'Savings']);
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('open-transaction-modal', date: '2026-03-15')
+        ->set('transactionType', 'transfer')
+        ->set('descriptionInput', '500 monthly savings')
+        ->set('accountId', $fromAccount->id)
+        ->set('transferToAccountId', $toAccount->id)
+        ->call('save')
+        ->assertSet('showModal', false)
+        ->assertDispatched('transaction-saved');
+
+    $transactions = Transaction::query()->where('user_id', $user->id)->get();
+    expect($transactions)->toHaveCount(2);
+
+    $debit = $transactions->firstWhere('direction', TransactionDirection::Debit);
+    $credit = $transactions->firstWhere('direction', TransactionDirection::Credit);
+
+    expect($debit)
+        ->account_id->toBe($fromAccount->id)
+        ->amount->toBe(50000)
+        ->description->toBe('monthly savings')
+        ->transfer_pair_id
+        ->toBe($credit->id)
+        ->and($credit)
+        ->account_id->toBe($toAccount->id)
+        ->amount->toBe(50000)
+        ->description->toBe('monthly savings')
+        ->transfer_pair_id->toBe($debit->id);
+});
+
+test('transfer debit and credit have correct directions', function () {
+    $user = User::factory()->create();
+    $fromAccount = Account::factory()->for($user)->create();
+    $toAccount = Account::factory()->for($user)->create();
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('open-transaction-modal', date: '2026-03-15')
+        ->set('transactionType', 'transfer')
+        ->set('descriptionInput', '100 transfer')
+        ->set('accountId', $fromAccount->id)
+        ->set('transferToAccountId', $toAccount->id)
+        ->call('save');
+
+    $debit = Transaction::query()
+        ->where('user_id', $user->id)
+        ->where('account_id', $fromAccount->id)
+        ->first();
+
+    $credit = Transaction::query()
+        ->where('user_id', $user->id)
+        ->where('account_id', $toAccount->id)
+        ->first();
+
+    expect($debit->direction)
+        ->toBe(TransactionDirection::Debit)
+        ->and($credit->direction)->toBe(TransactionDirection::Credit);
+});
+
+test('cannot transfer to same account', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('open-transaction-modal', date: '2026-03-15')
+        ->set('transactionType', 'transfer')
+        ->set('descriptionInput', '100 self transfer')
+        ->set('accountId', $account->id)
+        ->set('transferToAccountId', $account->id)
+        ->call('save')
+        ->assertHasErrors(['transferToAccountId']);
+
+    expect(Transaction::query()->where('user_id', $user->id)->count())->toBe(0);
+});
+
+test('edit transfer opens with pre-filled data for both sides', function () {
+    $user = User::factory()->create();
+    $fromAccount = Account::factory()->for($user)->create();
+    $toAccount = Account::factory()->for($user)->create();
+
+    $debit = Transaction::factory()->for($user)->create([
+        'account_id' => $fromAccount->id,
+        'amount' => 10000,
+        'direction' => TransactionDirection::Debit,
+        'description' => 'savings transfer',
+        'post_date' => '2026-03-15',
+        'source' => TransactionSource::Manual,
+    ]);
+
+    $credit = Transaction::factory()->for($user)->create([
+        'account_id' => $toAccount->id,
+        'amount' => 10000,
+        'direction' => TransactionDirection::Credit,
+        'description' => 'savings transfer',
+        'post_date' => '2026-03-15',
+        'source' => TransactionSource::Manual,
+        'transfer_pair_id' => $debit->id,
+    ]);
+
+    $debit->update(['transfer_pair_id' => $credit->id]);
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('edit-transaction', id: $debit->id)
+        ->assertSet('showModal', true)
+        ->assertSet('transactionType', 'transfer')
+        ->assertSet('accountId', $fromAccount->id)
+        ->assertSet('transferToAccountId', $toAccount->id)
+        ->assertSet('descriptionInput', '100.00 savings transfer');
+});
+
+test('edit transfer updates both sides', function () {
+    $user = User::factory()->create();
+    $fromAccount = Account::factory()->for($user)->create();
+    $toAccount = Account::factory()->for($user)->create();
+
+    $debit = Transaction::factory()->for($user)->create([
+        'account_id' => $fromAccount->id,
+        'amount' => 10000,
+        'direction' => TransactionDirection::Debit,
+        'description' => 'original',
+        'post_date' => '2026-03-15',
+        'source' => TransactionSource::Manual,
+    ]);
+
+    $credit = Transaction::factory()->for($user)->create([
+        'account_id' => $toAccount->id,
+        'amount' => 10000,
+        'direction' => TransactionDirection::Credit,
+        'description' => 'original',
+        'post_date' => '2026-03-15',
+        'source' => TransactionSource::Manual,
+        'transfer_pair_id' => $debit->id,
+    ]);
+
+    $debit->update(['transfer_pair_id' => $credit->id]);
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('edit-transaction', id: $debit->id)
+        ->set('descriptionInput', '200 updated transfer')
+        ->call('save')
+        ->assertSet('showModal', false);
+
+    $debit->refresh();
+    $credit->refresh();
+
+    expect($debit)
+        ->amount->toBe(20000)
+        ->description
+        ->toBe('updated transfer')
+        ->and($credit)
+        ->amount->toBe(20000)
+        ->description->toBe('updated transfer');
+});
+
+test('delete transfer removes both sides', function () {
+    $user = User::factory()->create();
+    $fromAccount = Account::factory()->for($user)->create();
+    $toAccount = Account::factory()->for($user)->create();
+
+    $debit = Transaction::factory()->for($user)->create([
+        'account_id' => $fromAccount->id,
+        'amount' => 10000,
+        'direction' => TransactionDirection::Debit,
+        'source' => TransactionSource::Manual,
+    ]);
+
+    $credit = Transaction::factory()->for($user)->create([
+        'account_id' => $toAccount->id,
+        'amount' => 10000,
+        'direction' => TransactionDirection::Credit,
+        'source' => TransactionSource::Manual,
+        'transfer_pair_id' => $debit->id,
+    ]);
+
+    $debit->update(['transfer_pair_id' => $credit->id]);
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('edit-transaction', id: $debit->id)
+        ->call('deleteTransaction')
+        ->assertSet('showModal', false)
+        ->assertDispatched('transaction-saved');
+
+    expect(Transaction::query()->where('user_id', $user->id)->count())->toBe(0);
+});
+
+test('delete non-transfer removes single transaction', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $transaction = Transaction::factory()->for($user)->for($account)->manual()->create();
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('edit-transaction', id: $transaction->id)
+        ->call('deleteTransaction')
+        ->assertSet('showModal', false);
+
+    expect(Transaction::query()->where('id', $transaction->id)->exists())->toBeFalse();
+});
+
+test('cannot delete basiq transaction', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $transaction = Transaction::factory()->for($user)->for($account)->fromBasiq()->create();
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('edit-transaction', id: $transaction->id)
+        ->call('deleteTransaction');
+
+    expect(Transaction::query()->where('id', $transaction->id)->exists())->toBeTrue();
+});
+
+test('clicking credit side of transfer opens debit side for editing', function () {
+    $user = User::factory()->create();
+    $fromAccount = Account::factory()->for($user)->create();
+    $toAccount = Account::factory()->for($user)->create();
+
+    $debit = Transaction::factory()->for($user)->create([
+        'account_id' => $fromAccount->id,
+        'amount' => 5000,
+        'direction' => TransactionDirection::Debit,
+        'description' => 'transfer test',
+        'source' => TransactionSource::Manual,
+    ]);
+
+    $credit = Transaction::factory()->for($user)->create([
+        'account_id' => $toAccount->id,
+        'amount' => 5000,
+        'direction' => TransactionDirection::Credit,
+        'description' => 'transfer test',
+        'source' => TransactionSource::Manual,
+        'transfer_pair_id' => $debit->id,
+    ]);
+
+    $debit->update(['transfer_pair_id' => $credit->id]);
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('edit-transaction', id: $credit->id)
+        ->assertSet('editingTransactionId', $debit->id)
+        ->assertSet('transactionType', 'transfer')
+        ->assertSet('accountId', $fromAccount->id)
+        ->assertSet('transferToAccountId', $toAccount->id);
 });


### PR DESCRIPTION
## Summary
- Add "Transfer" as a third transaction type alongside Expense and Income, using double-entry bookkeeping (debit on source account, credit on destination, linked via `transfer_pair_id`)
- Add delete functionality for transactions — transfers delete both sides atomically, Basiq transactions are protected
- Add distinct blue styling for transfer transactions in the calendar view (desktop + mobile)

## Changes
- **`TransactionModal.php`** — `createTransfer()`, `updateTransfer()`, `deleteTransaction()`, `isTransfer()` helper, updated `openForEdit()` for transfer pair detection (normalizes to debit side), conditional validation for `transferToAccountId` with same-account prevention
- **`transaction-modal.blade.php`** — Transfer tab, "From account"/"To account" labels, conditional "To account" dropdown, delete button with `wire:confirm`, transfer-aware headings and submit labels
- **`CalendarView.php`** — Added `isTransfer` boolean to transaction data map
- **`calendar-view.blade.php`** — Blue styling for transfers using `match(true)` (refactored from nested ternaries), both desktop and mobile views
- **`TransactionModalTest.php`** — 10 new tests for transfer create/edit/delete, 1 existing test updated
- **`CalendarViewTest.php`** — 2 new tests for `isTransfer` flag

## Test plan
- [x] All 36 TransactionModal tests pass (27 existing + 10 new - 1 updated)
- [x] All 20 CalendarView tests pass (18 existing + 2 new)
- [x] PHPStan passes with no errors
- [x] Pint formatting clean
- [x] Full `op ci` passes (706 tests, 0 failures)
- [ ] Manual: create transfer between two accounts → two linked transactions on calendar with blue styling
- [ ] Manual: edit transfer → both sides update atomically
- [ ] Manual: delete transfer → both sides removed
- [ ] Manual: cannot transfer to same account (validation error)

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)