### PR TITLE
fix: [120] Transaction modal Enter/Plan auto-selection and visibility for all types

### DIFF
--- a/CLAUDE.local.md
+++ b/CLAUDE.local.md
@@ -58,6 +58,16 @@ This is non-negotiable. There are zero exceptions to this rule.
 
 ---
 
+## GitHub Account
+
+The repo belongs to `robwilde`. Before running `gh` commands, ensure the correct account is active:
+
+```bash
+gh auth switch --user robwilde
+```
+
+---
+
 ## GitHub Project Board
 
 Track project tasks and roadmap at: https://github.com/users/robwilde/projects/2

--- a/app/Livewire/TransactionModal.php
+++ b/app/Livewire/TransactionModal.php
@@ -13,6 +13,7 @@ use App\Models\Category;
 use App\Models\PlannedTransaction;
 use App\Models\Transaction;
 use App\Support\AmountParser;
+use Carbon\CarbonImmutable;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\Rule;
 use Illuminate\View\View;
@@ -59,6 +60,7 @@ final class TransactionModal extends Component
     {
         $this->resetForm();
         $this->date = $date;
+        $this->mode = CarbonImmutable::parse($date)->isFuture() ? 'plan' : 'enter';
         $this->showModal = true;
     }
 

--- a/resources/views/livewire/transaction-modal.blade.php
+++ b/resources/views/livewire/transaction-modal.blade.php
@@ -86,7 +86,7 @@
                 </div>
             </div>
 
-            @if(!$editingTransactionId && !$editingPlannedTransactionId && $transactionType !== 'transfer')
+            @if(!$editingTransactionId && !$editingPlannedTransactionId)
                 <div class="flex items-center justify-center gap-4">
                     <flux:text size="sm" class="text-zinc-500">{{ __('Enter vs Plan') }}</flux:text>
                     <div class="flex gap-1">

--- a/tests/Feature/Livewire/TransactionModalTest.php
+++ b/tests/Feature/Livewire/TransactionModalTest.php
@@ -933,14 +933,52 @@ test('plan mode allows transfer transaction type', function () {
         ->description->toBe('monthly savings');
 });
 
-test('plan toggle hidden for transfers', function () {
+test('plan toggle visible for transfers', function () {
     $user = User::factory()->create();
 
     Livewire::actingAs($user)
         ->test(TransactionModal::class)
         ->dispatch('open-transaction-modal', date: '2026-03-15')
         ->set('transactionType', 'transfer')
-        ->assertDontSee(__('Enter vs Plan'));
+        ->assertSee(__('Enter vs Plan'));
+});
+
+test('auto-selects enter mode for today date', function () {
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('open-transaction-modal', date: today()->format('Y-m-d'))
+        ->assertSet('mode', 'enter');
+});
+
+test('auto-selects enter mode for past date', function () {
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('open-transaction-modal', date: today()->subDay()->format('Y-m-d'))
+        ->assertSet('mode', 'enter');
+});
+
+test('auto-selects plan mode for future date', function () {
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('open-transaction-modal', date: today()->addDay()->format('Y-m-d'))
+        ->assertSet('mode', 'plan');
+});
+
+test('user can manually override auto-selected mode', function () {
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('open-transaction-modal', date: today()->addDay()->format('Y-m-d'))
+        ->assertSet('mode', 'plan')
+        ->set('mode', 'enter')
+        ->assertSet('mode', 'enter');
 });
 
 test('plan toggle hidden when editing', function () {


### PR DESCRIPTION
## Summary

Fixes #120 — Two bugs in the transaction modal's Enter/Plan toggle:

- **Auto-selection by date**: Clicking a future date now defaults to "Plan" mode; today/past dates default to "Enter". Uses `CarbonImmutable::parse($date)->isFuture()` in `openForAdd()`
- **Toggle visible for transfers**: Removed the `$transactionType !== 'transfer'` exclusion from the Blade `@if` condition. The backend (`createPlannedTransaction()`) already handled transfers — only the UI was blocking it
- Users can still manually override the auto-selected mode

## Changes

| File | Change |
|------|--------|
| `app/Livewire/TransactionModal.php` | Added `CarbonImmutable` import + date comparison in `openForAdd()` |
| `resources/views/livewire/transaction-modal.blade.php` | Removed transfer exclusion from toggle condition |
| `tests/Feature/Livewire/TransactionModalTest.php` | Reversed 1 test, added 4 new auto-selection tests |

## Test plan

- [x] `auto-selects enter mode for today date` — passes
- [x] `auto-selects enter mode for past date` — passes
- [x] `auto-selects plan mode for future date` — passes
- [x] `user can manually override auto-selected mode` — passes
- [x] `plan toggle visible for transfers` — reversed test passes
- [x] `plan toggle hidden when editing` — existing test still passes
- [x] `plan mode allows transfer transaction type` — existing test still passes
- [x] Full CI: 788 tests passing, Pint clean, PHPStan 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)