### PR TITLE
feat: [118] Replace transaction type selector buttons with dropdown

### DIFF
--- a/resources/views/livewire/transaction-modal.blade.php
+++ b/resources/views/livewire/transaction-modal.blade.php
@@ -1,33 +1,54 @@
-@php use App\Enums\RecurrenceFrequency;use Carbon\CarbonImmutable; @endphp
+@php
+    use App\Enums\RecurrenceFrequency;
+    use Carbon\CarbonImmutable;
+
+    $typeColor = match($transactionType) {
+        'expense' => 'text-red-600 dark:text-red-400',
+        'income' => 'text-green-600 dark:text-green-400',
+        'transfer' => 'text-blue-600 dark:text-blue-400',
+        default => '',
+    };
+@endphp
 <div>
     <flux:modal wire:model="showModal" class="md:w-lg">
         <form wire:submit="save" class="space-y-6">
             <div class="flex items-center justify-between">
-                <flux:heading size="lg">
-                    @if($editingPlannedTransactionId)
-                        @if($transactionType === 'expense')
-                            {{ __('Edit Planned Expense') }}
-                        @else
-                            {{ __('Edit Planned Income') }}
-                        @endif
-                    @elseif($editingTransactionId)
+                @if($isBasiqTransaction || $editingTransactionId || $editingPlannedTransactionId)
+                    <flux:heading size="lg" class="{{ $typeColor }}">
                         @if($transactionType === 'transfer')
-                            {{ __('Edit Transfer') }}
-                        @elseif($transactionType === 'expense')
-                            {{ __('Edit Expense') }}
+                            {{ __('Between Accounts') }}
+                        @elseif($transactionType === 'income')
+                            {{ __('Income') }}
                         @else
-                            {{ __('Edit Income') }}
+                            {{ __('Expense') }}
                         @endif
-                    @else
-                        @if($transactionType === 'transfer')
-                            {{ __('Add Transfer') }}
-                        @elseif($transactionType === 'expense')
-                            {{ __('Add Expense') }}
-                        @else
-                            {{ __('Add Income') }}
-                        @endif
-                    @endif
-                </flux:heading>
+                    </flux:heading>
+                @else
+                    <flux:dropdown>
+                        <flux:button variant="ghost" class="text-lg! font-semibold! {{ $typeColor }}" icon:trailing="chevron-down" type="button">
+                            @if($transactionType === 'transfer')
+                                {{ __('transfer between accounts') }}
+                            @elseif($transactionType === 'income')
+                                {{ __('income') }}
+                            @else
+                                {{ __('expense') }}
+                            @endif
+                        </flux:button>
+
+                        <flux:menu>
+                            <flux:menu.item wire:click="$set('transactionType', 'expense')" class="text-red-600 dark:text-red-400">
+                                {{ __('expense') }}
+                            </flux:menu.item>
+                            <flux:menu.item wire:click="$set('transactionType', 'income')" class="text-green-600 dark:text-green-400">
+                                {{ __('income') }}
+                            </flux:menu.item>
+                            <flux:menu.item wire:click="$set('transactionType', 'transfer')" class="text-blue-600 dark:text-blue-400">
+                                {{ __('transfer between accounts') }}
+                            </flux:menu.item>
+                        </flux:menu>
+                    </flux:dropdown>
+                @endif
+
                 <div class="flex items-center gap-2">
                     @if($isBasiqTransaction)
                         <flux:badge color="blue" size="sm" icon="cloud-arrow-down">
@@ -40,36 +61,6 @@
                         </flux:badge>
                     @endif
                 </div>
-            </div>
-
-            <div class="flex gap-2">
-                <flux:button
-                        variant="{{ $transactionType === 'expense' ? 'primary' : 'ghost' }}"
-                        wire:click="$set('transactionType', 'expense')"
-                        type="button"
-                        class="flex-1"
-                        :disabled="$isBasiqTransaction || $editingPlannedTransactionId"
-                >
-                    {{ __('Expense') }}
-                </flux:button>
-                <flux:button
-                        variant="{{ $transactionType === 'income' ? 'primary' : 'ghost' }}"
-                        wire:click="$set('transactionType', 'income')"
-                        type="button"
-                        class="flex-1"
-                        :disabled="$isBasiqTransaction || $editingPlannedTransactionId"
-                >
-                    {{ __('Income') }}
-                </flux:button>
-                <flux:button
-                        variant="{{ $transactionType === 'transfer' ? 'primary' : 'ghost' }}"
-                        wire:click="$set('transactionType', 'transfer'); $set('mode', 'enter')"
-                        type="button"
-                        class="flex-1"
-                        :disabled="$isBasiqTransaction || $editingPlannedTransactionId"
-                >
-                    {{ __('Transfer') }}
-                </flux:button>
             </div>
 
             @if(!$editingTransactionId && !$editingPlannedTransactionId && $transactionType !== 'transfer')
@@ -233,7 +224,9 @@
                 <flux:spacer/>
                 <flux:button type="submit" variant="primary">
                     @if($editingPlannedTransactionId)
-                        @if($transactionType === 'expense')
+                        @if($transactionType === 'transfer')
+                            {{ __('Update planned transfer') }}
+                        @elseif($transactionType === 'expense')
                             {{ __('Update planned expense') }}
                         @else
                             {{ __('Update planned income') }}
@@ -247,7 +240,9 @@
                             {{ __('Update income') }}
                         @endif
                     @elseif($mode === 'plan')
-                        @if($transactionType === 'expense')
+                        @if($transactionType === 'transfer')
+                            {{ __('Plan transfer') }}
+                        @elseif($transactionType === 'expense')
                             {{ __('Plan expense') }}
                         @else
                             {{ __('Plan income') }}

--- a/tests/Feature/Livewire/TransactionModalTest.php
+++ b/tests/Feature/Livewire/TransactionModalTest.php
@@ -1114,6 +1114,32 @@ test('editing planned transfer opens with pre-filled transfer data', function ()
         ->assertSet('descriptionInput', '500.00 monthly savings');
 });
 
+// ── Type Selector UI (#118) ────────────────────────────────────
+
+test('dropdown type selector shown when adding new transaction', function () {
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('open-transaction-modal', date: '2026-03-15')
+        ->assertSeeHtml("\$set('transactionType', 'expense')")
+        ->assertSeeHtml("\$set('transactionType', 'income')")
+        ->assertSeeHtml("\$set('transactionType', 'transfer')");
+});
+
+test('static heading shown when editing transaction', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $transaction = Transaction::factory()->for($user)->for($account)->manual()->create();
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('edit-transaction', id: $transaction->id)
+        ->assertDontSeeHtml("\$set('transactionType', 'expense')")
+        ->assertDontSeeHtml("\$set('transactionType', 'income')")
+        ->assertDontSeeHtml("\$set('transactionType', 'transfer')");
+});
+
 test('updating planned transfer saves both account ids', function () {
     $user = User::factory()->create();
     $fromAccount = Account::factory()->for($user)->create();


### PR DESCRIPTION
## Summary
- Replace the 3 horizontal Expense/Income/Transfer buttons with a `<flux:dropdown>` embedded in the modal heading area
- Dropdown trigger displays the current type as a ghost button styled like a heading with a chevron-down icon
- Menu items use lowercase labels ("expense", "income", "transfer between accounts") matching the HoneyMoney reference design
- When editing existing, planned, or synced transactions, the dropdown falls back to a static `<flux:heading>` (type shouldn't change for existing records)
- Removes the old Transfer button hack that forced `$set('mode', 'enter')` — no longer needed since #125 added planned transfer support

Closes #118

## Test plan
- [x] `op test.filter TransactionModal` — all 59 tests pass
- [x] `op ci` — full CI green (777 passed, Pint clean, PHPStan clean)
- [ ] Visual check: open modal from calendar, verify dropdown appears with chevron
- [ ] Click dropdown to see menu options, select each type and verify form updates
- [ ] Edit an existing transaction — verify static heading shown (no dropdown)
- [ ] Edit a synced Basiq transaction — verify static heading shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)