### PR TITLE
fix: [122] Hide date field in transaction modal enter mode

### DIFF
--- a/resources/views/livewire/transaction-modal.blade.php
+++ b/resources/views/livewire/transaction-modal.blade.php
@@ -182,13 +182,15 @@
                 @endforeach
             </flux:select>
 
-            <flux:input
-                    wire:model="date"
-                    :label="__('Date')"
-                    type="date"
-                    required
-                    :disabled="$isBasiqTransaction"
-            />
+            @if($mode === 'plan')
+                <flux:input
+                        wire:model="date"
+                        :label="__('Date')"
+                        type="date"
+                        required
+                        :disabled="$isBasiqTransaction"
+                />
+            @endif
 
             @if($mode === 'plan')
                 <flux:select wire:model="frequency" :label="__('Frequency')" required>

--- a/tests/Feature/Livewire/TransactionModalTest.php
+++ b/tests/Feature/Livewire/TransactionModalTest.php
@@ -762,6 +762,26 @@ test('enter mode hides plan fields', function () {
         ->assertDontSee(__('Frequency'));
 });
 
+test('enter mode hides date input field', function () {
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('open-transaction-modal', date: '2026-03-15')
+        ->assertSet('mode', 'enter')
+        ->assertDontSee(__('Date'));
+});
+
+test('plan mode shows date input field', function () {
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('open-transaction-modal', date: '2026-03-15')
+        ->set('mode', 'plan')
+        ->assertSee(__('Date'));
+});
+
 test('plan mode saves to planned_transactions table', function () {
     $user = User::factory()->create();
     $account = Account::factory()->for($user)->create();


### PR DESCRIPTION
## Summary
- Conditionally render the date input field in the transaction modal — only visible in `plan` mode, hidden in `enter` mode
- Date field was previously always shown but is only relevant when planning future transactions
- Added tests verifying date field visibility for both `enter` and `plan` modes

## Test plan
- [ ] Open transaction modal in `enter` mode → date field should not be visible
- [ ] Switch to `plan` mode → date field should appear
- [ ] Create a planned transaction with a date → verify it saves correctly
- [ ] Run `op test.filter TransactionModalTest` → all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #122