### PR TITLE
feat: [91] Reconciliation — link Basiq transactions to planned transactions

### DIFF
--- a/app/Livewire/CalendarView.php
+++ b/app/Livewire/CalendarView.php
@@ -7,6 +7,7 @@ namespace App\Livewire;
 use App\Casts\MoneyCast;
 use App\Models\PlannedTransaction;
 use App\Models\Transaction;
+use App\Services\ReconciliationMatcher;
 use Carbon\CarbonImmutable;
 use Carbon\Constants\UnitValue;
 use Illuminate\Support\Collection;
@@ -48,7 +49,7 @@ final class CalendarView extends Component
         unset($this->calendarData); // @phpstan-ignore property.notFound
     }
 
-    /** @return array{monthLabel: string, weeks: list<list<array{date: int, fullDate: string, isCurrentMonth: bool, isToday: bool, transactions: list<array{id: int|null, category: string, amount: int, direction: string, type: string, source: string, isTransfer: bool, planned_transaction_id: int|null}>}>>, isCurrentMonth: bool} */
+    /** @return array{monthLabel: string, weeks: list<list<array{date: int, fullDate: string, isCurrentMonth: bool, isToday: bool, transactions: list<array{id: int|null, category: string, amount: int, direction: string, type: string, source: string, isTransfer: bool, planned_transaction_id: int|null, reconciliation_status: string|null, linked_transaction_id: int|null, occurrence_date: string|null}>}>>, isCurrentMonth: bool} */
     #[Computed(persist: true)]
     public function calendarData(): array
     {
@@ -59,16 +60,27 @@ final class CalendarView extends Component
         $gridStart = $monthStart->startOfWeek(UnitValue::MONDAY);
         $gridEnd = $monthEnd->endOfWeek(UnitValue::SUNDAY);
 
-        /** @var Collection<string, Collection<int, Transaction>> $transactionsByDate */
-        $transactionsByDate = Transaction::query()
+        $allTransactions = Transaction::query()
             ->where('user_id', auth()->id())
             ->whereBetween('post_date', [$gridStart, $gridEnd])
             ->with('category:id,name')
             ->orderBy('post_date')
-            ->get()
+            ->get();
+
+        /** @var Collection<string, Collection<int, Transaction>> $transactionsByDate */
+        $transactionsByDate = $allTransactions
             ->groupBy(fn (Transaction $t) => $t->post_date->format('Y-m-d'));
 
-        /** @var Collection<string, list<array{id: null, category: string, amount: int, direction: string, type: string, source: string, isTransfer: false, planned_transaction_id: int}>> $plannedByDate */
+        /** @var Collection<int, Collection<int, Transaction>> $linkedByPlannedId */
+        $linkedByPlannedId = $allTransactions
+            ->filter(fn (Transaction $t) => $t->planned_transaction_id !== null)
+            ->groupBy('planned_transaction_id');
+
+        /** @var Collection<int, Collection<int, Transaction>> $unlinkedByAccount */
+        $unlinkedByAccount = $allTransactions
+            ->filter(fn (Transaction $t) => $t->planned_transaction_id === null)
+            ->groupBy('account_id');
+
         $plannedByDate = collect();
 
         $plannedTransactions = PlannedTransaction::query()
@@ -83,6 +95,14 @@ final class CalendarView extends Component
             foreach ($planned->occurrencesBetween($gridStart, $gridEnd) as $date) {
                 $dateKey = $date->format('Y-m-d');
                 $existing = $plannedByDate->get($dateKey, []);
+
+                $reconciliationResult = $this->resolveReconciliationStatus(
+                    $planned,
+                    $date,
+                    $linkedByPlannedId,
+                    $unlinkedByAccount,
+                );
+
                 $existing[] = [
                     'id' => null,
                     'category' => $planned->category?->name ?? $planned->description, // @phpstan-ignore nullsafe.neverNull
@@ -92,6 +112,9 @@ final class CalendarView extends Component
                     'source' => 'planned',
                     'isTransfer' => false,
                     'planned_transaction_id' => $planned->id,
+                    'reconciliation_status' => $reconciliationResult['status'],
+                    'linked_transaction_id' => $reconciliationResult['linked_transaction_id'],
+                    'occurrence_date' => $dateKey,
                 ];
                 $plannedByDate->put($dateKey, $existing);
             }
@@ -114,7 +137,10 @@ final class CalendarView extends Component
                     'type' => 'actual',
                     'source' => $t->source->value,
                     'isTransfer' => $t->transfer_pair_id !== null,
-                    'planned_transaction_id' => null,
+                    'planned_transaction_id' => $t->planned_transaction_id,
+                    'reconciliation_status' => null,
+                    'linked_transaction_id' => null,
+                    'occurrence_date' => null,
                 ])->values()->all();
 
                 $week[] = [
@@ -122,7 +148,7 @@ final class CalendarView extends Component
                     'fullDate' => $dateKey,
                     'isCurrentMonth' => $current->month === $monthStart->month && $current->year === $monthStart->year,
                     'isToday' => $current->isSameDay($today),
-                    'transactions' => array_merge($actualTxns, $plannedByDate->get($dateKey, [])),
+                    'transactions' => array_merge($actualTxns, (array) $plannedByDate->get($dateKey, [])),
                 ];
 
                 $current = $current->addDay();
@@ -156,9 +182,45 @@ final class CalendarView extends Component
         ]);
     }
 
+    /**
+     * @param  Collection<int, Collection<int, Transaction>>  $linkedByPlannedId
+     * @param  Collection<int, Collection<int, Transaction>>  $unlinkedByAccount
+     * @return array{status: string, linked_transaction_id: int|null}
+     */
+    private function resolveReconciliationStatus(
+        PlannedTransaction $planned,
+        CarbonImmutable $occurrenceDate,
+        Collection $linkedByPlannedId,
+        Collection $unlinkedByAccount,
+    ): array {
+        $linked = $linkedByPlannedId->get($planned->id, collect())
+            ->first(fn (Transaction $t) => abs($t->post_date->diffInDays($occurrenceDate)) <= ReconciliationMatcher::DATE_TOLERANCE_DAYS);
+
+        if ($linked) {
+            return ['status' => 'reconciled', 'linked_transaction_id' => $linked->id];
+        }
+
+        $hasSuggestion = $unlinkedByAccount->get($planned->account_id, collect())
+            ->contains(function (Transaction $t) use ($planned, $occurrenceDate) {
+                if ($t->direction !== $planned->direction) {
+                    return false;
+                }
+
+                if (abs($t->post_date->diffInDays($occurrenceDate)) > ReconciliationMatcher::DATE_TOLERANCE_DAYS) {
+                    return false;
+                }
+
+                $amountDiff = abs(abs($t->amount) - abs($planned->amount));
+
+                return $amountDiff <= abs($planned->amount) * ReconciliationMatcher::AMOUNT_TOLERANCE;
+            });
+
+        return ['status' => $hasSuggestion ? 'suggested' : 'unreconciled', 'linked_transaction_id' => null];
+    }
+
     private function monthStart(): CarbonImmutable
     {
-        $date = CarbonImmutable::createFromFormat('Y-m', $this->currentMonth);
+        $date = CarbonImmutable::createFromFormat('Y-m-d', $this->currentMonth.'-01');
 
         if (! $date instanceof CarbonImmutable) {
             $date = CarbonImmutable::now();

--- a/app/Livewire/ReconciliationModal.php
+++ b/app/Livewire/ReconciliationModal.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire;
+
+use App\Casts\MoneyCast;
+use App\Models\PlannedTransaction;
+use App\Models\Transaction;
+use App\Services\ReconciliationMatcher;
+use Carbon\CarbonImmutable;
+use Illuminate\View\View;
+use Livewire\Attributes\On;
+use Livewire\Component;
+
+final class ReconciliationModal extends Component
+{
+    public bool $showModal = false;
+
+    public ?int $plannedTransactionId = null;
+
+    public ?string $occurrenceDate = null;
+
+    /** @var array{description: string, amount: int, direction: string, category: string|null, account_name: string}|null */
+    public ?array $plannedDetails = null;
+
+    /** @var list<array{id: int, description: string, amount: int, direction: string, post_date: string, account_name: string, amount_diff: int}> */
+    public array $suggestions = [];
+
+    /** @var array{id: int, description: string, amount: int, post_date: string}|null */
+    public ?array $linkedTransaction = null;
+
+    private ReconciliationMatcher $matcher;
+
+    public function boot(ReconciliationMatcher $matcher): void
+    {
+        $this->matcher = $matcher;
+    }
+
+    #[On('open-reconciliation-modal')]
+    public function openForPlanned(int $plannedId, string $occurrenceDate): void
+    {
+        $planned = PlannedTransaction::query()
+            ->where('user_id', auth()->id())
+            ->with(['category:id,name', 'account:id,name'])
+            ->find($plannedId);
+
+        if (! $planned) {
+            return;
+        }
+
+        $this->plannedTransactionId = $planned->id;
+        $this->occurrenceDate = $occurrenceDate;
+
+        $this->plannedDetails = [
+            'description' => $planned->description,
+            'amount' => $planned->amount,
+            'direction' => $planned->direction->value,
+            'category' => $planned->category?->name,
+            'account_name' => $planned->account->name, // @phpstan-ignore property.nonObject
+        ];
+
+        $this->loadMatches($planned, CarbonImmutable::parse($occurrenceDate));
+        $this->showModal = true;
+    }
+
+    public function link(int $transactionId): void
+    {
+        $transaction = Transaction::query()
+            ->where('user_id', auth()->id())
+            ->find($transactionId);
+
+        $planned = PlannedTransaction::query()
+            ->where('user_id', auth()->id())
+            ->find($this->plannedTransactionId);
+
+        if (! $transaction || ! $planned) {
+            return;
+        }
+
+        $this->matcher->link($transaction, $planned);
+
+        if ($this->occurrenceDate) {
+            $this->loadMatches($planned, CarbonImmutable::parse($this->occurrenceDate));
+        }
+
+        $this->dispatch('transaction-saved');
+    }
+
+    public function unlink(int $transactionId): void
+    {
+        $transaction = Transaction::query()
+            ->where('user_id', auth()->id())
+            ->find($transactionId);
+
+        if (! $transaction) {
+            return;
+        }
+
+        $this->matcher->unlink($transaction);
+
+        $planned = PlannedTransaction::query()
+            ->where('user_id', auth()->id())
+            ->find($this->plannedTransactionId);
+
+        if ($planned && $this->occurrenceDate) {
+            $this->loadMatches($planned, CarbonImmutable::parse($this->occurrenceDate));
+        }
+
+        $this->dispatch('transaction-saved');
+    }
+
+    public function editPlanned(): void
+    {
+        $this->showModal = false;
+        $this->dispatch('edit-planned-transaction', id: $this->plannedTransactionId);
+    }
+
+    public function render(): View
+    {
+        return view('livewire.reconciliation-modal', [
+            'formatMoney' => MoneyCast::format(...),
+        ]);
+    }
+
+    private function loadMatches(PlannedTransaction $planned, CarbonImmutable $date): void
+    {
+        $linked = $this->matcher->findLinkedForOccurrence($planned, $date);
+
+        if ($linked) {
+            $this->linkedTransaction = [
+                'id' => $linked->id,
+                'description' => $linked->clean_description ?? $linked->description,
+                'amount' => $linked->amount,
+                'post_date' => $linked->post_date->format('Y-m-d'),
+            ];
+            $this->suggestions = [];
+
+            return;
+        }
+
+        $this->linkedTransaction = null;
+        $suggestions = $this->matcher->findSuggestions($planned, $date);
+
+        $this->suggestions = $suggestions->map(fn (Transaction $t) => [
+            'id' => $t->id,
+            'description' => $t->clean_description ?? $t->description,
+            'amount' => $t->amount,
+            'direction' => $t->direction->value,
+            'post_date' => $t->post_date->format('Y-m-d'),
+            'account_name' => $t->account->name, // @phpstan-ignore property.nonObject
+            'amount_diff' => abs($t->amount) - abs($planned->amount),
+        ])->values()->all();
+    }
+}

--- a/app/Services/ReconciliationMatcher.php
+++ b/app/Services/ReconciliationMatcher.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Models\PlannedTransaction;
+use App\Models\Transaction;
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Collection;
+
+final readonly class ReconciliationMatcher
+{
+    public const float AMOUNT_TOLERANCE = 0.10;
+
+    public const int DATE_TOLERANCE_DAYS = 3;
+
+    /**
+     * @return Collection<int, Transaction>
+     */
+    public function findSuggestions(PlannedTransaction $planned, CarbonImmutable $occurrenceDate): Collection
+    {
+        $dateFrom = $occurrenceDate->subDays(self::DATE_TOLERANCE_DAYS);
+        $dateTo = $occurrenceDate->addDays(self::DATE_TOLERANCE_DAYS);
+        $minAmount = (int) floor($planned->amount * (1 - self::AMOUNT_TOLERANCE));
+        $maxAmount = (int) ceil($planned->amount * (1 + self::AMOUNT_TOLERANCE));
+
+        return Transaction::query()
+            ->where('user_id', $planned->user_id)
+            ->where('account_id', $planned->account_id)
+            ->where('direction', $planned->direction)
+            ->whereNull('planned_transaction_id')
+            ->whereBetween('post_date', [$dateFrom, $dateTo])
+            ->whereRaw('ABS(amount) BETWEEN ? AND ?', [$minAmount, $maxAmount])
+            ->with('account:id,name')
+            ->get()
+            ->sortBy([
+                fn (Transaction $a, Transaction $b) => abs($a->post_date->diffInDays($occurrenceDate)) <=> abs($b->post_date->diffInDays($occurrenceDate)),
+                fn (Transaction $a, Transaction $b) => abs(abs($a->amount) - abs($planned->amount)) <=> abs(abs($b->amount) - abs($planned->amount)),
+            ])
+            ->values();
+    }
+
+    public function findLinkedForOccurrence(PlannedTransaction $planned, CarbonImmutable $occurrenceDate): ?Transaction
+    {
+        $dateFrom = $occurrenceDate->subDays(self::DATE_TOLERANCE_DAYS);
+        $dateTo = $occurrenceDate->addDays(self::DATE_TOLERANCE_DAYS);
+
+        return Transaction::query()
+            ->where('user_id', $planned->user_id)
+            ->where('planned_transaction_id', $planned->id)
+            ->whereBetween('post_date', [$dateFrom, $dateTo])
+            ->with('account:id,name')
+            ->first();
+    }
+
+    public function link(Transaction $transaction, PlannedTransaction $planned): void
+    {
+        $transaction->update(['planned_transaction_id' => $planned->id]);
+    }
+
+    public function unlink(Transaction $transaction): void
+    {
+        $transaction->update(['planned_transaction_id' => null]);
+    }
+}

--- a/resources/views/calendar.blade.php
+++ b/resources/views/calendar.blade.php
@@ -1,4 +1,5 @@
 <x-layouts::app :title="__('Calendar')">
     <livewire:calendar-view />
     <livewire:transaction-modal />
+    <livewire:reconciliation-modal />
 </x-layouts::app>

--- a/resources/views/livewire/calendar-view.blade.php
+++ b/resources/views/livewire/calendar-view.blade.php
@@ -43,7 +43,14 @@
                                     @foreach($day['transactions'] as $txn)
                                         @php
                                             $isPlanned = ($txn['type'] ?? 'actual') === 'planned';
+                                            $reconStatus = $txn['reconciliation_status'] ?? null;
+                                            $isReconciled = $reconStatus === 'reconciled';
+                                            $isSuggested = $reconStatus === 'suggested';
+
                                             $bgColor = match(true) {
+                                                $isReconciled && $txn['direction'] === 'debit' => 'bg-red-50 dark:bg-red-950/30',
+                                                $isReconciled => 'bg-green-50 dark:bg-green-950/30',
+                                                $isSuggested => 'border border-dashed border-amber-400 bg-amber-50/50 dark:border-amber-600 dark:bg-amber-950/20',
                                                 $isPlanned && $txn['direction'] === 'debit' => 'border border-dashed border-red-300 bg-red-50/50 dark:border-red-800 dark:bg-red-950/20',
                                                 $isPlanned => 'border border-dashed border-green-300 bg-green-50/50 dark:border-green-800 dark:bg-green-950/20',
                                                 ($txn['isTransfer'] ?? false) => 'bg-blue-50 dark:bg-blue-950/30',
@@ -51,6 +58,9 @@
                                                 default => 'bg-green-50 dark:bg-green-950/30',
                                             };
                                             $amountColor = match(true) {
+                                                $isReconciled && $txn['direction'] === 'debit' => 'text-red-600 dark:text-red-400',
+                                                $isReconciled => 'text-green-600 dark:text-green-400',
+                                                $isSuggested => 'text-amber-600 dark:text-amber-400',
                                                 $isPlanned && $txn['direction'] === 'debit' => 'text-red-400 dark:text-red-600',
                                                 $isPlanned => 'text-green-400 dark:text-green-600',
                                                 ($txn['isTransfer'] ?? false) => 'text-blue-600 dark:text-blue-400',
@@ -61,11 +71,27 @@
                                         @if($isPlanned)
                                             <button
                                                 type="button"
-                                                wire:click.stop="$dispatch('edit-planned-transaction', { id: {{ $txn['planned_transaction_id'] }} })"
+                                                wire:click.stop="$dispatch('open-reconciliation-modal', { plannedId: {{ $txn['planned_transaction_id'] }}, occurrenceDate: '{{ $txn['occurrence_date'] }}' })"
                                                 class="flex w-full cursor-pointer items-center justify-between gap-1 rounded px-1 py-0.5 text-xs hover:ring-1 hover:ring-indigo-300 dark:hover:ring-indigo-600 {{ $bgColor }}"
                                             >
-                                                <span class="flex items-center gap-0.5 truncate {{ !$day['isCurrentMonth'] ? 'text-zinc-400 dark:text-zinc-600' : 'text-zinc-500 dark:text-zinc-500' }}">
-                                                    <flux:icon.clock variant="mini" class="size-3 shrink-0"/>
+                                                @php
+                                                    $plannedTextColor = match(true) {
+                                                        !$day['isCurrentMonth'] => 'text-zinc-400 dark:text-zinc-600',
+                                                        $isReconciled => 'text-zinc-600 dark:text-zinc-400',
+                                                        default => 'text-zinc-500 dark:text-zinc-500',
+                                                    };
+                                                @endphp
+                                                <span class="flex items-center gap-0.5 truncate {{ $plannedTextColor }}">
+                                                    @if($isReconciled)
+                                                        <flux:icon.check-circle variant="mini" class="size-3 shrink-0 text-green-500"/>
+                                                    @elseif($isSuggested)
+                                                        <span class="relative">
+                                                            <flux:icon.clock variant="mini" class="size-3 shrink-0"/>
+                                                            <span class="absolute -top-0.5 -right-0.5 size-1.5 rounded-full bg-amber-400"></span>
+                                                        </span>
+                                                    @else
+                                                        <flux:icon.clock variant="mini" class="size-3 shrink-0"/>
+                                                    @endif
                                                     {{ $txn['category'] }}
                                                 </span>
                                                 <span class="shrink-0 tabular-nums font-medium {{ $amountColor }}">{{ $formatMoney($txn['amount']) }}</span>
@@ -117,22 +143,45 @@
                                 @foreach($day['transactions'] as $txn)
                                     @php
                                         $isPlanned = ($txn['type'] ?? 'actual') === 'planned';
+                                        $reconStatus = $txn['reconciliation_status'] ?? null;
+                                        $isReconciled = $reconStatus === 'reconciled';
+                                        $isSuggested = $reconStatus === 'suggested';
+
                                         $amountColor = match(true) {
+                                            $isReconciled && $txn['direction'] === 'debit' => 'text-red-600 dark:text-red-400',
+                                            $isReconciled => 'text-green-600 dark:text-green-400',
+                                            $isSuggested => 'text-amber-600 dark:text-amber-400',
                                             $isPlanned && $txn['direction'] === 'debit' => 'text-red-400 dark:text-red-600',
                                             $isPlanned => 'text-green-400 dark:text-green-600',
                                             ($txn['isTransfer'] ?? false) => 'text-blue-600 dark:text-blue-400',
                                             $txn['direction'] === 'debit' => 'text-red-600 dark:text-red-400',
                                             default => 'text-green-600 dark:text-green-400',
                                         };
+
+                                        $mobileBorder = match(true) {
+                                            $isReconciled => 'border border-solid ' . ($txn['direction'] === 'debit' ? 'border-red-200 bg-red-50/50 dark:border-red-800 dark:bg-red-950/20' : 'border-green-200 bg-green-50/50 dark:border-green-800 dark:bg-green-950/20'),
+                                            $isSuggested => 'border border-dashed border-amber-400 bg-amber-50/50 dark:border-amber-600 dark:bg-amber-950/20',
+                                            $isPlanned => 'border border-dashed ' . ($txn['direction'] === 'debit' ? 'border-red-300 dark:border-red-800' : 'border-green-300 dark:border-green-800'),
+                                            default => '',
+                                        };
                                     @endphp
                                     @if($isPlanned)
                                         <button
                                             type="button"
-                                            wire:click.stop="$dispatch('edit-planned-transaction', { id: {{ $txn['planned_transaction_id'] }} })"
-                                            class="flex w-full cursor-pointer items-center justify-between rounded-md border border-dashed {{ $txn['direction'] === 'debit' ? 'border-red-300 dark:border-red-800' : 'border-green-300 dark:border-green-800' }} px-2 py-1 text-left text-sm hover:bg-zinc-100 dark:hover:bg-zinc-800"
+                                            wire:click.stop="$dispatch('open-reconciliation-modal', { plannedId: {{ $txn['planned_transaction_id'] }}, occurrenceDate: '{{ $txn['occurrence_date'] }}' })"
+                                            class="flex w-full cursor-pointer items-center justify-between rounded-md px-2 py-1 text-left text-sm hover:bg-zinc-100 dark:hover:bg-zinc-800 {{ $mobileBorder }}"
                                         >
-                                            <span class="flex items-center gap-1 truncate text-zinc-500 dark:text-zinc-500">
-                                                <flux:icon.clock variant="mini" class="size-3.5 shrink-0"/>
+                                            <span class="flex items-center gap-1 truncate {{ $isReconciled ? 'text-zinc-600 dark:text-zinc-400' : 'text-zinc-500 dark:text-zinc-500' }}">
+                                                @if($isReconciled)
+                                                    <flux:icon.check-circle variant="mini" class="size-3.5 shrink-0 text-green-500"/>
+                                                @elseif($isSuggested)
+                                                    <span class="relative">
+                                                        <flux:icon.clock variant="mini" class="size-3.5 shrink-0"/>
+                                                        <span class="absolute -top-0.5 -right-0.5 size-1.5 rounded-full bg-amber-400"></span>
+                                                    </span>
+                                                @else
+                                                    <flux:icon.clock variant="mini" class="size-3.5 shrink-0"/>
+                                                @endif
                                                 {{ $txn['category'] }}
                                             </span>
                                             <span class="shrink-0 tabular-nums font-medium {{ $amountColor }}">{{ $formatMoney($txn['amount']) }}</span>

--- a/resources/views/livewire/reconciliation-modal.blade.php
+++ b/resources/views/livewire/reconciliation-modal.blade.php
@@ -1,0 +1,133 @@
+@php use Carbon\CarbonImmutable; @endphp
+<div>
+    <flux:modal wire:model="showModal" class="md:w-lg">
+        @if($plannedDetails)
+            <div class="space-y-6">
+                <div class="flex items-center justify-between">
+                    <flux:heading size="lg">{{ __('Reconcile Transaction') }}</flux:heading>
+                    @if($occurrenceDate)
+                        <flux:badge color="zinc">
+                            {{ CarbonImmutable::parse($occurrenceDate)->format('D j M Y') }}
+                        </flux:badge>
+                    @endif
+                </div>
+
+                <div class="rounded-lg border border-zinc-200 p-4 dark:border-zinc-700">
+                    <div class="flex items-center justify-between">
+                        <div>
+                            <flux:text size="sm" class="text-zinc-500">{{ __('Planned') }}</flux:text>
+                            <div class="mt-1 font-medium text-zinc-900 dark:text-zinc-100">
+                                {{ $plannedDetails['description'] }}
+                            </div>
+                            @if($plannedDetails['category'])
+                                <flux:text size="sm" class="mt-0.5 text-zinc-500">
+                                    {{ $plannedDetails['category'] }} &middot; {{ $plannedDetails['account_name'] }}
+                                </flux:text>
+                            @else
+                                <flux:text size="sm" class="mt-0.5 text-zinc-500">
+                                    {{ $plannedDetails['account_name'] }}
+                                </flux:text>
+                            @endif
+                        </div>
+                        <div class="text-right">
+                            <span class="text-lg font-semibold tabular-nums {{ $plannedDetails['direction'] === 'debit' ? 'text-red-600 dark:text-red-400' : 'text-green-600 dark:text-green-400' }}">
+                                {{ $formatMoney($plannedDetails['amount']) }}
+                            </span>
+                        </div>
+                    </div>
+                </div>
+
+                @if($linkedTransaction)
+                    <div>
+                        <flux:text size="sm" class="mb-2 font-medium text-zinc-700 dark:text-zinc-300">
+                            <flux:icon.check-circle variant="mini" class="inline size-4 text-green-500"/>
+                            {{ __('Linked transaction') }}
+                        </flux:text>
+                        <div class="rounded-lg border border-green-200 bg-green-50/50 p-3 dark:border-green-800 dark:bg-green-950/20">
+                            <div class="flex items-center justify-between">
+                                <div>
+                                    <div class="font-medium text-zinc-900 dark:text-zinc-100">
+                                        {{ $linkedTransaction['description'] }}
+                                    </div>
+                                    <flux:text size="sm" class="text-zinc-500">
+                                        {{ CarbonImmutable::parse($linkedTransaction['post_date'])->format('D j M Y') }}
+                                    </flux:text>
+                                </div>
+                                <div class="flex items-center gap-3">
+                                    <span class="font-semibold tabular-nums">
+                                        {{ $formatMoney($linkedTransaction['amount']) }}
+                                    </span>
+                                    <flux:button
+                                        variant="subtle"
+                                        size="sm"
+                                        wire:click="unlink({{ $linkedTransaction['id'] }})"
+                                        wire:confirm="{{ __('Unlink this transaction?') }}"
+                                    >
+                                        {{ __('Unlink') }}
+                                    </flux:button>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                @endif
+
+                @if(!$linkedTransaction && count($suggestions) > 0)
+                    <div>
+                        <flux:text size="sm" class="mb-2 font-medium text-zinc-700 dark:text-zinc-300">
+                            {{ __('Suggested matches') }}
+                        </flux:text>
+                        <div class="space-y-2">
+                            @foreach($suggestions as $suggestion)
+                                <div class="flex items-center justify-between rounded-lg border border-amber-200 bg-amber-50/50 p-3 dark:border-amber-700 dark:bg-amber-950/20">
+                                    <div class="min-w-0 flex-1">
+                                        <div class="truncate font-medium text-zinc-900 dark:text-zinc-100">
+                                            {{ $suggestion['description'] }}
+                                        </div>
+                                        <div class="flex items-center gap-2">
+                                            <flux:text size="sm" class="text-zinc-500">
+                                                {{ CarbonImmutable::parse($suggestion['post_date'])->format('D j M') }}
+                                            </flux:text>
+                                            @if($suggestion['amount_diff'] !== 0)
+                                                <flux:badge size="sm" :color="$suggestion['amount_diff'] > 0 ? 'red' : 'green'">
+                                                    {{ $suggestion['amount_diff'] > 0 ? '+' : '' }}{{ $formatMoney($suggestion['amount_diff']) }}
+                                                </flux:badge>
+                                            @endif
+                                        </div>
+                                    </div>
+                                    <div class="flex items-center gap-3">
+                                        <span class="font-semibold tabular-nums">
+                                            {{ $formatMoney($suggestion['amount']) }}
+                                        </span>
+                                        <flux:button
+                                            variant="primary"
+                                            size="sm"
+                                            wire:click="link({{ $suggestion['id'] }})"
+                                        >
+                                            {{ __('Link') }}
+                                        </flux:button>
+                                    </div>
+                                </div>
+                            @endforeach
+                        </div>
+                    </div>
+                @endif
+
+                @if(!$linkedTransaction && count($suggestions) === 0)
+                    <div class="rounded-lg border border-dashed border-zinc-300 p-6 text-center dark:border-zinc-600">
+                        <flux:icon.magnifying-glass class="mx-auto size-8 text-zinc-400"/>
+                        <flux:text class="mt-2">{{ __('No matching transactions found near this date.') }}</flux:text>
+                    </div>
+                @endif
+
+                <div class="flex justify-between">
+                    <flux:button variant="subtle" wire:click="editPlanned" type="button">
+                        {{ __('Edit planned') }}
+                    </flux:button>
+                    <flux:button variant="ghost" wire:click="$set('showModal', false)" type="button">
+                        {{ __('Close') }}
+                    </flux:button>
+                </div>
+            </div>
+        @endif
+    </flux:modal>
+</div>

--- a/tests/Feature/Livewire/CalendarViewTest.php
+++ b/tests/Feature/Livewire/CalendarViewTest.php
@@ -127,7 +127,7 @@ test('previous month navigation works', function () {
         ->call('previousMonth');
 
     $data = $component->get('calendarData');
-    $expectedLabel = now()->subMonth()->format('F Y');
+    $expectedLabel = now()->startOfMonth()->subMonth()->format('F Y');
 
     expect($data['monthLabel'])->toBe($expectedLabel)
         ->and($data['isCurrentMonth'])->toBeFalse();
@@ -141,7 +141,7 @@ test('next month navigation works', function () {
         ->call('nextMonth');
 
     $data = $component->get('calendarData');
-    $expectedLabel = now()->addMonth()->format('F Y');
+    $expectedLabel = now()->startOfMonth()->addMonth()->format('F Y');
 
     expect($data['monthLabel'])->toBe($expectedLabel)
         ->and($data['isCurrentMonth'])->toBeFalse();
@@ -631,4 +631,236 @@ test('only current user planned transactions are shown', function () {
         ->where('type', 'planned');
 
     expect($planned)->toHaveCount(1);
+});
+
+// ── Reconciliation Status ────────────────────────────────────────
+
+test('planned entry has reconciled status when linked transaction exists near occurrence date', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $date = now()->startOfMonth()->addDays(9);
+
+    $planned = PlannedTransaction::factory()->for($user)->for($account)->noRepeat()->create([
+        'amount' => 15000,
+        'direction' => TransactionDirection::Debit,
+        'start_date' => $date,
+    ]);
+
+    Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'amount' => 15000,
+        'post_date' => $date,
+        'planned_transaction_id' => $planned->id,
+    ]);
+
+    $component = Livewire::actingAs($user)->test(CalendarView::class);
+
+    $data = $component->get('calendarData');
+    $plannedEntry = collect($data['weeks'])->flatten(1)
+        ->flatMap(fn (array $day) => $day['transactions'])
+        ->firstWhere('type', 'planned');
+
+    expect($plannedEntry['reconciliation_status'])->toBe('reconciled')
+        ->and($plannedEntry['linked_transaction_id'])->not->toBeNull();
+});
+
+test('planned entry has unreconciled status when no matching transactions exist', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+
+    PlannedTransaction::factory()->for($user)->for($account)->noRepeat()->create([
+        'amount' => 15000,
+        'direction' => TransactionDirection::Debit,
+        'start_date' => now()->startOfMonth()->addDays(9),
+    ]);
+
+    $component = Livewire::actingAs($user)->test(CalendarView::class);
+
+    $data = $component->get('calendarData');
+    $plannedEntry = collect($data['weeks'])->flatten(1)
+        ->flatMap(fn (array $day) => $day['transactions'])
+        ->firstWhere('type', 'planned');
+
+    expect($plannedEntry['reconciliation_status'])->toBe('unreconciled')
+        ->and($plannedEntry['linked_transaction_id'])->toBeNull();
+});
+
+test('planned entry has suggested status when unlinked match exists', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $date = now()->startOfMonth()->addDays(9);
+
+    PlannedTransaction::factory()->for($user)->for($account)->noRepeat()->create([
+        'amount' => 15000,
+        'direction' => TransactionDirection::Debit,
+        'start_date' => $date,
+    ]);
+
+    Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'amount' => 15000,
+        'post_date' => $date,
+    ]);
+
+    $component = Livewire::actingAs($user)->test(CalendarView::class);
+
+    $data = $component->get('calendarData');
+    $plannedEntry = collect($data['weeks'])->flatten(1)
+        ->flatMap(fn (array $day) => $day['transactions'])
+        ->firstWhere('type', 'planned');
+
+    expect($plannedEntry['reconciliation_status'])->toBe('suggested');
+});
+
+test('suggestion status respects amount tolerance', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $date = now()->startOfMonth()->addDays(9);
+
+    PlannedTransaction::factory()->for($user)->for($account)->noRepeat()->create([
+        'amount' => 10000,
+        'direction' => TransactionDirection::Debit,
+        'start_date' => $date,
+    ]);
+
+    Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'amount' => 12000,
+        'post_date' => $date,
+    ]);
+
+    $component = Livewire::actingAs($user)->test(CalendarView::class);
+
+    $data = $component->get('calendarData');
+    $plannedEntry = collect($data['weeks'])->flatten(1)
+        ->flatMap(fn (array $day) => $day['transactions'])
+        ->firstWhere('type', 'planned');
+
+    expect($plannedEntry['reconciliation_status'])->toBe('unreconciled');
+});
+
+test('suggestion status respects date tolerance', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $date = now()->startOfMonth()->addDays(9);
+
+    PlannedTransaction::factory()->for($user)->for($account)->noRepeat()->create([
+        'amount' => 10000,
+        'direction' => TransactionDirection::Debit,
+        'start_date' => $date,
+    ]);
+
+    Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'amount' => 10000,
+        'post_date' => $date->addDays(5),
+    ]);
+
+    $component = Livewire::actingAs($user)->test(CalendarView::class);
+
+    $data = $component->get('calendarData');
+    $plannedEntry = collect($data['weeks'])->flatten(1)
+        ->flatMap(fn (array $day) => $day['transactions'])
+        ->firstWhere('type', 'planned');
+
+    expect($plannedEntry['reconciliation_status'])->toBe('unreconciled');
+});
+
+test('suggestion status requires same account', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $otherAccount = Account::factory()->for($user)->create();
+    $date = now()->startOfMonth()->addDays(9);
+
+    PlannedTransaction::factory()->for($user)->for($account)->noRepeat()->create([
+        'amount' => 10000,
+        'direction' => TransactionDirection::Debit,
+        'start_date' => $date,
+    ]);
+
+    Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $otherAccount->id,
+        'amount' => 10000,
+        'post_date' => $date,
+    ]);
+
+    $component = Livewire::actingAs($user)->test(CalendarView::class);
+
+    $data = $component->get('calendarData');
+    $plannedEntry = collect($data['weeks'])->flatten(1)
+        ->flatMap(fn (array $day) => $day['transactions'])
+        ->firstWhere('type', 'planned');
+
+    expect($plannedEntry['reconciliation_status'])->toBe('unreconciled');
+});
+
+test('suggestion status requires same direction', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $date = now()->startOfMonth()->addDays(9);
+
+    PlannedTransaction::factory()->for($user)->for($account)->noRepeat()->create([
+        'amount' => 10000,
+        'direction' => TransactionDirection::Debit,
+        'start_date' => $date,
+    ]);
+
+    Transaction::factory()->for($user)->credit()->create([
+        'account_id' => $account->id,
+        'amount' => 10000,
+        'post_date' => $date,
+    ]);
+
+    $component = Livewire::actingAs($user)->test(CalendarView::class);
+
+    $data = $component->get('calendarData');
+    $plannedEntry = collect($data['weeks'])->flatten(1)
+        ->flatMap(fn (array $day) => $day['transactions'])
+        ->firstWhere('type', 'planned');
+
+    expect($plannedEntry['reconciliation_status'])->toBe('unreconciled');
+});
+
+test('planned entry includes occurrence_date field', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $date = now()->startOfMonth()->addDays(9);
+
+    PlannedTransaction::factory()->for($user)->for($account)->noRepeat()->create([
+        'start_date' => $date,
+    ]);
+
+    $component = Livewire::actingAs($user)->test(CalendarView::class);
+
+    $data = $component->get('calendarData');
+    $plannedEntry = collect($data['weeks'])->flatten(1)
+        ->flatMap(fn (array $day) => $day['transactions'])
+        ->firstWhere('type', 'planned');
+
+    expect($plannedEntry['occurrence_date'])->toBe($date->format('Y-m-d'));
+});
+
+test('actual transaction includes planned_transaction_id when linked', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $date = now()->startOfMonth()->addDays(9);
+
+    $planned = PlannedTransaction::factory()->for($user)->for($account)->noRepeat()->create([
+        'start_date' => $date,
+    ]);
+
+    Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'post_date' => $date,
+        'planned_transaction_id' => $planned->id,
+    ]);
+
+    $component = Livewire::actingAs($user)->test(CalendarView::class);
+
+    $data = $component->get('calendarData');
+    $actualEntry = collect($data['weeks'])->flatten(1)
+        ->flatMap(fn (array $day) => $day['transactions'])
+        ->firstWhere('type', 'actual');
+
+    expect($actualEntry['planned_transaction_id'])->toBe($planned->id);
 });

--- a/tests/Feature/Livewire/ReconciliationModalTest.php
+++ b/tests/Feature/Livewire/ReconciliationModalTest.php
@@ -1,0 +1,290 @@
+<?php
+
+/** @noinspection StaticClosureCanBeUsedInspection */
+
+declare(strict_types=1);
+
+use App\Enums\TransactionDirection;
+use App\Livewire\ReconciliationModal;
+use App\Models\Account;
+use App\Models\Category;
+use App\Models\PlannedTransaction;
+use App\Models\Transaction;
+use App\Models\User;
+use Livewire\Livewire;
+
+test('component renders for authenticated user', function () {
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(ReconciliationModal::class)
+        ->assertSuccessful();
+});
+
+test('opens with correct planned transaction and occurrence date', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $category = Category::factory()->create(['name' => 'Rent']);
+
+    $planned = PlannedTransaction::factory()->for($user)->for($account)->noRepeat()->create([
+        'description' => 'Monthly Rent',
+        'amount' => 150000,
+        'direction' => TransactionDirection::Debit,
+        'category_id' => $category->id,
+        'start_date' => '2026-03-15',
+    ]);
+
+    $component = Livewire::actingAs($user)
+        ->test(ReconciliationModal::class)
+        ->dispatch('open-reconciliation-modal', plannedId: $planned->id, occurrenceDate: '2026-03-15');
+
+    expect($component->get('showModal'))->toBeTrue()
+        ->and($component->get('plannedTransactionId'))->toBe($planned->id)
+        ->and($component->get('occurrenceDate'))->toBe('2026-03-15')
+        ->and($component->get('plannedDetails.description'))->toBe('Monthly Rent')
+        ->and($component->get('plannedDetails.amount'))->toBe(150000)
+        ->and($component->get('plannedDetails.category'))->toBe('Rent');
+});
+
+test('lists suggested matches for unlinked occurrence', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+
+    $planned = PlannedTransaction::factory()->for($user)->for($account)->noRepeat()->create([
+        'amount' => 15000,
+        'direction' => TransactionDirection::Debit,
+        'start_date' => '2026-03-15',
+    ]);
+
+    Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'amount' => 15000,
+        'post_date' => '2026-03-15',
+        'description' => 'RENT PAYMENT',
+    ]);
+
+    $component = Livewire::actingAs($user)
+        ->test(ReconciliationModal::class)
+        ->dispatch('open-reconciliation-modal', plannedId: $planned->id, occurrenceDate: '2026-03-15');
+
+    $suggestions = $component->get('suggestions');
+
+    expect($suggestions)->toHaveCount(1)
+        ->and($suggestions[0]['description'])->toBe('RENT PAYMENT')
+        ->and($component->get('linkedTransaction'))->toBeNull();
+});
+
+test('shows already linked transaction when reconciled', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+
+    $planned = PlannedTransaction::factory()->for($user)->for($account)->noRepeat()->create([
+        'amount' => 15000,
+        'direction' => TransactionDirection::Debit,
+        'start_date' => '2026-03-15',
+    ]);
+
+    $linked = Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'amount' => 15000,
+        'post_date' => '2026-03-15',
+        'planned_transaction_id' => $planned->id,
+        'description' => 'RENT PAYMENT',
+    ]);
+
+    $component = Livewire::actingAs($user)
+        ->test(ReconciliationModal::class)
+        ->dispatch('open-reconciliation-modal', plannedId: $planned->id, occurrenceDate: '2026-03-15');
+
+    expect($component->get('linkedTransaction'))->not->toBeNull()
+        ->and($component->get('linkedTransaction.id'))->toBe($linked->id)
+        ->and($component->get('suggestions'))->toBeEmpty();
+});
+
+test('link action sets planned_transaction_id on the transaction', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+
+    $planned = PlannedTransaction::factory()->for($user)->for($account)->noRepeat()->create([
+        'amount' => 15000,
+        'direction' => TransactionDirection::Debit,
+        'start_date' => '2026-03-15',
+    ]);
+
+    $transaction = Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'amount' => 15000,
+        'post_date' => '2026-03-15',
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(ReconciliationModal::class)
+        ->dispatch('open-reconciliation-modal', plannedId: $planned->id, occurrenceDate: '2026-03-15')
+        ->call('link', $transaction->id)
+        ->assertDispatched('transaction-saved');
+
+    expect($transaction->fresh()->planned_transaction_id)->toBe($planned->id);
+});
+
+test('unlink action clears planned_transaction_id', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+
+    $planned = PlannedTransaction::factory()->for($user)->for($account)->noRepeat()->create([
+        'amount' => 15000,
+        'direction' => TransactionDirection::Debit,
+        'start_date' => '2026-03-15',
+    ]);
+
+    $transaction = Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'amount' => 15000,
+        'post_date' => '2026-03-15',
+        'planned_transaction_id' => $planned->id,
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(ReconciliationModal::class)
+        ->dispatch('open-reconciliation-modal', plannedId: $planned->id, occurrenceDate: '2026-03-15')
+        ->call('unlink', $transaction->id)
+        ->assertDispatched('transaction-saved');
+
+    expect($transaction->fresh()->planned_transaction_id)->toBeNull();
+});
+
+test('dispatches transaction-saved event after link', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+
+    $planned = PlannedTransaction::factory()->for($user)->for($account)->noRepeat()->create([
+        'amount' => 15000,
+        'direction' => TransactionDirection::Debit,
+        'start_date' => '2026-03-15',
+    ]);
+
+    $transaction = Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'amount' => 15000,
+        'post_date' => '2026-03-15',
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(ReconciliationModal::class)
+        ->dispatch('open-reconciliation-modal', plannedId: $planned->id, occurrenceDate: '2026-03-15')
+        ->call('link', $transaction->id)
+        ->assertDispatched('transaction-saved');
+});
+
+test('cannot open for planned transaction owned by another user', function () {
+    $user = User::factory()->create();
+    $otherUser = User::factory()->create();
+    $otherAccount = Account::factory()->for($otherUser)->create();
+
+    $planned = PlannedTransaction::factory()->for($otherUser)->for($otherAccount)->noRepeat()->create([
+        'start_date' => '2026-03-15',
+    ]);
+
+    $component = Livewire::actingAs($user)
+        ->test(ReconciliationModal::class)
+        ->dispatch('open-reconciliation-modal', plannedId: $planned->id, occurrenceDate: '2026-03-15');
+
+    expect($component->get('showModal'))->toBeFalse();
+});
+
+test('cannot link transaction owned by another user', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $otherUser = User::factory()->create();
+    $otherAccount = Account::factory()->for($otherUser)->create();
+
+    $planned = PlannedTransaction::factory()->for($user)->for($account)->noRepeat()->create([
+        'amount' => 15000,
+        'direction' => TransactionDirection::Debit,
+        'start_date' => '2026-03-15',
+    ]);
+
+    $otherTransaction = Transaction::factory()->for($otherUser)->debit()->create([
+        'account_id' => $otherAccount->id,
+        'amount' => 15000,
+        'post_date' => '2026-03-15',
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(ReconciliationModal::class)
+        ->dispatch('open-reconciliation-modal', plannedId: $planned->id, occurrenceDate: '2026-03-15')
+        ->call('link', $otherTransaction->id);
+
+    expect($otherTransaction->fresh()->planned_transaction_id)->toBeNull();
+});
+
+test('edit planned dispatches edit-planned-transaction event and closes modal', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+
+    $planned = PlannedTransaction::factory()->for($user)->for($account)->noRepeat()->create([
+        'start_date' => '2026-03-15',
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(ReconciliationModal::class)
+        ->dispatch('open-reconciliation-modal', plannedId: $planned->id, occurrenceDate: '2026-03-15')
+        ->call('editPlanned')
+        ->assertDispatched('edit-planned-transaction', id: $planned->id)
+        ->assertSet('showModal', false);
+});
+
+test('suggestions include amount difference', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+
+    $planned = PlannedTransaction::factory()->for($user)->for($account)->noRepeat()->create([
+        'amount' => 10000,
+        'direction' => TransactionDirection::Debit,
+        'start_date' => '2026-03-15',
+    ]);
+
+    Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'amount' => 10500,
+        'post_date' => '2026-03-15',
+    ]);
+
+    $component = Livewire::actingAs($user)
+        ->test(ReconciliationModal::class)
+        ->dispatch('open-reconciliation-modal', plannedId: $planned->id, occurrenceDate: '2026-03-15');
+
+    $suggestions = $component->get('suggestions');
+
+    expect($suggestions)->toHaveCount(1)
+        ->and($suggestions[0]['amount_diff'])->toBe(500);
+});
+
+test('after linking suggestions are cleared and linked transaction is shown', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+
+    $planned = PlannedTransaction::factory()->for($user)->for($account)->noRepeat()->create([
+        'amount' => 15000,
+        'direction' => TransactionDirection::Debit,
+        'start_date' => '2026-03-15',
+    ]);
+
+    $transaction = Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'amount' => 15000,
+        'post_date' => '2026-03-15',
+    ]);
+
+    $component = Livewire::actingAs($user)
+        ->test(ReconciliationModal::class)
+        ->dispatch('open-reconciliation-modal', plannedId: $planned->id, occurrenceDate: '2026-03-15');
+
+    expect($component->get('suggestions'))->toHaveCount(1)
+        ->and($component->get('linkedTransaction'))->toBeNull();
+
+    $component->call('link', $transaction->id);
+
+    expect($component->get('linkedTransaction'))->not->toBeNull()
+        ->and($component->get('linkedTransaction.id'))->toBe($transaction->id)
+        ->and($component->get('suggestions'))->toBeEmpty();
+});

--- a/tests/Feature/Services/ReconciliationMatcherTest.php
+++ b/tests/Feature/Services/ReconciliationMatcherTest.php
@@ -1,0 +1,332 @@
+<?php
+
+/** @noinspection StaticClosureCanBeUsedInspection */
+
+declare(strict_types=1);
+
+use App\Enums\TransactionDirection;
+use App\Models\Account;
+use App\Models\PlannedTransaction;
+use App\Models\Transaction;
+use App\Models\User;
+use App\Services\ReconciliationMatcher;
+use Carbon\CarbonImmutable;
+
+beforeEach(function () {
+    $this->matcher = app(ReconciliationMatcher::class);
+    $this->user = User::factory()->create();
+    $this->account = Account::factory()->for($this->user)->create();
+});
+
+// ── findSuggestions ──────────────────────────────────────────────
+
+test('finds matching transaction on same account with similar amount and nearby date', function () {
+    $planned = PlannedTransaction::factory()->for($this->user)->for($this->account)->noRepeat()->create([
+        'amount' => 10000,
+        'direction' => TransactionDirection::Debit,
+        'start_date' => '2026-03-15',
+    ]);
+
+    Transaction::factory()->for($this->user)->debit()->create([
+        'account_id' => $this->account->id,
+        'amount' => 10000,
+        'post_date' => '2026-03-15',
+    ]);
+
+    $suggestions = $this->matcher->findSuggestions($planned, CarbonImmutable::parse('2026-03-15'));
+
+    expect($suggestions)->toHaveCount(1);
+});
+
+test('finds transaction within amount tolerance of 10 percent', function () {
+    $planned = PlannedTransaction::factory()->for($this->user)->for($this->account)->noRepeat()->create([
+        'amount' => 10000,
+        'direction' => TransactionDirection::Debit,
+        'start_date' => '2026-03-15',
+    ]);
+
+    Transaction::factory()->for($this->user)->debit()->create([
+        'account_id' => $this->account->id,
+        'amount' => 10900,
+        'post_date' => '2026-03-15',
+    ]);
+
+    $suggestions = $this->matcher->findSuggestions($planned, CarbonImmutable::parse('2026-03-15'));
+
+    expect($suggestions)->toHaveCount(1);
+});
+
+test('ignores transaction outside amount tolerance', function () {
+    $planned = PlannedTransaction::factory()->for($this->user)->for($this->account)->noRepeat()->create([
+        'amount' => 10000,
+        'direction' => TransactionDirection::Debit,
+        'start_date' => '2026-03-15',
+    ]);
+
+    Transaction::factory()->for($this->user)->debit()->create([
+        'account_id' => $this->account->id,
+        'amount' => 11100,
+        'post_date' => '2026-03-15',
+    ]);
+
+    $suggestions = $this->matcher->findSuggestions($planned, CarbonImmutable::parse('2026-03-15'));
+
+    expect($suggestions)->toBeEmpty();
+});
+
+test('finds transaction within date tolerance of 3 days', function () {
+    $planned = PlannedTransaction::factory()->for($this->user)->for($this->account)->noRepeat()->create([
+        'amount' => 10000,
+        'direction' => TransactionDirection::Debit,
+        'start_date' => '2026-03-15',
+    ]);
+
+    Transaction::factory()->for($this->user)->debit()->create([
+        'account_id' => $this->account->id,
+        'amount' => 10000,
+        'post_date' => '2026-03-18',
+    ]);
+
+    $suggestions = $this->matcher->findSuggestions($planned, CarbonImmutable::parse('2026-03-15'));
+
+    expect($suggestions)->toHaveCount(1);
+});
+
+test('ignores transaction outside date tolerance', function () {
+    $planned = PlannedTransaction::factory()->for($this->user)->for($this->account)->noRepeat()->create([
+        'amount' => 10000,
+        'direction' => TransactionDirection::Debit,
+        'start_date' => '2026-03-15',
+    ]);
+
+    Transaction::factory()->for($this->user)->debit()->create([
+        'account_id' => $this->account->id,
+        'amount' => 10000,
+        'post_date' => '2026-03-19',
+    ]);
+
+    $suggestions = $this->matcher->findSuggestions($planned, CarbonImmutable::parse('2026-03-15'));
+
+    expect($suggestions)->toBeEmpty();
+});
+
+test('ignores transactions on different account', function () {
+    $otherAccount = Account::factory()->for($this->user)->create();
+
+    $planned = PlannedTransaction::factory()->for($this->user)->for($this->account)->noRepeat()->create([
+        'amount' => 10000,
+        'direction' => TransactionDirection::Debit,
+        'start_date' => '2026-03-15',
+    ]);
+
+    Transaction::factory()->for($this->user)->debit()->create([
+        'account_id' => $otherAccount->id,
+        'amount' => 10000,
+        'post_date' => '2026-03-15',
+    ]);
+
+    $suggestions = $this->matcher->findSuggestions($planned, CarbonImmutable::parse('2026-03-15'));
+
+    expect($suggestions)->toBeEmpty();
+});
+
+test('ignores already linked transactions', function () {
+    $planned = PlannedTransaction::factory()->for($this->user)->for($this->account)->noRepeat()->create([
+        'amount' => 10000,
+        'direction' => TransactionDirection::Debit,
+        'start_date' => '2026-03-15',
+    ]);
+
+    $otherPlanned = PlannedTransaction::factory()->for($this->user)->for($this->account)->noRepeat()->create();
+
+    Transaction::factory()->for($this->user)->debit()->create([
+        'account_id' => $this->account->id,
+        'amount' => 10000,
+        'post_date' => '2026-03-15',
+        'planned_transaction_id' => $otherPlanned->id,
+    ]);
+
+    $suggestions = $this->matcher->findSuggestions($planned, CarbonImmutable::parse('2026-03-15'));
+
+    expect($suggestions)->toBeEmpty();
+});
+
+test('ignores transactions with wrong direction', function () {
+    $planned = PlannedTransaction::factory()->for($this->user)->for($this->account)->noRepeat()->create([
+        'amount' => 10000,
+        'direction' => TransactionDirection::Debit,
+        'start_date' => '2026-03-15',
+    ]);
+
+    Transaction::factory()->for($this->user)->credit()->create([
+        'account_id' => $this->account->id,
+        'amount' => 10000,
+        'post_date' => '2026-03-15',
+    ]);
+
+    $suggestions = $this->matcher->findSuggestions($planned, CarbonImmutable::parse('2026-03-15'));
+
+    expect($suggestions)->toBeEmpty();
+});
+
+test('returns results ordered by date proximity then amount proximity', function () {
+    $planned = PlannedTransaction::factory()->for($this->user)->for($this->account)->noRepeat()->create([
+        'amount' => 10000,
+        'direction' => TransactionDirection::Debit,
+        'start_date' => '2026-03-15',
+    ]);
+
+    $farDate = Transaction::factory()->for($this->user)->debit()->create([
+        'account_id' => $this->account->id,
+        'amount' => 10000,
+        'post_date' => '2026-03-17',
+    ]);
+
+    $exactDate = Transaction::factory()->for($this->user)->debit()->create([
+        'account_id' => $this->account->id,
+        'amount' => 10500,
+        'post_date' => '2026-03-15',
+    ]);
+
+    $suggestions = $this->matcher->findSuggestions($planned, CarbonImmutable::parse('2026-03-15'));
+
+    expect($suggestions)->toHaveCount(2)
+        ->and($suggestions->first()->id)->toBe($exactDate->id)
+        ->and($suggestions->last()->id)->toBe($farDate->id);
+});
+
+test('finds and correctly sorts transactions with negative amounts', function () {
+    $planned = PlannedTransaction::factory()->for($this->user)->for($this->account)->noRepeat()->create([
+        'amount' => 10000,
+        'direction' => TransactionDirection::Debit,
+        'start_date' => '2026-03-15',
+    ]);
+
+    $exactNegative = Transaction::factory()->for($this->user)->debit()->create([
+        'account_id' => $this->account->id,
+        'amount' => -10000,
+        'post_date' => '2026-03-15',
+    ]);
+
+    $closeNegative = Transaction::factory()->for($this->user)->debit()->create([
+        'account_id' => $this->account->id,
+        'amount' => -10500,
+        'post_date' => '2026-03-15',
+    ]);
+
+    $suggestions = $this->matcher->findSuggestions($planned, CarbonImmutable::parse('2026-03-15'));
+
+    expect($suggestions)->toHaveCount(2)
+        ->and($suggestions->first()->id)->toBe($exactNegative->id)
+        ->and($suggestions->last()->id)->toBe($closeNegative->id);
+});
+
+test('includes transactions from other users accounts are excluded', function () {
+    $otherUser = User::factory()->create();
+    $otherAccount = Account::factory()->for($otherUser)->create();
+
+    $planned = PlannedTransaction::factory()->for($this->user)->for($this->account)->noRepeat()->create([
+        'amount' => 10000,
+        'direction' => TransactionDirection::Debit,
+        'start_date' => '2026-03-15',
+    ]);
+
+    Transaction::factory()->for($otherUser)->debit()->create([
+        'account_id' => $otherAccount->id,
+        'amount' => 10000,
+        'post_date' => '2026-03-15',
+    ]);
+
+    $suggestions = $this->matcher->findSuggestions($planned, CarbonImmutable::parse('2026-03-15'));
+
+    expect($suggestions)->toBeEmpty();
+});
+
+// ── link ─────────────────────────────────────────────────────────
+
+test('link sets planned_transaction_id on the transaction', function () {
+    $planned = PlannedTransaction::factory()->for($this->user)->for($this->account)->noRepeat()->create();
+
+    $transaction = Transaction::factory()->for($this->user)->debit()->create([
+        'account_id' => $this->account->id,
+    ]);
+
+    $this->matcher->link($transaction, $planned);
+
+    expect($transaction->fresh()->planned_transaction_id)->toBe($planned->id);
+});
+
+test('link overwrites existing planned_transaction_id', function () {
+    $planned = PlannedTransaction::factory()->for($this->user)->for($this->account)->noRepeat()->create();
+    $otherPlanned = PlannedTransaction::factory()->for($this->user)->for($this->account)->noRepeat()->create();
+
+    $transaction = Transaction::factory()->for($this->user)->debit()->create([
+        'account_id' => $this->account->id,
+        'planned_transaction_id' => $otherPlanned->id,
+    ]);
+
+    $this->matcher->link($transaction, $planned);
+
+    expect($transaction->fresh()->planned_transaction_id)->toBe($planned->id);
+});
+
+// ── unlink ───────────────────────────────────────────────────────
+
+test('unlink clears planned_transaction_id on the transaction', function () {
+    $planned = PlannedTransaction::factory()->for($this->user)->for($this->account)->noRepeat()->create();
+
+    $transaction = Transaction::factory()->for($this->user)->debit()->create([
+        'account_id' => $this->account->id,
+        'planned_transaction_id' => $planned->id,
+    ]);
+
+    $this->matcher->unlink($transaction);
+
+    expect($transaction->fresh()->planned_transaction_id)->toBeNull();
+});
+
+test('unlink on already unlinked transaction does nothing', function () {
+    $transaction = Transaction::factory()->for($this->user)->debit()->create([
+        'account_id' => $this->account->id,
+        'planned_transaction_id' => null,
+    ]);
+
+    $this->matcher->unlink($transaction);
+
+    expect($transaction->fresh()->planned_transaction_id)->toBeNull();
+});
+
+// ── findLinkedForOccurrence ──────────────────────────────────────
+
+test('findLinkedForOccurrence returns linked transaction near occurrence date', function () {
+    $planned = PlannedTransaction::factory()->for($this->user)->for($this->account)->noRepeat()->create([
+        'start_date' => '2026-03-15',
+    ]);
+
+    $linked = Transaction::factory()->for($this->user)->debit()->create([
+        'account_id' => $this->account->id,
+        'post_date' => '2026-03-15',
+        'planned_transaction_id' => $planned->id,
+    ]);
+
+    $result = $this->matcher->findLinkedForOccurrence($planned, CarbonImmutable::parse('2026-03-15'));
+
+    expect($result)->not->toBeNull()
+        ->and($result->id)->toBe($linked->id);
+});
+
+test('findLinkedForOccurrence returns null when linked transaction is outside date tolerance', function () {
+    $planned = PlannedTransaction::factory()->for($this->user)->for($this->account)->noRepeat()->create([
+        'start_date' => '2026-03-15',
+    ]);
+
+    Transaction::factory()->for($this->user)->debit()->create([
+        'account_id' => $this->account->id,
+        'post_date' => '2026-04-15',
+        'planned_transaction_id' => $planned->id,
+    ]);
+
+    $result = $this->matcher->findLinkedForOccurrence($planned, CarbonImmutable::parse('2026-03-15'));
+
+    expect($result)->toBeNull();
+});


### PR DESCRIPTION
## Summary

- Add `ReconciliationMatcher` service with configurable tolerance matching (±10% amount, ±3 days date) to find, link, and unlink actual transactions against planned transaction occurrences
- Enhance `CalendarView` to compute reconciliation status (reconciled/suggested/unreconciled) per planned occurrence using zero additional queries (in-memory matching from already-fetched data)
- Add `ReconciliationModal` Livewire component for manually linking/unlinking actual transactions to planned occurrences, with suggested matches and amount difference indicators
- Update calendar visual indicators: checkmark icon (reconciled), yellow dot (suggested match available), clock icon (unreconciled)

## Test plan

- [x] `ReconciliationMatcherTest` — 16 tests covering suggestion matching, tolerance boundaries, link/unlink, ordering, user isolation
- [x] `CalendarViewTest` — 8 new tests for reconciliation status on planned entries (reconciled, suggested, unreconciled, tolerance checks)
- [x] `ReconciliationModalTest` — 12 tests covering open, link, unlink, user authorization, event dispatch, state transitions
- [x] `op ci` passes (lint, PHPStan, 771 tests)

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)