### PR TITLE
fix: [121] Change transaction modal amount field to textarea

### DIFF
--- a/resources/views/livewire/transaction-modal.blade.php
+++ b/resources/views/livewire/transaction-modal.blade.php
@@ -112,13 +112,26 @@
                 </div>
             @endif
 
-            <flux:input
+            @if($transactionType === 'transfer')
+                <flux:input
+                    wire:key="description-transfer"
                     wire:model.blur="descriptionInput"
-                    :label="$mode === 'plan' ? __('Planned amount with description') : __('Amount with description')"
-                    placeholder="4*15 zoo tickets (tip is ignored)"
+                    :label="$mode === 'plan' ? __('Planned amount with description') : __('Actual amount with description')"
+                    placeholder="100 savings transfer"
                     required
                     :disabled="$isBasiqTransaction"
-            />
+                />
+            @else
+                <flux:textarea
+                    wire:key="description-non-transfer"
+                    wire:model.blur="descriptionInput"
+                    :label="$mode === 'plan' ? __('Planned amount with description') : __('Actual amount with description')"
+                    placeholder="4*15 zoo tickets&#10;(100 in parentheses is ignored)"
+                    rows="2"
+                    required
+                    :disabled="$isBasiqTransaction"
+                />
+            @endif
 
             @if($isBasiqTransaction)
                 <flux:input


### PR DESCRIPTION
## Summary
- Expense/income transaction types now use `<flux:textarea rows="2">` instead of `<flux:input>`, allowing multiline expressions (e.g., `4*15 zoo tickets` with parenthesized text on a second line)
- Transfer type keeps the single-line `<flux:input>` for simple inline amounts
- Enter mode label updated from "Amount with description" to "Actual amount with description"

## Test plan
- [ ] `op ci` passes (lint, PHPStan, 788 tests) — verified locally
- [ ] Open modal as expense → confirm textarea with 2 rows
- [ ] Open modal as income → confirm textarea with 2 rows
- [ ] Open modal as transfer → confirm single-line input
- [ ] Toggle between Enter/Plan mode → confirm label changes correctly
- [ ] Type multiline input in textarea → confirm parsed amount displays correctly

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)