### PR TITLE
feat: [124] Transfer form layout redesign with dedicated amount input

### DIFF
--- a/app/Livewire/TransactionModal.php
+++ b/app/Livewire/TransactionModal.php
@@ -45,6 +45,10 @@ final class TransactionModal extends Component
 
     public ?int $transferToAccountId = null;
 
+    public string $transferAmount = '';
+
+    public string $transferDescription = '';
+
     public string $mode = 'enter';
 
     public ?int $editingPlannedTransactionId = null;
@@ -104,17 +108,20 @@ final class TransactionModal extends Component
                 $this->accountId = $debitSide->account_id;
                 $this->transferToAccountId = $creditSide->account_id;
             }
+
+            $this->transferAmount = number_format($transaction->amount / 100, 2, '.', '');
+            $this->transferDescription = $transaction->description ?? '';
         } else {
             $this->transactionType = $transaction->direction === TransactionDirection::Debit
                 ? 'expense'
                 : 'income';
 
             $this->accountId = $transaction->account_id;
-        }
 
-        $dollars = number_format($transaction->amount / 100, 2, '.', '');
-        $description = $transaction->description ?? '';
-        $this->descriptionInput = $description !== '' ? "{$dollars} {$description}" : $dollars;
+            $dollars = number_format($transaction->amount / 100, 2, '.', '');
+            $description = $transaction->description ?? '';
+            $this->descriptionInput = $description !== '' ? "{$dollars} {$description}" : $dollars;
+        }
 
         if ($this->isBasiqTransaction) {
             $this->cleanDescription = $transaction->clean_description ?? '';
@@ -146,15 +153,17 @@ final class TransactionModal extends Component
         if ($planned->transfer_to_account_id !== null) {
             $this->transactionType = 'transfer';
             $this->transferToAccountId = $planned->transfer_to_account_id;
+            $this->transferAmount = number_format($planned->amount / 100, 2, '.', '');
+            $this->transferDescription = $planned->description ?? '';
         } else {
             $this->transactionType = $planned->direction === TransactionDirection::Debit
                 ? 'expense'
                 : 'income';
-        }
 
-        $dollars = number_format($planned->amount / 100, 2, '.', '');
-        $description = $planned->description ?? '';
-        $this->descriptionInput = $description !== '' ? "{$dollars} {$description}" : $dollars;
+            $dollars = number_format($planned->amount / 100, 2, '.', '');
+            $description = $planned->description ?? '';
+            $this->descriptionInput = $description !== '' ? "{$dollars} {$description}" : $dollars;
+        }
 
         $this->accountId = $planned->account_id;
         $this->categoryId = $planned->category_id;
@@ -205,9 +214,21 @@ final class TransactionModal extends Component
 
     public function updatedTransactionType(): void
     {
-        if ($this->transactionType !== 'transfer' && ! $this->isBasiqTransaction) {
-            $this->notes = '';
+        if ($this->transactionType === 'transfer') {
+            $this->descriptionInput = '';
+        } else {
+            $this->transferAmount = '';
+            $this->transferDescription = '';
+
+            if (! $this->isBasiqTransaction) {
+                $this->notes = '';
+            }
         }
+    }
+
+    public function swapAccounts(): void
+    {
+        [$this->accountId, $this->transferToAccountId] = [$this->transferToAccountId, $this->accountId];
     }
 
     /**
@@ -287,11 +308,9 @@ final class TransactionModal extends Component
 
     private function createTransaction(): bool
     {
-        $parsed = AmountParser::parse($this->descriptionInput);
+        $resolved = $this->resolveAmountAndDescription();
 
-        if ($parsed->amount <= 0) {
-            $this->addError('descriptionInput', __('The amount must be greater than zero.'));
-
+        if ($resolved === false) {
             return false;
         }
 
@@ -299,11 +318,11 @@ final class TransactionModal extends Component
             'user_id' => auth()->id(),
             'account_id' => $this->accountId,
             'category_id' => $this->categoryId,
-            'amount' => $parsed->amount,
+            'amount' => $resolved['amount'],
             'direction' => $this->transactionType === 'expense'
                 ? TransactionDirection::Debit
                 : TransactionDirection::Credit,
-            'description' => $parsed->description,
+            'description' => $resolved['description'],
             'post_date' => $this->date,
             'status' => TransactionStatus::Posted,
             'source' => TransactionSource::Manual,
@@ -318,24 +337,21 @@ final class TransactionModal extends Component
      */
     private function createTransfer(): bool
     {
-        $parsed = AmountParser::parse($this->descriptionInput);
+        $resolved = $this->resolveAmountAndDescription();
 
-        if ($parsed->amount <= 0) {
-            $this->addError('descriptionInput', __('The amount must be greater than zero.'));
-
+        if ($resolved === false) {
             return false;
         }
 
-        DB::transaction(function () use ($parsed): void {
+        DB::transaction(function () use ($resolved): void {
             $shared = [
                 'user_id' => auth()->id(),
                 'category_id' => $this->categoryId,
-                'amount' => $parsed->amount,
-                'description' => $parsed->description,
+                'amount' => $resolved['amount'],
+                'description' => $resolved['description'],
                 'post_date' => $this->date,
                 'status' => TransactionStatus::Posted,
                 'source' => TransactionSource::Manual,
-                'notes' => $this->notes !== '' ? $this->notes : null,
             ];
 
             $debit = Transaction::query()->create($shared + [
@@ -357,11 +373,9 @@ final class TransactionModal extends Component
 
     private function createPlannedTransaction(): bool
     {
-        $parsed = AmountParser::parse($this->descriptionInput);
+        $resolved = $this->resolveAmountAndDescription();
 
-        if ($parsed->amount <= 0) {
-            $this->addError('descriptionInput', __('The amount must be greater than zero.'));
-
+        if ($resolved === false) {
             return false;
         }
 
@@ -377,9 +391,9 @@ final class TransactionModal extends Component
                 ? $this->transferToAccountId
                 : null,
             'category_id' => $this->categoryId,
-            'amount' => $parsed->amount,
+            'amount' => $resolved['amount'],
             'direction' => $direction,
-            'description' => $parsed->description,
+            'description' => $resolved['description'],
             'start_date' => $this->date,
             'frequency' => RecurrenceFrequency::from($this->frequency),
             'until_date' => $this->untilType === 'until-date' ? $this->untilDate : null,
@@ -399,11 +413,9 @@ final class TransactionModal extends Component
             return false;
         }
 
-        $parsed = AmountParser::parse($this->descriptionInput);
+        $resolved = $this->resolveAmountAndDescription();
 
-        if ($parsed->amount <= 0) {
-            $this->addError('descriptionInput', __('The amount must be greater than zero.'));
-
+        if ($resolved === false) {
             return false;
         }
 
@@ -418,9 +430,9 @@ final class TransactionModal extends Component
                 ? $this->transferToAccountId
                 : null,
             'category_id' => $this->categoryId,
-            'amount' => $parsed->amount,
+            'amount' => $resolved['amount'],
             'direction' => $direction,
-            'description' => $parsed->description,
+            'description' => $resolved['description'],
             'start_date' => $this->date,
             'frequency' => RecurrenceFrequency::from($this->frequency),
             'until_date' => $this->untilType === 'until-date' ? $this->untilDate : null,
@@ -449,22 +461,20 @@ final class TransactionModal extends Component
             return true;
         }
 
-        $parsed = AmountParser::parse($this->descriptionInput);
+        $resolved = $this->resolveAmountAndDescription();
 
-        if ($parsed->amount <= 0) {
-            $this->addError('descriptionInput', __('The amount must be greater than zero.'));
-
+        if ($resolved === false) {
             return false;
         }
 
         $transaction->update([
             'account_id' => $this->accountId,
             'category_id' => $this->categoryId,
-            'amount' => $parsed->amount,
+            'amount' => $resolved['amount'],
             'direction' => $this->transactionType === 'expense'
                 ? TransactionDirection::Debit
                 : TransactionDirection::Credit,
-            'description' => $parsed->description,
+            'description' => $resolved['description'],
             'post_date' => $this->date,
             'notes' => $this->notes !== '' ? $this->notes : null,
         ]);
@@ -493,21 +503,18 @@ final class TransactionModal extends Component
             return false;
         }
 
-        $parsed = AmountParser::parse($this->descriptionInput);
+        $resolved = $this->resolveAmountAndDescription();
 
-        if ($parsed->amount <= 0) {
-            $this->addError('descriptionInput', __('The amount must be greater than zero.'));
-
+        if ($resolved === false) {
             return false;
         }
 
-        DB::transaction(function () use ($transaction, $pair, $parsed): void {
+        DB::transaction(function () use ($transaction, $pair, $resolved): void {
             $shared = [
                 'category_id' => $this->categoryId,
-                'amount' => $parsed->amount,
-                'description' => $parsed->description,
+                'amount' => $resolved['amount'],
+                'description' => $resolved['description'],
                 'post_date' => $this->date,
-                'notes' => $this->notes !== '' ? $this->notes : null,
             ];
 
             $debitSide = $transaction->direction === TransactionDirection::Debit ? $transaction : $pair;
@@ -518,6 +525,30 @@ final class TransactionModal extends Component
         });
 
         return true;
+    }
+
+    /** @return array{amount: int, description: ?string}|false */
+    private function resolveAmountAndDescription(): array|false
+    {
+        if ($this->transactionType === 'transfer') {
+            $amount = (int) round((float) $this->transferAmount * 100);
+            $transferDescription = mb_trim($this->transferDescription);
+            $description = $transferDescription !== '' ? $transferDescription : null;
+            $errorKey = 'transferAmount';
+        } else {
+            $parsed = AmountParser::parse($this->descriptionInput);
+            $amount = $parsed->amount;
+            $description = $parsed->description;
+            $errorKey = 'descriptionInput';
+        }
+
+        if ($amount <= 0) {
+            $this->addError($errorKey, __('The amount must be greater than zero.'));
+
+            return false;
+        }
+
+        return ['amount' => $amount, 'description' => $description];
     }
 
     private function isTransfer(): bool
@@ -546,6 +577,8 @@ final class TransactionModal extends Component
         $this->notes = '';
         $this->cleanDescription = '';
         $this->transferToAccountId = null;
+        $this->transferAmount = '';
+        $this->transferDescription = '';
         $this->mode = 'enter';
         $this->frequency = 'every-month';
         $this->untilType = 'always';
@@ -556,10 +589,20 @@ final class TransactionModal extends Component
     /** @return array<string, mixed> */
     private function formRules(): array
     {
+        $isTransfer = $this->isTransfer();
+
         $rules = [
             'mode' => ['required', Rule::in(['enter', 'plan'])],
             'transactionType' => ['required', Rule::in(['expense', 'income', 'transfer'])],
-            'descriptionInput' => ['required', 'string', 'max:255'],
+            'descriptionInput' => $isTransfer
+                ? ['nullable', 'string', 'max:255']
+                : ['required', 'string', 'max:255'],
+            'transferAmount' => $isTransfer
+                ? ['required', 'numeric', 'min:0.01']
+                : ['nullable'],
+            'transferDescription' => $isTransfer
+                ? ['nullable', 'string', 'max:255']
+                : ['nullable'],
             'accountId' => [
                 'required',
                 Rule::exists('accounts', 'id')->where('user_id', auth()->id()),
@@ -571,7 +614,7 @@ final class TransactionModal extends Component
             'date' => ['required', 'date_format:Y-m-d'],
             'notes' => ['nullable', 'string', 'max:1000'],
             'cleanDescription' => ['nullable', 'string', 'max:255'],
-            'transferToAccountId' => $this->isTransfer()
+            'transferToAccountId' => $isTransfer
                 ? [
                     'required',
                     Rule::exists('accounts', 'id')->where('user_id', auth()->id()),

--- a/resources/views/livewire/transaction-modal.blade.php
+++ b/resources/views/livewire/transaction-modal.blade.php
@@ -113,15 +113,60 @@
             @endif
 
             @if($transactionType === 'transfer')
-                <flux:input
-                    wire:key="description-transfer"
-                    wire:model.blur="descriptionInput"
-                    :label="$mode === 'plan' ? __('Planned amount with description') : __('Actual amount with description')"
-                    placeholder="100 savings transfer"
-                    required
-                    :disabled="$isBasiqTransaction"
-                />
+                {{-- Transfer layout: From account + inline amount --}}
+                <div class="flex items-end gap-3">
+                    <div class="flex-1">
+                        <flux:select
+                                wire:model="accountId"
+                                :label="__('From account')"
+                                required
+                        >
+                            <flux:select.option value="">{{ __('Select account') }}</flux:select.option>
+                            @foreach($accounts as $account)
+                                <flux:select.option value="{{ $account->id }}">
+                                    {{ $account->name }} ({{ $formatMoney($account->balance) }})
+                                </flux:select.option>
+                            @endforeach
+                        </flux:select>
+                    </div>
+                    <div class="flex items-end gap-1.5">
+                        <flux:input
+                                wire:model.blur="transferAmount"
+                                type="number"
+                                step="0.01"
+                                min="0.01"
+                                placeholder="0"
+                                class="w-24 tabular-nums"
+                                aria-label="{{ __('Transfer amount') }}"
+                                required
+                        />
+                        <flux:text class="pb-2 text-zinc-500">{{ __('AUD') }}</flux:text>
+                    </div>
+                </div>
+
+                {{-- To account with swap button --}}
+                <div class="flex items-end gap-3">
+                    <div class="flex-1">
+                        <flux:select wire:model="transferToAccountId" :label="__('To account')" required>
+                            <flux:select.option value="">{{ __('Select account') }}</flux:select.option>
+                            @foreach($accounts as $account)
+                                <flux:select.option value="{{ $account->id }}">
+                                    {{ $account->name }} ({{ $formatMoney($account->balance) }})
+                                </flux:select.option>
+                            @endforeach
+                        </flux:select>
+                    </div>
+                    <flux:button
+                            variant="ghost"
+                            size="sm"
+                            wire:click="swapAccounts"
+                            type="button"
+                            icon="arrows-right-left"
+                            class="mb-0.5"
+                    />
+                </div>
             @else
+                {{-- Non-transfer layout: textarea + parsed amount + account --}}
                 <flux:textarea
                     wire:key="description-non-transfer"
                     wire:model.blur="descriptionInput"
@@ -131,39 +176,28 @@
                     required
                     :disabled="$isBasiqTransaction"
                 />
-            @endif
 
-            @if($isBasiqTransaction)
-                <flux:input
-                        wire:model.blur="cleanDescription"
-                        :label="__('Clean description')"
-                        :placeholder="__('Your description for this transaction')"
-                />
-            @endif
+                @if($isBasiqTransaction)
+                    <flux:input
+                            wire:model.blur="cleanDescription"
+                            :label="__('Clean description')"
+                            :placeholder="__('Your description for this transaction')"
+                    />
+                @endif
 
-            <div class="rounded-lg bg-zinc-50 px-4 py-3 dark:bg-zinc-800">
-                <flux:text size="sm" class="text-zinc-500">{{ __('Parsed amount') }}</flux:text>
-                <div class="mt-1 text-lg font-semibold tabular-nums">
-                    {{ $formatMoney($parsedAmount) }} — {{ __('Australian Dollar') }}
+                <div class="rounded-lg bg-zinc-50 px-4 py-3 dark:bg-zinc-800">
+                    <flux:text size="sm" class="text-zinc-500">{{ __('Parsed amount') }}</flux:text>
+                    <div class="mt-1 text-lg font-semibold tabular-nums">
+                        {{ $formatMoney($parsedAmount) }} — {{ __('Australian Dollar') }}
+                    </div>
                 </div>
-            </div>
 
-            <flux:select
-                    wire:model="accountId"
-                    :label="$transactionType === 'transfer' ? __('From account') : __('Account')"
-                    required
-                    :disabled="$isBasiqTransaction"
-            >
-                <flux:select.option value="">{{ __('Select account') }}</flux:select.option>
-                @foreach($accounts as $account)
-                    <flux:select.option value="{{ $account->id }}">
-                        {{ $account->name }} ({{ $formatMoney($account->balance) }})
-                    </flux:select.option>
-                @endforeach
-            </flux:select>
-
-            @if($transactionType === 'transfer')
-                <flux:select wire:model="transferToAccountId" :label="__('To account')" required>
+                <flux:select
+                        wire:model="accountId"
+                        :label="__('Account')"
+                        required
+                        :disabled="$isBasiqTransaction"
+                >
                     <flux:select.option value="">{{ __('Select account') }}</flux:select.option>
                     @foreach($accounts as $account)
                         <flux:select.option value="{{ $account->id }}">
@@ -232,10 +266,17 @@
                 </div>
             @endif
 
-            @if($transactionType === 'transfer' || $isBasiqTransaction)
+            @if($transactionType === 'transfer')
+                <flux:textarea
+                        wire:model="transferDescription"
+                        :label="__('Transfer description')"
+                        :placeholder="__('Optional description')"
+                        rows="2"
+                />
+            @elseif($isBasiqTransaction)
                 <flux:textarea
                         wire:model="notes"
-                        :label="$transactionType === 'transfer' ? __('Transfer description') : __('Notes')"
+                        :label="__('Notes')"
                         :placeholder="__('Optional notes')"
                         rows="2"
                 />

--- a/tests/Feature/Livewire/TransactionModalTest.php
+++ b/tests/Feature/Livewire/TransactionModalTest.php
@@ -207,7 +207,9 @@ test('resets form after save', function () {
         ->assertSet('descriptionInput', '')
         ->assertSet('accountId', null)
         ->assertSet('categoryId', null)
-        ->assertSet('transactionType', 'expense');
+        ->assertSet('transactionType', 'expense')
+        ->assertSet('transferAmount', '')
+        ->assertSet('transferDescription', '');
 });
 
 test('cannot save to another user account', function () {
@@ -485,7 +487,8 @@ test('transfer creates two linked transactions', function () {
         ->test(TransactionModal::class)
         ->dispatch('open-transaction-modal', date: '2026-03-15')
         ->set('transactionType', 'transfer')
-        ->set('descriptionInput', '500 monthly savings')
+        ->set('transferAmount', '500')
+        ->set('transferDescription', 'monthly savings')
         ->set('accountId', $fromAccount->id)
         ->set('transferToAccountId', $toAccount->id)
         ->call('save')
@@ -520,7 +523,8 @@ test('transfer debit and credit have correct directions', function () {
         ->test(TransactionModal::class)
         ->dispatch('open-transaction-modal', date: '2026-03-15')
         ->set('transactionType', 'transfer')
-        ->set('descriptionInput', '100 transfer')
+        ->set('transferAmount', '100')
+        ->set('transferDescription', 'transfer')
         ->set('accountId', $fromAccount->id)
         ->set('transferToAccountId', $toAccount->id)
         ->call('save');
@@ -548,7 +552,8 @@ test('cannot transfer to same account', function () {
         ->test(TransactionModal::class)
         ->dispatch('open-transaction-modal', date: '2026-03-15')
         ->set('transactionType', 'transfer')
-        ->set('descriptionInput', '100 self transfer')
+        ->set('transferAmount', '100')
+        ->set('transferDescription', 'self transfer')
         ->set('accountId', $account->id)
         ->set('transferToAccountId', $account->id)
         ->call('save')
@@ -590,7 +595,8 @@ test('edit transfer opens with pre-filled data for both sides', function () {
         ->assertSet('transactionType', 'transfer')
         ->assertSet('accountId', $fromAccount->id)
         ->assertSet('transferToAccountId', $toAccount->id)
-        ->assertSet('descriptionInput', '100.00 savings transfer');
+        ->assertSet('transferAmount', '100.00')
+        ->assertSet('transferDescription', 'savings transfer');
 });
 
 test('edit transfer updates both sides', function () {
@@ -622,7 +628,8 @@ test('edit transfer updates both sides', function () {
     Livewire::actingAs($user)
         ->test(TransactionModal::class)
         ->dispatch('edit-transaction', id: $debit->id)
-        ->set('descriptionInput', '200 updated transfer')
+        ->set('transferAmount', '200')
+        ->set('transferDescription', 'updated transfer')
         ->call('save')
         ->assertSet('showModal', false);
 
@@ -937,7 +944,8 @@ test('plan mode allows transfer transaction type', function () {
         ->dispatch('open-transaction-modal', date: '2026-03-15')
         ->set('mode', 'plan')
         ->set('transactionType', 'transfer')
-        ->set('descriptionInput', '500 monthly savings')
+        ->set('transferAmount', '500')
+        ->set('transferDescription', 'monthly savings')
         ->set('accountId', $fromAccount->id)
         ->set('transferToAccountId', $toAccount->id)
         ->call('save')
@@ -1124,7 +1132,8 @@ test('planned transfer requires transfer_to_account_id', function () {
         ->dispatch('open-transaction-modal', date: '2026-03-15')
         ->set('mode', 'plan')
         ->set('transactionType', 'transfer')
-        ->set('descriptionInput', '500 savings')
+        ->set('transferAmount', '500')
+        ->set('transferDescription', 'savings')
         ->set('accountId', $account->id)
         ->set('transferToAccountId', null)
         ->call('save')
@@ -1140,7 +1149,8 @@ test('planned transfer cannot use same account for both sides', function () {
         ->dispatch('open-transaction-modal', date: '2026-03-15')
         ->set('mode', 'plan')
         ->set('transactionType', 'transfer')
-        ->set('descriptionInput', '500 savings')
+        ->set('transferAmount', '500')
+        ->set('transferDescription', 'savings')
         ->set('accountId', $account->id)
         ->set('transferToAccountId', $account->id)
         ->call('save')
@@ -1170,7 +1180,8 @@ test('editing planned transfer opens with pre-filled transfer data', function ()
         ->assertSet('transactionType', 'transfer')
         ->assertSet('accountId', $fromAccount->id)
         ->assertSet('transferToAccountId', $toAccount->id)
-        ->assertSet('descriptionInput', '500.00 monthly savings');
+        ->assertSet('transferAmount', '500.00')
+        ->assertSet('transferDescription', 'monthly savings');
 });
 
 // ── Type Selector UI (#118) ────────────────────────────────────
@@ -1219,7 +1230,8 @@ test('updating planned transfer saves both account ids', function () {
         ->test(TransactionModal::class)
         ->dispatch('edit-planned-transaction', id: $planned->id)
         ->set('transferToAccountId', $newToAccount->id)
-        ->set('descriptionInput', '750 updated savings')
+        ->set('transferAmount', '750')
+        ->set('transferDescription', 'updated savings')
         ->call('save')
         ->assertHasNoErrors()
         ->assertSet('showModal', false);
@@ -1360,12 +1372,12 @@ test('switching from transfer to expense hides notes field', function () {
         ->set('transactionType', 'transfer')
         ->assertSee(__('Transfer description'))
         ->set('transactionType', 'expense')
-        ->assertSet('notes', '')
+        ->assertSet('transferDescription', '')
         ->assertDontSee(__('Notes'))
         ->assertDontSee(__('Transfer description'));
 });
 
-test('switching from transfer clears notes before save', function () {
+test('switching from transfer clears transfer fields before save', function () {
     $user = User::factory()->create();
     $account = Account::factory()->for($user)->create();
     $category = Category::factory()->create();
@@ -1374,9 +1386,11 @@ test('switching from transfer clears notes before save', function () {
         ->test(TransactionModal::class)
         ->dispatch('open-transaction-modal', date: '2026-03-15')
         ->set('transactionType', 'transfer')
-        ->set('notes', 'Transfer memo that should be cleared')
+        ->set('transferDescription', 'Transfer memo that should be cleared')
+        ->set('transferAmount', '100')
         ->set('transactionType', 'expense')
-        ->assertSet('notes', '')
+        ->assertSet('transferDescription', '')
+        ->assertSet('transferAmount', '')
         ->set('descriptionInput', '50 Groceries')
         ->set('accountId', $account->id)
         ->set('categoryId', $category->id)
@@ -1387,4 +1401,112 @@ test('switching from transfer clears notes before save', function () {
     expect($transaction)
         ->not->toBeNull()
         ->notes->toBeNull();
+});
+
+// ── Transfer Form Redesign (#124) ─────────────────────────────
+
+test('transfer amount validation rejects zero', function () {
+    $user = User::factory()->create();
+    $fromAccount = Account::factory()->for($user)->create();
+    $toAccount = Account::factory()->for($user)->create();
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('open-transaction-modal', date: '2026-03-15')
+        ->set('transactionType', 'transfer')
+        ->set('transferAmount', '0')
+        ->set('accountId', $fromAccount->id)
+        ->set('transferToAccountId', $toAccount->id)
+        ->call('save')
+        ->assertHasErrors(['transferAmount']);
+
+    expect(Transaction::query()->where('user_id', $user->id)->count())->toBe(0);
+});
+
+test('transfer amount validation rejects non-numeric', function () {
+    $user = User::factory()->create();
+    $fromAccount = Account::factory()->for($user)->create();
+    $toAccount = Account::factory()->for($user)->create();
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('open-transaction-modal', date: '2026-03-15')
+        ->set('transactionType', 'transfer')
+        ->set('transferAmount', 'abc')
+        ->set('accountId', $fromAccount->id)
+        ->set('transferToAccountId', $toAccount->id)
+        ->call('save')
+        ->assertHasErrors(['transferAmount']);
+});
+
+test('transfer description maps to transaction description not notes', function () {
+    $user = User::factory()->create();
+    $fromAccount = Account::factory()->for($user)->create();
+    $toAccount = Account::factory()->for($user)->create();
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('open-transaction-modal', date: '2026-03-15')
+        ->set('transactionType', 'transfer')
+        ->set('transferAmount', '250')
+        ->set('transferDescription', 'rent contribution')
+        ->set('accountId', $fromAccount->id)
+        ->set('transferToAccountId', $toAccount->id)
+        ->call('save');
+
+    $debit = Transaction::query()
+        ->where('user_id', $user->id)
+        ->where('direction', TransactionDirection::Debit)
+        ->first();
+
+    expect($debit)
+        ->description->toBe('rent contribution')
+        ->notes->toBeNull();
+});
+
+test('switching to transfer clears descriptionInput', function () {
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('open-transaction-modal', date: '2026-03-15')
+        ->set('descriptionInput', '50 groceries')
+        ->set('transactionType', 'transfer')
+        ->assertSet('descriptionInput', '');
+});
+
+test('swap accounts swaps from and to', function () {
+    $user = User::factory()->create();
+    $fromAccount = Account::factory()->for($user)->create();
+    $toAccount = Account::factory()->for($user)->create();
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('open-transaction-modal', date: '2026-03-15')
+        ->set('transactionType', 'transfer')
+        ->set('accountId', $fromAccount->id)
+        ->set('transferToAccountId', $toAccount->id)
+        ->call('swapAccounts')
+        ->assertSet('accountId', $toAccount->id)
+        ->assertSet('transferToAccountId', $fromAccount->id);
+});
+
+test('transfer form hides parsed amount box', function () {
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('open-transaction-modal', date: '2026-03-15')
+        ->set('transactionType', 'transfer')
+        ->assertDontSee(__('Parsed amount'));
+});
+
+test('non-transfer form shows parsed amount box', function () {
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('open-transaction-modal', date: '2026-03-15')
+        ->set('transactionType', 'expense')
+        ->assertSee(__('Parsed amount'));
 });


### PR DESCRIPTION
## Summary

Closes #124

- Replaces the shared `AmountParser`-based textarea with a **dedicated inline amount input** and separate **transfer description** field for transfers
- Adds **swap accounts button** (⇆) next to the "To account" dropdown
- Fixes semantic mismatch where "Transfer description" label wrote to `Transaction.notes` instead of `Transaction.description`
- Extracts `resolveAmountAndDescription()` to eliminate duplicate amount parsing logic across 6 methods
- Non-transfer types (expense/income) are completely unchanged

### Transfer layout

```
┌─────────────────────────────────┬────────────┐
│  From account (dropdown)        │  0    AUD  │
├─────────────────────────────────┤            │
│  To account (dropdown)  [⇆]    │            │
└─────────────────────────────────┴────────────┘
│  Transfer description (textarea)             │
└──────────────────────────────────────────────┘
```

## Test plan

- [x] 10 existing transfer tests updated to use `transferAmount`/`transferDescription`
- [x] 7 new tests added (validation, description mapping, swap, parsed amount visibility)
- [x] All 803 tests pass
- [x] PHPStan clean, Pint clean
- [ ] Manual: open modal → switch to transfer → verify inline amount + swap button
- [ ] Manual: edit existing transfer → verify `transferAmount` and `transferDescription` pre-fill
- [ ] Manual: create planned transfer → verify frequency/until controls alongside new layout
- [ ] Manual: expense/income flow unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)