### PR TITLE
feat: [119] Transaction modal header background colors by type

### DIFF
--- a/resources/views/livewire/transaction-modal.blade.php
+++ b/resources/views/livewire/transaction-modal.blade.php
@@ -5,61 +5,84 @@
     $typeColor = match($transactionType) {
         'expense' => 'text-red-600 dark:text-red-400',
         'income' => 'text-green-600 dark:text-green-400',
-        'transfer' => 'text-blue-600 dark:text-blue-400',
+        'transfer' => 'text-amber-600 dark:text-amber-400',
+        default => '',
+    };
+
+    $headerBg = match($transactionType) {
+        'expense' => 'bg-red-50 dark:bg-red-950/30',
+        'income' => 'bg-green-50 dark:bg-green-950/30',
+        'transfer' => 'bg-amber-50 dark:bg-amber-950/30',
+        default => '',
+    };
+
+    $borderColor = match($transactionType) {
+        'expense' => 'border-l-4 border-l-red-500',
+        'income' => 'border-l-4 border-l-green-500',
+        'transfer' => 'border-l-4 border-l-amber-500',
+        default => '',
+    };
+
+    $buttonClasses = match($transactionType) {
+        'expense' => 'bg-red-600! hover:bg-red-700! text-white!',
+        'income' => 'bg-green-600! hover:bg-green-700! text-white!',
+        'transfer' => 'bg-amber-600! hover:bg-amber-700! text-white!',
         default => '',
     };
 @endphp
 <div>
-    <flux:modal wire:model="showModal" class="md:w-lg">
+    <flux:modal wire:model="showModal" class="md:w-lg {{ $borderColor }}">
         <form wire:submit="save" class="space-y-6">
-            <div class="flex items-center justify-between">
-                @if($isBasiqTransaction || $editingTransactionId || $editingPlannedTransactionId)
-                    <flux:heading size="lg" class="{{ $typeColor }}">
-                        @if($transactionType === 'transfer')
-                            {{ __('Between Accounts') }}
-                        @elseif($transactionType === 'income')
-                            {{ __('Income') }}
-                        @else
-                            {{ __('Expense') }}
-                        @endif
-                    </flux:heading>
-                @else
-                    <flux:dropdown>
-                        <flux:button variant="ghost" class="text-lg! font-semibold! {{ $typeColor }}" icon:trailing="chevron-down" type="button">
+            <div class="-mx-6 -mt-6 mb-6 rounded-t-xl px-6 py-4 {{ $headerBg }}">
+                <div class="flex items-center justify-between">
+                    @if($isBasiqTransaction || $editingTransactionId || $editingPlannedTransactionId)
+                        <flux:heading size="lg" class="{{ $typeColor }}">
                             @if($transactionType === 'transfer')
-                                {{ __('transfer between accounts') }}
+                                {{ __('Between Accounts') }}
                             @elseif($transactionType === 'income')
-                                {{ __('income') }}
+                                {{ __('Income') }}
                             @else
-                                {{ __('expense') }}
+                                {{ __('Expense') }}
                             @endif
-                        </flux:button>
+                        </flux:heading>
+                    @else
+                        <flux:dropdown>
+                            <flux:button variant="ghost" class="text-lg! font-semibold! {{ $typeColor }}" icon:trailing="chevron-down" type="button">
+                                @if($transactionType === 'transfer')
+                                    {{ __('transfer between accounts') }}
+                                @elseif($transactionType === 'income')
+                                    {{ __('income') }}
+                                @else
+                                    {{ __('expense') }}
+                                @endif
+                            </flux:button>
 
-                        <flux:menu>
-                            <flux:menu.item wire:click="$set('transactionType', 'expense')" class="text-red-600 dark:text-red-400">
-                                {{ __('expense') }}
-                            </flux:menu.item>
-                            <flux:menu.item wire:click="$set('transactionType', 'income')" class="text-green-600 dark:text-green-400">
-                                {{ __('income') }}
-                            </flux:menu.item>
-                            <flux:menu.item wire:click="$set('transactionType', 'transfer')" class="text-blue-600 dark:text-blue-400">
-                                {{ __('transfer between accounts') }}
-                            </flux:menu.item>
-                        </flux:menu>
-                    </flux:dropdown>
-                @endif
+                            <flux:menu>
+                                <flux:menu.item wire:click="$set('transactionType', 'expense')" class="text-red-600 dark:text-red-400">
+                                    {{ __('expense') }}
+                                </flux:menu.item>
+                                <flux:menu.item wire:click="$set('transactionType', 'income')" class="text-green-600 dark:text-green-400">
+                                    {{ __('income') }}
+                                </flux:menu.item>
+                                <flux:menu.item wire:click="$set('transactionType', 'transfer')" class="text-amber-600 dark:text-amber-400">
+                                    {{ __('transfer between accounts') }}
+                                </flux:menu.item>
+                            </flux:menu>
+                        </flux:dropdown>
+                    @endif
 
-                <div class="flex items-center gap-2">
-                    @if($isBasiqTransaction)
-                        <flux:badge color="blue" size="sm" icon="cloud-arrow-down">
-                            {{ __('Synced from bank') }}
-                        </flux:badge>
-                    @endif
-                    @if($date)
-                        <flux:badge color="zinc">
-                            {{ CarbonImmutable::parse($date)->format('D j M Y') }}
-                        </flux:badge>
-                    @endif
+                    <div class="flex items-center gap-2">
+                        @if($isBasiqTransaction)
+                            <flux:badge color="blue" size="sm" icon="cloud-arrow-down">
+                                {{ __('Synced from bank') }}
+                            </flux:badge>
+                        @endif
+                        @if($date)
+                            <flux:badge color="zinc">
+                                {{ CarbonImmutable::parse($date)->format('D j M Y') }}
+                            </flux:badge>
+                        @endif
+                    </div>
                 </div>
             </div>
 
@@ -222,7 +245,7 @@
                     </flux:button>
                 @endif
                 <flux:spacer/>
-                <flux:button type="submit" variant="primary">
+                <flux:button type="submit" variant="primary" class="{{ $buttonClasses }}">
                     @if($editingPlannedTransactionId)
                         @if($transactionType === 'transfer')
                             {{ __('Update planned transfer') }}

--- a/tests/Feature/Livewire/TransactionModalTest.php
+++ b/tests/Feature/Livewire/TransactionModalTest.php
@@ -780,7 +780,8 @@ test('plan mode saves to planned_transactions table', function () {
         ->assertSet('showModal', false)
         ->assertHasNoErrors();
 
-    expect(PlannedTransaction::query()->where('user_id', $user->id)->count())->toBe(1)
+    expect(PlannedTransaction::query()->where('user_id', $user->id)->count())
+        ->toBe(1)
         ->and(Transaction::query()->where('user_id', $user->id)->count())->toBe($transactionCountBefore);
 });
 
@@ -1170,4 +1171,79 @@ test('updating planned transfer saves both account ids', function () {
         ->transfer_to_account_id->toBe($newToAccount->id)
         ->amount->toBe(75000)
         ->description->toBe('updated savings');
+});
+
+// ── Header Colors (#119) ──────────────────────────────────────
+
+test('expense header renders red background', function () {
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('open-transaction-modal', date: '2026-03-15')
+        ->set('transactionType', 'expense')
+        ->assertSeeHtml('bg-red-50')
+        ->assertSeeHtml('border-l-red-500')
+        ->assertSeeHtml('bg-red-600!');
+});
+
+test('income header renders green background', function () {
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('open-transaction-modal', date: '2026-03-15')
+        ->set('transactionType', 'income')
+        ->assertSeeHtml('bg-green-50')
+        ->assertSeeHtml('border-l-green-500')
+        ->assertSeeHtml('bg-green-600!');
+});
+
+test('transfer header renders amber background', function () {
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('open-transaction-modal', date: '2026-03-15')
+        ->set('transactionType', 'transfer')
+        ->assertSeeHtml('bg-amber-50')
+        ->assertSeeHtml('border-l-amber-500')
+        ->assertSeeHtml('bg-amber-600!');
+});
+
+test('transfer uses amber not blue', function () {
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('open-transaction-modal', date: '2026-03-15')
+        ->set('transactionType', 'transfer')
+        ->assertSeeHtml('text-amber-600')
+        ->assertDontSeeHtml('text-blue-600');
+});
+
+test('submit button has type-specific classes', function () {
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('open-transaction-modal', date: '2026-03-15')
+        ->set('transactionType', 'expense')
+        ->assertSeeHtml('bg-red-600!')
+        ->assertSeeHtml('hover:bg-red-700!')
+        ->assertSeeHtml('text-white!');
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('open-transaction-modal', date: '2026-03-15')
+        ->set('transactionType', 'income')
+        ->assertSeeHtml('bg-green-600!')
+        ->assertSeeHtml('hover:bg-green-700!');
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('open-transaction-modal', date: '2026-03-15')
+        ->set('transactionType', 'transfer')
+        ->assertSeeHtml('bg-amber-600!')
+        ->assertSeeHtml('hover:bg-amber-700!');
 });


### PR DESCRIPTION
## Summary

- Added type-specific **header background colors** (red/green/amber) to the transaction modal for expense/income/transfer
- Added a **colored left border accent** (`border-l-4`) to the modal panel
- **Submit button** now matches the transaction type color instead of generic primary blue
- **Corrected transfer color** from blue to amber to match design specs
- Added **5 new tests** verifying header backgrounds, border accents, button colors, and a blue-to-amber regression guard

Closes #119

## Test plan

- [x] `op test.filter TransactionModalTest` — 66 passed (218 assertions)
- [x] `op lint.dirty` — pass
- [x] `op ci` — 784 passed, 0 PHPStan errors
- [ ] Visual check: open modal in each mode (expense/income/transfer) and verify colors match reference designs

🤖 Generated with [Claude Code](https://claude.com/claude-code)