### PR TITLE
feat: [125] Planned transfers backend and UI support

### DIFF
--- a/app/Livewire/CalendarView.php
+++ b/app/Livewire/CalendarView.php
@@ -110,7 +110,7 @@ final class CalendarView extends Component
                     'direction' => $planned->direction->value,
                     'type' => 'planned',
                     'source' => 'planned',
-                    'isTransfer' => false,
+                    'isTransfer' => $planned->transfer_to_account_id !== null,
                     'planned_transaction_id' => $planned->id,
                     'reconciliation_status' => $reconciliationResult['status'],
                     'linked_transaction_id' => $reconciliationResult['linked_transaction_id'],

--- a/app/Livewire/TransactionModal.php
+++ b/app/Livewire/TransactionModal.php
@@ -140,9 +140,15 @@ final class TransactionModal extends Component
 
         $this->editingPlannedTransactionId = $planned->id;
         $this->mode = 'plan';
-        $this->transactionType = $planned->direction === TransactionDirection::Debit
-            ? 'expense'
-            : 'income';
+
+        if ($planned->transfer_to_account_id !== null) {
+            $this->transactionType = 'transfer';
+            $this->transferToAccountId = $planned->transfer_to_account_id;
+        } else {
+            $this->transactionType = $planned->direction === TransactionDirection::Debit
+                ? 'expense'
+                : 'income';
+        }
 
         $dollars = number_format($planned->amount / 100, 2, '.', '');
         $description = $planned->description ?? '';
@@ -350,14 +356,20 @@ final class TransactionModal extends Component
             return false;
         }
 
+        $direction = match ($this->transactionType) {
+            'income' => TransactionDirection::Credit,
+            default => TransactionDirection::Debit,
+        };
+
         PlannedTransaction::query()->create([
             'user_id' => auth()->id(),
             'account_id' => $this->accountId,
+            'transfer_to_account_id' => $this->transactionType === 'transfer'
+                ? $this->transferToAccountId
+                : null,
             'category_id' => $this->categoryId,
             'amount' => $parsed->amount,
-            'direction' => $this->transactionType === 'expense'
-                ? TransactionDirection::Debit
-                : TransactionDirection::Credit,
+            'direction' => $direction,
             'description' => $parsed->description,
             'start_date' => $this->date,
             'frequency' => RecurrenceFrequency::from($this->frequency),
@@ -386,13 +398,19 @@ final class TransactionModal extends Component
             return false;
         }
 
+        $direction = match ($this->transactionType) {
+            'income' => TransactionDirection::Credit,
+            default => TransactionDirection::Debit,
+        };
+
         $planned->update([
             'account_id' => $this->accountId,
+            'transfer_to_account_id' => $this->transactionType === 'transfer'
+                ? $this->transferToAccountId
+                : null,
             'category_id' => $this->categoryId,
             'amount' => $parsed->amount,
-            'direction' => $this->transactionType === 'expense'
-                ? TransactionDirection::Debit
-                : TransactionDirection::Credit,
+            'direction' => $direction,
             'description' => $parsed->description,
             'start_date' => $this->date,
             'frequency' => RecurrenceFrequency::from($this->frequency),
@@ -554,7 +572,7 @@ final class TransactionModal extends Component
         ];
 
         if ($this->mode === 'plan') {
-            $rules['transactionType'] = ['required', Rule::in(['expense', 'income'])];
+            $rules['transactionType'] = ['required', Rule::in(['expense', 'income', 'transfer'])];
             $rules['frequency'] = ['required', Rule::in(array_column(RecurrenceFrequency::cases(), 'value'))];
             $rules['untilType'] = ['required', Rule::in(['always', 'until-date'])];
             $rules['untilDate'] = $this->untilType === 'until-date'

--- a/app/Models/PlannedTransaction.php
+++ b/app/Models/PlannedTransaction.php
@@ -19,6 +19,7 @@ use Illuminate\Support\Collection;
  * @property int $id
  * @property int $user_id
  * @property int $account_id
+ * @property int|null $transfer_to_account_id
  * @property int|null $category_id
  * @property int $amount
  * @property TransactionDirection $direction
@@ -42,6 +43,7 @@ final class PlannedTransaction extends Model
     protected $fillable = [
         'user_id',
         'account_id',
+        'transfer_to_account_id',
         'category_id',
         'amount',
         'direction',
@@ -63,6 +65,12 @@ final class PlannedTransaction extends Model
     public function account(): BelongsTo
     {
         return $this->belongsTo(Account::class);
+    }
+
+    /** @return BelongsTo<Account, $this> */
+    public function transferToAccount(): BelongsTo
+    {
+        return $this->belongsTo(Account::class, 'transfer_to_account_id');
     }
 
     /** @return BelongsTo<Category, $this> */

--- a/database/factories/PlannedTransactionFactory.php
+++ b/database/factories/PlannedTransactionFactory.php
@@ -73,4 +73,14 @@ final class PlannedTransactionFactory extends Factory
             'is_active' => false,
         ]);
     }
+
+    public function transfer(): self
+    {
+        return $this->state(fn (array $attributes) => [
+            'transfer_to_account_id' => Account::factory()->for(
+                User::find($attributes['user_id'])
+            ),
+            'direction' => TransactionDirection::Debit,
+        ]);
+    }
 }

--- a/database/migrations/2026_03_29_063018_add_transfer_to_account_id_to_planned_transactions.php
+++ b/database/migrations/2026_03_29_063018_add_transfer_to_account_id_to_planned_transactions.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('planned_transactions', function (Blueprint $table) {
+            $table->foreignId('transfer_to_account_id')
+                ->nullable()
+                ->after('account_id')
+                ->constrained('accounts')
+                ->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('planned_transactions', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('transfer_to_account_id');
+        });
+    }
+};

--- a/tests/Feature/Livewire/TransactionModalTest.php
+++ b/tests/Feature/Livewire/TransactionModalTest.php
@@ -906,21 +906,30 @@ test('plan mode validates until_date required when until-date type selected', fu
         ->assertHasErrors(['untilDate']);
 });
 
-test('plan mode rejects transfer transaction type via validation', function () {
+test('plan mode allows transfer transaction type', function () {
     $user = User::factory()->create();
-    $account = Account::factory()->for($user)->create();
+    $fromAccount = Account::factory()->for($user)->create();
+    $toAccount = Account::factory()->for($user)->create();
 
     Livewire::actingAs($user)
         ->test(TransactionModal::class)
         ->dispatch('open-transaction-modal', date: '2026-03-15')
         ->set('mode', 'plan')
         ->set('transactionType', 'transfer')
-        ->set('descriptionInput', '500 transfer')
-        ->set('accountId', $account->id)
+        ->set('descriptionInput', '500 monthly savings')
+        ->set('accountId', $fromAccount->id)
+        ->set('transferToAccountId', $toAccount->id)
         ->call('save')
-        ->assertHasErrors(['transactionType']);
+        ->assertHasNoErrors()
+        ->assertSet('showModal', false);
 
-    expect(PlannedTransaction::query()->where('user_id', $user->id)->count())->toBe(0);
+    $planned = PlannedTransaction::query()->where('user_id', $user->id)->first();
+    expect($planned)
+        ->direction->toBe(TransactionDirection::Debit)
+        ->amount->toBe(50000)
+        ->account_id->toBe($fromAccount->id)
+        ->transfer_to_account_id->toBe($toAccount->id)
+        ->description->toBe('monthly savings');
 });
 
 test('plan toggle hidden for transfers', function () {
@@ -972,7 +981,7 @@ test('editing planned transaction enforces plan validation even when mode is tam
         ->test(TransactionModal::class)
         ->dispatch('edit-planned-transaction', id: $planned->id)
         ->set('mode', 'enter')
-        ->set('transactionType', 'transfer')
+        ->set('transactionType', 'invalid-type')
         ->set('frequency', 'invalid-frequency')
         ->call('save')
         ->assertHasErrors(['transactionType', 'frequency']);
@@ -1043,4 +1052,96 @@ test('plan mode resets form after save', function () {
         ->assertSet('frequency', RecurrenceFrequency::EveryMonth->value)
         ->assertSet('untilType', 'always')
         ->assertSet('untilDate', null);
+});
+
+// ── Planned Transfers (#125) ────────────────────────────────────
+
+test('planned transfer requires transfer_to_account_id', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('open-transaction-modal', date: '2026-03-15')
+        ->set('mode', 'plan')
+        ->set('transactionType', 'transfer')
+        ->set('descriptionInput', '500 savings')
+        ->set('accountId', $account->id)
+        ->set('transferToAccountId', null)
+        ->call('save')
+        ->assertHasErrors(['transferToAccountId']);
+});
+
+test('planned transfer cannot use same account for both sides', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('open-transaction-modal', date: '2026-03-15')
+        ->set('mode', 'plan')
+        ->set('transactionType', 'transfer')
+        ->set('descriptionInput', '500 savings')
+        ->set('accountId', $account->id)
+        ->set('transferToAccountId', $account->id)
+        ->call('save')
+        ->assertHasErrors(['transferToAccountId']);
+});
+
+test('editing planned transfer opens with pre-filled transfer data', function () {
+    $user = User::factory()->create();
+    $fromAccount = Account::factory()->for($user)->create();
+    $toAccount = Account::factory()->for($user)->create();
+
+    $planned = PlannedTransaction::factory()->for($user)->create([
+        'account_id' => $fromAccount->id,
+        'transfer_to_account_id' => $toAccount->id,
+        'amount' => 50000,
+        'direction' => TransactionDirection::Debit,
+        'description' => 'monthly savings',
+        'start_date' => '2026-04-01',
+        'frequency' => RecurrenceFrequency::EveryMonth,
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('edit-planned-transaction', id: $planned->id)
+        ->assertSet('showModal', true)
+        ->assertSet('mode', 'plan')
+        ->assertSet('transactionType', 'transfer')
+        ->assertSet('accountId', $fromAccount->id)
+        ->assertSet('transferToAccountId', $toAccount->id)
+        ->assertSet('descriptionInput', '500.00 monthly savings');
+});
+
+test('updating planned transfer saves both account ids', function () {
+    $user = User::factory()->create();
+    $fromAccount = Account::factory()->for($user)->create();
+    $toAccount = Account::factory()->for($user)->create();
+    $newToAccount = Account::factory()->for($user)->create();
+
+    $planned = PlannedTransaction::factory()->for($user)->create([
+        'account_id' => $fromAccount->id,
+        'transfer_to_account_id' => $toAccount->id,
+        'amount' => 50000,
+        'direction' => TransactionDirection::Debit,
+        'description' => 'savings',
+        'start_date' => '2026-04-01',
+        'frequency' => RecurrenceFrequency::EveryMonth,
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('edit-planned-transaction', id: $planned->id)
+        ->set('transferToAccountId', $newToAccount->id)
+        ->set('descriptionInput', '750 updated savings')
+        ->call('save')
+        ->assertHasNoErrors()
+        ->assertSet('showModal', false);
+
+    $planned->refresh();
+    expect($planned)
+        ->transfer_to_account_id->toBe($newToAccount->id)
+        ->amount->toBe(75000)
+        ->description->toBe('updated savings');
 });


### PR DESCRIPTION
## Summary
Closes #125

- Adds `transfer_to_account_id` nullable foreign key to `planned_transactions` table
- Updates `PlannedTransaction` model with new fillable field and `transferToAccount()` relationship
- Updates `TransactionModal` component to support creating, editing, and validating planned transfers
- Updates `CalendarView` to detect and display planned transfers with the transfer color styling
- Adds `transfer()` factory state to `PlannedTransactionFactory`

## Test plan
- [x] 59 TransactionModal tests pass (4 new planned transfer tests added)
- [ ] Verify planned transfer creation via UI (plan mode + transfer type)
- [ ] Verify planned transfer editing loads both account IDs
- [ ] Verify planned transfer displays on calendar with transfer styling
- [ ] Verify existing planned expenses/income unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)