### PR TITLE
feat: [89] Implement Plan mode toggle in TransactionModal

### DIFF
--- a/app/Livewire/TransactionModal.php
+++ b/app/Livewire/TransactionModal.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 namespace App\Livewire;
 
 use App\Casts\MoneyCast;
+use App\Enums\RecurrenceFrequency;
 use App\Enums\TransactionDirection;
 use App\Enums\TransactionSource;
 use App\Enums\TransactionStatus;
 use App\Models\Category;
+use App\Models\PlannedTransaction;
 use App\Models\Transaction;
 use App\Support\AmountParser;
 use Illuminate\Support\Facades\DB;
@@ -41,6 +43,14 @@ final class TransactionModal extends Component
     public string $cleanDescription = '';
 
     public ?int $transferToAccountId = null;
+
+    public string $mode = 'enter';
+
+    public string $frequency = 'every-month';
+
+    public string $untilType = 'always';
+
+    public ?string $untilDate = null;
 
     #[On('open-transaction-modal')]
     public function openForAdd(string $date): void
@@ -120,7 +130,9 @@ final class TransactionModal extends Component
     {
         $this->validate($this->formRules());
 
-        if ($this->editingTransactionId) {
+        if ($this->mode === 'plan') {
+            $saved = $this->createPlannedTransaction();
+        } elseif ($this->editingTransactionId) {
             $saved = $this->isTransfer()
                 ? $this->updateTransfer()
                 : $this->updateTransaction();
@@ -267,6 +279,34 @@ final class TransactionModal extends Component
         return true;
     }
 
+    private function createPlannedTransaction(): bool
+    {
+        $parsed = AmountParser::parse($this->descriptionInput);
+
+        if ($parsed->amount <= 0) {
+            $this->addError('descriptionInput', __('The amount must be greater than zero.'));
+
+            return false;
+        }
+
+        PlannedTransaction::query()->create([
+            'user_id' => auth()->id(),
+            'account_id' => $this->accountId,
+            'category_id' => $this->categoryId,
+            'amount' => $parsed->amount,
+            'direction' => $this->transactionType === 'expense'
+                ? TransactionDirection::Debit
+                : TransactionDirection::Credit,
+            'description' => $parsed->description,
+            'start_date' => $this->date,
+            'frequency' => RecurrenceFrequency::from($this->frequency),
+            'until_date' => $this->untilType === 'until-date' ? $this->untilDate : null,
+            'is_active' => true,
+        ]);
+
+        return true;
+    }
+
     private function updateTransaction(): bool
     {
         $transaction = Transaction::query()
@@ -383,13 +423,18 @@ final class TransactionModal extends Component
         $this->notes = '';
         $this->cleanDescription = '';
         $this->transferToAccountId = null;
+        $this->mode = 'enter';
+        $this->frequency = 'every-month';
+        $this->untilType = 'always';
+        $this->untilDate = null;
         $this->resetValidation();
     }
 
     /** @return array<string, mixed> */
     private function formRules(): array
     {
-        return [
+        $rules = [
+            'mode' => ['required', Rule::in(['enter', 'plan'])],
             'transactionType' => ['required', Rule::in(['expense', 'income', 'transfer'])],
             'descriptionInput' => ['required', 'string', 'max:255'],
             'accountId' => [
@@ -411,5 +456,16 @@ final class TransactionModal extends Component
                 ]
                 : ['nullable'],
         ];
+
+        if ($this->mode === 'plan') {
+            $rules['transactionType'] = ['required', Rule::in(['expense', 'income'])];
+            $rules['frequency'] = ['required', Rule::in(array_column(RecurrenceFrequency::cases(), 'value'))];
+            $rules['untilType'] = ['required', Rule::in(['always', 'until-date'])];
+            $rules['untilDate'] = $this->untilType === 'until-date'
+                ? ['required', 'date_format:Y-m-d', 'after_or_equal:date']
+                : ['nullable'];
+        }
+
+        return $rules;
     }
 }

--- a/resources/views/livewire/transaction-modal.blade.php
+++ b/resources/views/livewire/transaction-modal.blade.php
@@ -1,4 +1,4 @@
-@php use Carbon\CarbonImmutable; @endphp
+@php use App\Enums\RecurrenceFrequency;use Carbon\CarbonImmutable; @endphp
 <div>
     <flux:modal wire:model="showModal" class="md:w-lg">
         <form wire:submit="save" class="space-y-6">
@@ -38,47 +38,73 @@
 
             <div class="flex gap-2">
                 <flux:button
-                    variant="{{ $transactionType === 'expense' ? 'primary' : 'ghost' }}"
-                    wire:click="$set('transactionType', 'expense')"
-                    type="button"
-                    class="flex-1"
-                    :disabled="$isBasiqTransaction"
+                        variant="{{ $transactionType === 'expense' ? 'primary' : 'ghost' }}"
+                        wire:click="$set('transactionType', 'expense')"
+                        type="button"
+                        class="flex-1"
+                        :disabled="$isBasiqTransaction"
                 >
                     {{ __('Expense') }}
                 </flux:button>
                 <flux:button
-                    variant="{{ $transactionType === 'income' ? 'primary' : 'ghost' }}"
-                    wire:click="$set('transactionType', 'income')"
-                    type="button"
-                    class="flex-1"
-                    :disabled="$isBasiqTransaction"
+                        variant="{{ $transactionType === 'income' ? 'primary' : 'ghost' }}"
+                        wire:click="$set('transactionType', 'income')"
+                        type="button"
+                        class="flex-1"
+                        :disabled="$isBasiqTransaction"
                 >
                     {{ __('Income') }}
                 </flux:button>
                 <flux:button
-                    variant="{{ $transactionType === 'transfer' ? 'primary' : 'ghost' }}"
-                    wire:click="$set('transactionType', 'transfer')"
-                    type="button"
-                    class="flex-1"
-                    :disabled="$isBasiqTransaction"
+                        variant="{{ $transactionType === 'transfer' ? 'primary' : 'ghost' }}"
+                        wire:click="$set('transactionType', 'transfer'); $set('mode', 'enter')"
+                        type="button"
+                        class="flex-1"
+                        :disabled="$isBasiqTransaction"
                 >
                     {{ __('Transfer') }}
                 </flux:button>
             </div>
 
+            @if(!$editingTransactionId && $transactionType !== 'transfer')
+                <div class="flex items-center justify-center gap-4">
+                    <flux:text size="sm" class="text-zinc-500">{{ __('Enter vs Plan') }}</flux:text>
+                    <div class="flex gap-1">
+                        <flux:button
+                                variant="{{ $mode === 'enter' ? 'filled' : 'ghost' }}"
+                                size="sm"
+                                wire:click="$set('mode', 'enter')"
+                                type="button"
+                                icon="check"
+                        >
+                            {{ __('Enter') }}
+                        </flux:button>
+                        <flux:button
+                                variant="{{ $mode === 'plan' ? 'filled' : 'ghost' }}"
+                                size="sm"
+                                wire:click="$set('mode', 'plan')"
+                                type="button"
+                                icon="pencil"
+                        >
+                            {{ __('Plan') }}
+                        </flux:button>
+                    </div>
+                </div>
+            @endif
+
             <flux:input
-                wire:model.blur="descriptionInput"
-                :label="__('Amount with description')"
-                placeholder="4*15 zoo tickets (tip is ignored)"
-                required
-                :disabled="$isBasiqTransaction"
+                    wire:model.blur="descriptionInput"
+                    :label="$mode === 'plan' ? __('Planned amount with description') : __('Amount with description')"
+                    placeholder="4*15 zoo tickets (tip is ignored)"
+                    required
+                    :disabled="$isBasiqTransaction"
             />
 
             @if($isBasiqTransaction)
                 <flux:input
-                    wire:model.blur="cleanDescription"
-                    :label="__('Clean description')"
-                    :placeholder="__('Your description for this transaction')"
+                        wire:model.blur="cleanDescription"
+                        :label="__('Clean description')"
+                        :placeholder="__('Your description for this transaction')"
                 />
             @endif
 
@@ -90,10 +116,10 @@
             </div>
 
             <flux:select
-                wire:model="accountId"
-                :label="$transactionType === 'transfer' ? __('From account') : __('Account')"
-                required
-                :disabled="$isBasiqTransaction"
+                    wire:model="accountId"
+                    :label="$transactionType === 'transfer' ? __('From account') : __('Account')"
+                    required
+                    :disabled="$isBasiqTransaction"
             >
                 <flux:select.option value="">{{ __('Select account') }}</flux:select.option>
                 @foreach($accounts as $account)
@@ -124,27 +150,67 @@
             </flux:select>
 
             <flux:input
-                wire:model="date"
-                :label="__('Date')"
-                type="date"
-                required
-                :disabled="$isBasiqTransaction"
+                    wire:model="date"
+                    :label="__('Date')"
+                    type="date"
+                    required
+                    :disabled="$isBasiqTransaction"
             />
 
+            @if($mode === 'plan')
+                <flux:select wire:model="frequency" :label="__('Frequency')" required>
+                    @foreach(RecurrenceFrequency::cases() as $freq)
+                        <flux:select.option value="{{ $freq->value }}">
+                            {{ $freq->label() }}
+                        </flux:select.option>
+                    @endforeach
+                </flux:select>
+
+                <div class="space-y-3">
+                    <div class="flex gap-1">
+                        <flux:button
+                                variant="{{ $untilType === 'always' ? 'filled' : 'ghost' }}"
+                                size="sm"
+                                wire:click="$set('untilType', 'always')"
+                                type="button"
+                        >
+                            {{ __('Always') }}
+                        </flux:button>
+                        <flux:button
+                                variant="{{ $untilType === 'until-date' ? 'filled' : 'ghost' }}"
+                                size="sm"
+                                wire:click="$set('untilType', 'until-date')"
+                                type="button"
+                        >
+                            {{ __('Until date') }}
+                        </flux:button>
+                    </div>
+
+                    @if($untilType === 'until-date')
+                        <flux:input
+                                wire:model="untilDate"
+                                :label="__('Until date')"
+                                type="date"
+                                required
+                        />
+                    @endif
+                </div>
+            @endif
+
             <flux:textarea
-                wire:model="notes"
-                :label="__('Notes')"
-                :placeholder="__('Optional notes')"
-                rows="2"
+                    wire:model="notes"
+                    :label="__('Notes')"
+                    :placeholder="__('Optional notes')"
+                    rows="2"
             />
 
             <div class="flex">
                 @if($editingTransactionId && !$isBasiqTransaction)
                     <flux:button
-                        variant="danger"
-                        wire:click="deleteTransaction"
-                        wire:confirm="{{ __('Are you sure you want to delete this transaction?') }}"
-                        type="button"
+                            variant="danger"
+                            wire:click="deleteTransaction"
+                            wire:confirm="{{ __('Are you sure you want to delete this transaction?') }}"
+                            type="button"
                     >
                         {{ __('Delete') }}
                     </flux:button>
@@ -158,6 +224,12 @@
                             {{ __('Update expense') }}
                         @else
                             {{ __('Update income') }}
+                        @endif
+                    @elseif($mode === 'plan')
+                        @if($transactionType === 'expense')
+                            {{ __('Plan expense') }}
+                        @else
+                            {{ __('Plan income') }}
                         @endif
                     @else
                         @if($transactionType === 'transfer')

--- a/tests/Feature/Livewire/TransactionModalTest.php
+++ b/tests/Feature/Livewire/TransactionModalTest.php
@@ -5,12 +5,14 @@
 declare(strict_types=1);
 
 use App\Enums\AccountStatus;
+use App\Enums\RecurrenceFrequency;
 use App\Enums\TransactionDirection;
 use App\Enums\TransactionSource;
 use App\Enums\TransactionStatus;
 use App\Livewire\TransactionModal;
 use App\Models\Account;
 use App\Models\Category;
+use App\Models\PlannedTransaction;
 use App\Models\Transaction;
 use App\Models\User;
 use Livewire\Livewire;
@@ -726,4 +728,254 @@ test('clicking credit side of transfer opens debit side for editing', function (
         ->assertSet('transactionType', 'transfer')
         ->assertSet('accountId', $fromAccount->id)
         ->assertSet('transferToAccountId', $toAccount->id);
+});
+
+// ── Plan Mode ────────────────────────────────────────────────────
+
+test('plan mode toggle defaults to enter mode', function () {
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('open-transaction-modal', date: '2026-03-15')
+        ->assertSet('mode', 'enter');
+});
+
+test('plan mode shows frequency and until fields', function () {
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('open-transaction-modal', date: '2026-03-15')
+        ->set('mode', 'plan')
+        ->assertSee(__('Frequency'))
+        ->assertSee(__('Always'));
+});
+
+test('enter mode hides plan fields', function () {
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('open-transaction-modal', date: '2026-03-15')
+        ->assertSet('mode', 'enter')
+        ->assertDontSee(__('Frequency'));
+});
+
+test('plan mode saves to planned_transactions table', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+
+    $transactionCountBefore = Transaction::query()->where('user_id', $user->id)->count();
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('open-transaction-modal', date: '2026-03-15')
+        ->set('mode', 'plan')
+        ->set('transactionType', 'expense')
+        ->set('descriptionInput', '50 monthly gym')
+        ->set('accountId', $account->id)
+        ->set('frequency', RecurrenceFrequency::EveryMonth->value)
+        ->call('save')
+        ->assertSet('showModal', false)
+        ->assertHasNoErrors();
+
+    expect(PlannedTransaction::query()->where('user_id', $user->id)->count())->toBe(1)
+        ->and(Transaction::query()->where('user_id', $user->id)->count())->toBe($transactionCountBefore);
+});
+
+test('plan mode stores correct direction for expense', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('open-transaction-modal', date: '2026-03-15')
+        ->set('mode', 'plan')
+        ->set('transactionType', 'expense')
+        ->set('descriptionInput', '100 rent')
+        ->set('accountId', $account->id)
+        ->call('save');
+
+    expect(PlannedTransaction::query()->where('user_id', $user->id)->first())
+        ->direction->toBe(TransactionDirection::Debit);
+});
+
+test('plan mode stores correct direction for income', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('open-transaction-modal', date: '2026-03-15')
+        ->set('mode', 'plan')
+        ->set('transactionType', 'income')
+        ->set('descriptionInput', '3000 salary')
+        ->set('accountId', $account->id)
+        ->call('save');
+
+    expect(PlannedTransaction::query()->where('user_id', $user->id)->first())
+        ->direction->toBe(TransactionDirection::Credit);
+});
+
+test('plan mode stores frequency correctly', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('open-transaction-modal', date: '2026-03-15')
+        ->set('mode', 'plan')
+        ->set('transactionType', 'expense')
+        ->set('descriptionInput', '20 streaming')
+        ->set('accountId', $account->id)
+        ->set('frequency', RecurrenceFrequency::EveryWeek->value)
+        ->call('save');
+
+    expect(PlannedTransaction::query()->where('user_id', $user->id)->first())
+        ->frequency->toBe(RecurrenceFrequency::EveryWeek);
+});
+
+test('plan mode always sets until_date to null', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('open-transaction-modal', date: '2026-03-15')
+        ->set('mode', 'plan')
+        ->set('transactionType', 'expense')
+        ->set('descriptionInput', '50 gym')
+        ->set('accountId', $account->id)
+        ->set('untilType', 'always')
+        ->call('save');
+
+    expect(PlannedTransaction::query()->where('user_id', $user->id)->first())
+        ->until_date->toBeNull();
+});
+
+test('plan mode until-date sets date correctly', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('open-transaction-modal', date: '2026-03-15')
+        ->set('mode', 'plan')
+        ->set('transactionType', 'expense')
+        ->set('descriptionInput', '50 gym')
+        ->set('accountId', $account->id)
+        ->set('untilType', 'until-date')
+        ->set('untilDate', '2026-09-15')
+        ->call('save');
+
+    expect(PlannedTransaction::query()->where('user_id', $user->id)->first())
+        ->until_date->format('Y-m-d')->toBe('2026-09-15');
+});
+
+test('plan mode validates frequency is valid enum', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('open-transaction-modal', date: '2026-03-15')
+        ->set('mode', 'plan')
+        ->set('transactionType', 'expense')
+        ->set('descriptionInput', '50 gym')
+        ->set('accountId', $account->id)
+        ->set('frequency', 'invalid-frequency')
+        ->call('save')
+        ->assertHasErrors(['frequency']);
+});
+
+test('plan mode validates until_date required when until-date type selected', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('open-transaction-modal', date: '2026-03-15')
+        ->set('mode', 'plan')
+        ->set('transactionType', 'expense')
+        ->set('descriptionInput', '50 gym')
+        ->set('accountId', $account->id)
+        ->set('untilType', 'until-date')
+        ->set('untilDate', null)
+        ->call('save')
+        ->assertHasErrors(['untilDate']);
+});
+
+test('plan mode rejects transfer transaction type via validation', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('open-transaction-modal', date: '2026-03-15')
+        ->set('mode', 'plan')
+        ->set('transactionType', 'transfer')
+        ->set('descriptionInput', '500 transfer')
+        ->set('accountId', $account->id)
+        ->call('save')
+        ->assertHasErrors(['transactionType']);
+
+    expect(PlannedTransaction::query()->where('user_id', $user->id)->count())->toBe(0);
+});
+
+test('plan toggle hidden for transfers', function () {
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('open-transaction-modal', date: '2026-03-15')
+        ->set('transactionType', 'transfer')
+        ->assertDontSee(__('Enter vs Plan'));
+});
+
+test('plan toggle hidden when editing', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $transaction = Transaction::factory()->for($user)->for($account)->manual()->create();
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('edit-transaction', id: $transaction->id)
+        ->assertDontSee(__('Enter vs Plan'));
+});
+
+test('plan mode dispatches transaction-saved event', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('open-transaction-modal', date: '2026-03-15')
+        ->set('mode', 'plan')
+        ->set('transactionType', 'expense')
+        ->set('descriptionInput', '50 gym')
+        ->set('accountId', $account->id)
+        ->call('save')
+        ->assertDispatched('transaction-saved');
+});
+
+test('plan mode resets form after save', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('open-transaction-modal', date: '2026-03-15')
+        ->set('mode', 'plan')
+        ->set('transactionType', 'expense')
+        ->set('descriptionInput', '50 gym')
+        ->set('accountId', $account->id)
+        ->set('frequency', RecurrenceFrequency::EveryWeek->value)
+        ->set('untilType', 'until-date')
+        ->set('untilDate', '2026-09-15')
+        ->call('save')
+        ->assertSet('mode', 'enter')
+        ->assertSet('frequency', RecurrenceFrequency::EveryMonth->value)
+        ->assertSet('untilType', 'always')
+        ->assertSet('untilDate', null);
 });


### PR DESCRIPTION
## Summary
- Adds Enter/Plan toggle to TransactionModal for expense and income transactions
- Plan mode reveals frequency dropdown (all 18 `RecurrenceFrequency` options) and Always/Until date selector
- Saves to `planned_transactions` table instead of `transactions` when in plan mode
- Dynamic labels: "Planned amount with description", "Plan expense" / "Plan income" buttons
- Toggle auto-hidden for transfers (planned transfer support deferred to follow-up issue) and edit mode

## Changes
- **`app/Livewire/TransactionModal.php`** — 4 new properties (`mode`, `frequency`, `untilType`, `untilDate`), `createPlannedTransaction()` method, conditional validation, reset logic
- **`resources/views/livewire/transaction-modal.blade.php`** — Enter/Plan toggle UI, frequency select, until type/date fields, dynamic submit button text
- **`tests/Feature/Livewire/TransactionModalTest.php`** — 15 new tests covering plan-mode creation, validation, direction mapping, frequency storage, until date handling, toggle visibility, form reset

## Test plan
- [x] `op test.filter TransactionModalTest` — 51 tests pass (36 existing + 15 new)
- [x] `op ci` — 721 tests pass, PHPStan clean, Pint clean
- [ ] Manual: open modal → switch to Plan → set frequency → save → verify `planned_transactions` row
- [ ] Manual: verify toggle hidden for transfers and edit mode

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)