### PR TITLE
fix: [138] Transaction Modal Phase 2 — Display Fixes + Type Toggle

### DIFF
--- a/app/Livewire/TransactionModal.php
+++ b/app/Livewire/TransactionModal.php
@@ -45,10 +45,6 @@ final class TransactionModal extends Component
 
     public ?int $transferToAccountId = null;
 
-    public string $transferAmount = '';
-
-    public string $transferDescription = '';
-
     public string $mode = 'enter';
 
     public ?int $editingPlannedTransactionId = null;
@@ -58,6 +54,8 @@ final class TransactionModal extends Component
     public string $untilType = 'always';
 
     public ?string $untilDate = null;
+
+    public bool $originalWasTransfer = false;
 
     #[On('open-transaction-modal')]
     public function openForAdd(string $date): void
@@ -93,6 +91,7 @@ final class TransactionModal extends Component
 
         $this->editingTransactionId = $transaction->id;
         $this->isBasiqTransaction = $transaction->source === TransactionSource::Basiq;
+        $this->originalWasTransfer = $transaction->transfer_pair_id !== null;
 
         if ($transaction->transfer_pair_id) {
             $this->transactionType = 'transfer';
@@ -108,20 +107,17 @@ final class TransactionModal extends Component
                 $this->accountId = $debitSide->account_id;
                 $this->transferToAccountId = $creditSide->account_id;
             }
-
-            $this->transferAmount = number_format($transaction->amount / 100, 2, '.', '');
-            $this->transferDescription = $transaction->description ?? '';
         } else {
             $this->transactionType = $transaction->direction === TransactionDirection::Debit
                 ? 'expense'
                 : 'income';
 
             $this->accountId = $transaction->account_id;
-
-            $dollars = number_format($transaction->amount / 100, 2, '.', '');
-            $description = $transaction->description ?? '';
-            $this->descriptionInput = $description !== '' ? "{$dollars} {$description}" : $dollars;
         }
+
+        $dollars = number_format(abs($transaction->amount) / 100, 2, '.', '');
+        $description = $transaction->description ?? '';
+        $this->descriptionInput = $description !== '' ? "{$dollars} {$description}" : $dollars;
 
         if ($this->isBasiqTransaction) {
             $this->cleanDescription = $transaction->clean_description ?? '';
@@ -149,21 +145,20 @@ final class TransactionModal extends Component
 
         $this->editingPlannedTransactionId = $planned->id;
         $this->mode = 'plan';
+        $this->originalWasTransfer = $planned->transfer_to_account_id !== null;
 
         if ($planned->transfer_to_account_id !== null) {
             $this->transactionType = 'transfer';
             $this->transferToAccountId = $planned->transfer_to_account_id;
-            $this->transferAmount = number_format($planned->amount / 100, 2, '.', '');
-            $this->transferDescription = $planned->description ?? '';
         } else {
             $this->transactionType = $planned->direction === TransactionDirection::Debit
                 ? 'expense'
                 : 'income';
-
-            $dollars = number_format($planned->amount / 100, 2, '.', '');
-            $description = $planned->description ?? '';
-            $this->descriptionInput = $description !== '' ? "{$dollars} {$description}" : $dollars;
         }
+
+        $dollars = number_format(abs($planned->amount) / 100, 2, '.', '');
+        $description = $planned->description ?? '';
+        $this->descriptionInput = $description !== '' ? "{$dollars} {$description}" : $dollars;
 
         $this->accountId = $planned->account_id;
         $this->categoryId = $planned->category_id;
@@ -214,21 +209,9 @@ final class TransactionModal extends Component
 
     public function updatedTransactionType(): void
     {
-        if ($this->transactionType === 'transfer') {
-            $this->descriptionInput = '';
-        } else {
-            $this->transferAmount = '';
-            $this->transferDescription = '';
-
-            if (! $this->isBasiqTransaction) {
-                $this->notes = '';
-            }
+        if ($this->transactionType !== 'transfer' && ! $this->isBasiqTransaction) {
+            $this->notes = '';
         }
-    }
-
-    public function swapAccounts(): void
-    {
-        [$this->accountId, $this->transferToAccountId] = [$this->transferToAccountId, $this->accountId];
     }
 
     /**
@@ -308,9 +291,11 @@ final class TransactionModal extends Component
 
     private function createTransaction(): bool
     {
-        $resolved = $this->resolveAmountAndDescription();
+        $parsed = AmountParser::parse($this->descriptionInput);
 
-        if ($resolved === false) {
+        if ($parsed->amount <= 0) {
+            $this->addError('descriptionInput', __('The amount must be greater than zero.'));
+
             return false;
         }
 
@@ -318,11 +303,11 @@ final class TransactionModal extends Component
             'user_id' => auth()->id(),
             'account_id' => $this->accountId,
             'category_id' => $this->categoryId,
-            'amount' => $resolved['amount'],
+            'amount' => $parsed->amount,
             'direction' => $this->transactionType === 'expense'
                 ? TransactionDirection::Debit
                 : TransactionDirection::Credit,
-            'description' => $resolved['description'],
+            'description' => $parsed->description,
             'post_date' => $this->date,
             'status' => TransactionStatus::Posted,
             'source' => TransactionSource::Manual,
@@ -337,21 +322,24 @@ final class TransactionModal extends Component
      */
     private function createTransfer(): bool
     {
-        $resolved = $this->resolveAmountAndDescription();
+        $parsed = AmountParser::parse($this->descriptionInput);
 
-        if ($resolved === false) {
+        if ($parsed->amount <= 0) {
+            $this->addError('descriptionInput', __('The amount must be greater than zero.'));
+
             return false;
         }
 
-        DB::transaction(function () use ($resolved): void {
+        DB::transaction(function () use ($parsed): void {
             $shared = [
                 'user_id' => auth()->id(),
                 'category_id' => $this->categoryId,
-                'amount' => $resolved['amount'],
-                'description' => $resolved['description'],
+                'amount' => $parsed->amount,
+                'description' => $parsed->description,
                 'post_date' => $this->date,
                 'status' => TransactionStatus::Posted,
                 'source' => TransactionSource::Manual,
+                'notes' => $this->notes !== '' ? $this->notes : null,
             ];
 
             $debit = Transaction::query()->create($shared + [
@@ -373,9 +361,11 @@ final class TransactionModal extends Component
 
     private function createPlannedTransaction(): bool
     {
-        $resolved = $this->resolveAmountAndDescription();
+        $parsed = AmountParser::parse($this->descriptionInput);
 
-        if ($resolved === false) {
+        if ($parsed->amount <= 0) {
+            $this->addError('descriptionInput', __('The amount must be greater than zero.'));
+
             return false;
         }
 
@@ -391,9 +381,9 @@ final class TransactionModal extends Component
                 ? $this->transferToAccountId
                 : null,
             'category_id' => $this->categoryId,
-            'amount' => $resolved['amount'],
+            'amount' => $parsed->amount,
             'direction' => $direction,
-            'description' => $resolved['description'],
+            'description' => $parsed->description,
             'start_date' => $this->date,
             'frequency' => RecurrenceFrequency::from($this->frequency),
             'until_date' => $this->untilType === 'until-date' ? $this->untilDate : null,
@@ -413,9 +403,11 @@ final class TransactionModal extends Component
             return false;
         }
 
-        $resolved = $this->resolveAmountAndDescription();
+        $parsed = AmountParser::parse($this->descriptionInput);
 
-        if ($resolved === false) {
+        if ($parsed->amount <= 0) {
+            $this->addError('descriptionInput', __('The amount must be greater than zero.'));
+
             return false;
         }
 
@@ -430,9 +422,9 @@ final class TransactionModal extends Component
                 ? $this->transferToAccountId
                 : null,
             'category_id' => $this->categoryId,
-            'amount' => $resolved['amount'],
+            'amount' => $parsed->amount,
             'direction' => $direction,
-            'description' => $resolved['description'],
+            'description' => $parsed->description,
             'start_date' => $this->date,
             'frequency' => RecurrenceFrequency::from($this->frequency),
             'until_date' => $this->untilType === 'until-date' ? $this->untilDate : null,
@@ -461,20 +453,22 @@ final class TransactionModal extends Component
             return true;
         }
 
-        $resolved = $this->resolveAmountAndDescription();
+        $parsed = AmountParser::parse($this->descriptionInput);
 
-        if ($resolved === false) {
+        if ($parsed->amount <= 0) {
+            $this->addError('descriptionInput', __('The amount must be greater than zero.'));
+
             return false;
         }
 
         $transaction->update([
             'account_id' => $this->accountId,
             'category_id' => $this->categoryId,
-            'amount' => $resolved['amount'],
+            'amount' => $parsed->amount,
             'direction' => $this->transactionType === 'expense'
                 ? TransactionDirection::Debit
                 : TransactionDirection::Credit,
-            'description' => $resolved['description'],
+            'description' => $parsed->description,
             'post_date' => $this->date,
             'notes' => $this->notes !== '' ? $this->notes : null,
         ]);
@@ -503,18 +497,21 @@ final class TransactionModal extends Component
             return false;
         }
 
-        $resolved = $this->resolveAmountAndDescription();
+        $parsed = AmountParser::parse($this->descriptionInput);
 
-        if ($resolved === false) {
+        if ($parsed->amount <= 0) {
+            $this->addError('descriptionInput', __('The amount must be greater than zero.'));
+
             return false;
         }
 
-        DB::transaction(function () use ($transaction, $pair, $resolved): void {
+        DB::transaction(function () use ($transaction, $pair, $parsed): void {
             $shared = [
                 'category_id' => $this->categoryId,
-                'amount' => $resolved['amount'],
-                'description' => $resolved['description'],
+                'amount' => $parsed->amount,
+                'description' => $parsed->description,
                 'post_date' => $this->date,
+                'notes' => $this->notes !== '' ? $this->notes : null,
             ];
 
             $debitSide = $transaction->direction === TransactionDirection::Debit ? $transaction : $pair;
@@ -525,30 +522,6 @@ final class TransactionModal extends Component
         });
 
         return true;
-    }
-
-    /** @return array{amount: int, description: ?string}|false */
-    private function resolveAmountAndDescription(): array|false
-    {
-        if ($this->transactionType === 'transfer') {
-            $amount = (int) round((float) $this->transferAmount * 100);
-            $transferDescription = mb_trim($this->transferDescription);
-            $description = $transferDescription !== '' ? $transferDescription : null;
-            $errorKey = 'transferAmount';
-        } else {
-            $parsed = AmountParser::parse($this->descriptionInput);
-            $amount = $parsed->amount;
-            $description = $parsed->description;
-            $errorKey = 'descriptionInput';
-        }
-
-        if ($amount <= 0) {
-            $this->addError($errorKey, __('The amount must be greater than zero.'));
-
-            return false;
-        }
-
-        return ['amount' => $amount, 'description' => $description];
     }
 
     private function isTransfer(): bool
@@ -577,8 +550,7 @@ final class TransactionModal extends Component
         $this->notes = '';
         $this->cleanDescription = '';
         $this->transferToAccountId = null;
-        $this->transferAmount = '';
-        $this->transferDescription = '';
+        $this->originalWasTransfer = false;
         $this->mode = 'enter';
         $this->frequency = 'every-month';
         $this->untilType = 'always';
@@ -589,20 +561,10 @@ final class TransactionModal extends Component
     /** @return array<string, mixed> */
     private function formRules(): array
     {
-        $isTransfer = $this->isTransfer();
-
         $rules = [
             'mode' => ['required', Rule::in(['enter', 'plan'])],
             'transactionType' => ['required', Rule::in(['expense', 'income', 'transfer'])],
-            'descriptionInput' => $isTransfer
-                ? ['nullable', 'string', 'max:255']
-                : ['required', 'string', 'max:255'],
-            'transferAmount' => $isTransfer
-                ? ['required', 'numeric', 'min:0.01']
-                : ['nullable'],
-            'transferDescription' => $isTransfer
-                ? ['nullable', 'string', 'max:255']
-                : ['nullable'],
+            'descriptionInput' => ['required', 'string', 'max:255'],
             'accountId' => [
                 'required',
                 Rule::exists('accounts', 'id')->where('user_id', auth()->id()),
@@ -614,7 +576,7 @@ final class TransactionModal extends Component
             'date' => ['required', 'date_format:Y-m-d'],
             'notes' => ['nullable', 'string', 'max:1000'],
             'cleanDescription' => ['nullable', 'string', 'max:255'],
-            'transferToAccountId' => $isTransfer
+            'transferToAccountId' => $this->isTransfer()
                 ? [
                     'required',
                     Rule::exists('accounts', 'id')->where('user_id', auth()->id()),

--- a/resources/views/livewire/transaction-modal.blade.php
+++ b/resources/views/livewire/transaction-modal.blade.php
@@ -35,7 +35,7 @@
         <form wire:submit="save" class="space-y-6">
             <div class="-mx-6 -mt-6 mb-6 rounded-t-xl px-6 py-4 {{ $headerBg }}">
                 <div class="flex items-center justify-between">
-                    @if($isBasiqTransaction || $editingTransactionId || $editingPlannedTransactionId)
+                    @if($isBasiqTransaction)
                         <flux:heading size="lg" class="{{ $typeColor }}">
                             @if($transactionType === 'transfer')
                                 {{ __('Between Accounts') }}
@@ -58,15 +58,19 @@
                             </flux:button>
 
                             <flux:menu>
-                                <flux:menu.item wire:click="$set('transactionType', 'expense')" class="text-red-600 dark:text-red-400">
-                                    {{ __('expense') }}
-                                </flux:menu.item>
-                                <flux:menu.item wire:click="$set('transactionType', 'income')" class="text-green-600 dark:text-green-400">
-                                    {{ __('income') }}
-                                </flux:menu.item>
-                                <flux:menu.item wire:click="$set('transactionType', 'transfer')" class="text-amber-600 dark:text-amber-400">
-                                    {{ __('transfer between accounts') }}
-                                </flux:menu.item>
+                                @if(!$originalWasTransfer || (!$editingTransactionId && !$editingPlannedTransactionId))
+                                    <flux:menu.item wire:click="$set('transactionType', 'expense')" class="text-red-600 dark:text-red-400">
+                                        {{ __('expense') }}
+                                    </flux:menu.item>
+                                    <flux:menu.item wire:click="$set('transactionType', 'income')" class="text-green-600 dark:text-green-400">
+                                        {{ __('income') }}
+                                    </flux:menu.item>
+                                @endif
+                                @if($originalWasTransfer || (!$editingTransactionId && !$editingPlannedTransactionId))
+                                    <flux:menu.item wire:click="$set('transactionType', 'transfer')" class="text-amber-600 dark:text-amber-400">
+                                        {{ __('transfer between accounts') }}
+                                    </flux:menu.item>
+                                @endif
                             </flux:menu>
                         </flux:dropdown>
                     @endif
@@ -78,9 +82,17 @@
                             </flux:badge>
                         @endif
                         @if($date)
-                            <flux:badge color="zinc">
-                                {{ CarbonImmutable::parse($date)->format('D j M Y') }}
-                            </flux:badge>
+                            @if($isBasiqTransaction)
+                                <flux:badge color="zinc">
+                                    {{ CarbonImmutable::parse($date)->format('D j M Y') }}
+                                </flux:badge>
+                            @else
+                                <flux:input
+                                    type="date"
+                                    wire:model.live="date"
+                                    class="py-1! text-sm!"
+                                />
+                            @endif
                         @endif
                     </div>
                 </div>
@@ -113,60 +125,15 @@
             @endif
 
             @if($transactionType === 'transfer')
-                {{-- Transfer layout: From account + inline amount --}}
-                <div class="flex items-end gap-3">
-                    <div class="flex-1">
-                        <flux:select
-                                wire:model="accountId"
-                                :label="__('From account')"
-                                required
-                        >
-                            <flux:select.option value="">{{ __('Select account') }}</flux:select.option>
-                            @foreach($accounts as $account)
-                                <flux:select.option value="{{ $account->id }}">
-                                    {{ $account->name }} ({{ $formatMoney($account->balance) }})
-                                </flux:select.option>
-                            @endforeach
-                        </flux:select>
-                    </div>
-                    <div class="flex items-end gap-1.5">
-                        <flux:input
-                                wire:model.blur="transferAmount"
-                                type="number"
-                                step="0.01"
-                                min="0.01"
-                                placeholder="0"
-                                class="w-24 tabular-nums"
-                                aria-label="{{ __('Transfer amount') }}"
-                                required
-                        />
-                        <flux:text class="pb-2 text-zinc-500">{{ __('AUD') }}</flux:text>
-                    </div>
-                </div>
-
-                {{-- To account with swap button --}}
-                <div class="flex items-end gap-3">
-                    <div class="flex-1">
-                        <flux:select wire:model="transferToAccountId" :label="__('To account')" required>
-                            <flux:select.option value="">{{ __('Select account') }}</flux:select.option>
-                            @foreach($accounts as $account)
-                                <flux:select.option value="{{ $account->id }}">
-                                    {{ $account->name }} ({{ $formatMoney($account->balance) }})
-                                </flux:select.option>
-                            @endforeach
-                        </flux:select>
-                    </div>
-                    <flux:button
-                            variant="ghost"
-                            size="sm"
-                            wire:click="swapAccounts"
-                            type="button"
-                            icon="arrows-right-left"
-                            class="mb-0.5"
-                    />
-                </div>
+                <flux:input
+                    wire:key="description-transfer"
+                    wire:model.blur="descriptionInput"
+                    :label="$mode === 'plan' ? __('Planned amount with description') : __('Actual amount with description')"
+                    placeholder="100 savings transfer"
+                    required
+                    :disabled="$isBasiqTransaction"
+                />
             @else
-                {{-- Non-transfer layout: textarea + parsed amount + account --}}
                 <flux:textarea
                     wire:key="description-non-transfer"
                     wire:model.blur="descriptionInput"
@@ -176,28 +143,39 @@
                     required
                     :disabled="$isBasiqTransaction"
                 />
+            @endif
 
-                @if($isBasiqTransaction)
-                    <flux:input
-                            wire:model.blur="cleanDescription"
-                            :label="__('Clean description')"
-                            :placeholder="__('Your description for this transaction')"
-                    />
-                @endif
+            @if($isBasiqTransaction)
+                <flux:input
+                        wire:model.blur="cleanDescription"
+                        :label="__('Clean description')"
+                        :placeholder="__('Your description for this transaction')"
+                />
+            @endif
 
-                <div class="rounded-lg bg-zinc-50 px-4 py-3 dark:bg-zinc-800">
-                    <flux:text size="sm" class="text-zinc-500">{{ __('Parsed amount') }}</flux:text>
-                    <div class="mt-1 text-lg font-semibold tabular-nums">
-                        {{ $formatMoney($parsedAmount) }} — {{ __('Australian Dollar') }}
-                    </div>
+            <div class="rounded-lg bg-zinc-50 px-4 py-3 dark:bg-zinc-800">
+                <flux:text size="sm" class="text-zinc-500">{{ __('Parsed amount') }}</flux:text>
+                <div class="mt-1 text-lg font-semibold tabular-nums">
+                    {{ $formatMoney($parsedAmount) }}
                 </div>
+            </div>
 
-                <flux:select
-                        wire:model="accountId"
-                        :label="__('Account')"
-                        required
-                        :disabled="$isBasiqTransaction"
-                >
+            <flux:select
+                    wire:model="accountId"
+                    :label="$transactionType === 'transfer' ? __('From account') : __('Account')"
+                    required
+                    :disabled="$isBasiqTransaction"
+            >
+                <flux:select.option value="">{{ __('Select account') }}</flux:select.option>
+                @foreach($accounts as $account)
+                    <flux:select.option value="{{ $account->id }}">
+                        {{ $account->name }} ({{ $formatMoney($account->balance) }})
+                    </flux:select.option>
+                @endforeach
+            </flux:select>
+
+            @if($transactionType === 'transfer')
+                <flux:select wire:model="transferToAccountId" :label="__('To account')" required>
                     <flux:select.option value="">{{ __('Select account') }}</flux:select.option>
                     @foreach($accounts as $account)
                         <flux:select.option value="{{ $account->id }}">
@@ -266,17 +244,10 @@
                 </div>
             @endif
 
-            @if($transactionType === 'transfer')
-                <flux:textarea
-                        wire:model="transferDescription"
-                        :label="__('Transfer description')"
-                        :placeholder="__('Optional description')"
-                        rows="2"
-                />
-            @elseif($isBasiqTransaction)
+            @if($transactionType === 'transfer' || $isBasiqTransaction)
                 <flux:textarea
                         wire:model="notes"
-                        :label="__('Notes')"
+                        :label="$transactionType === 'transfer' ? __('Transfer description') : __('Notes')"
                         :placeholder="__('Optional notes')"
                         rows="2"
                 />

--- a/tests/Feature/Livewire/TransactionModalTest.php
+++ b/tests/Feature/Livewire/TransactionModalTest.php
@@ -207,9 +207,7 @@ test('resets form after save', function () {
         ->assertSet('descriptionInput', '')
         ->assertSet('accountId', null)
         ->assertSet('categoryId', null)
-        ->assertSet('transactionType', 'expense')
-        ->assertSet('transferAmount', '')
-        ->assertSet('transferDescription', '');
+        ->assertSet('transactionType', 'expense');
 });
 
 test('cannot save to another user account', function () {
@@ -487,8 +485,7 @@ test('transfer creates two linked transactions', function () {
         ->test(TransactionModal::class)
         ->dispatch('open-transaction-modal', date: '2026-03-15')
         ->set('transactionType', 'transfer')
-        ->set('transferAmount', '500')
-        ->set('transferDescription', 'monthly savings')
+        ->set('descriptionInput', '500 monthly savings')
         ->set('accountId', $fromAccount->id)
         ->set('transferToAccountId', $toAccount->id)
         ->call('save')
@@ -523,8 +520,7 @@ test('transfer debit and credit have correct directions', function () {
         ->test(TransactionModal::class)
         ->dispatch('open-transaction-modal', date: '2026-03-15')
         ->set('transactionType', 'transfer')
-        ->set('transferAmount', '100')
-        ->set('transferDescription', 'transfer')
+        ->set('descriptionInput', '100 transfer')
         ->set('accountId', $fromAccount->id)
         ->set('transferToAccountId', $toAccount->id)
         ->call('save');
@@ -552,8 +548,7 @@ test('cannot transfer to same account', function () {
         ->test(TransactionModal::class)
         ->dispatch('open-transaction-modal', date: '2026-03-15')
         ->set('transactionType', 'transfer')
-        ->set('transferAmount', '100')
-        ->set('transferDescription', 'self transfer')
+        ->set('descriptionInput', '100 self transfer')
         ->set('accountId', $account->id)
         ->set('transferToAccountId', $account->id)
         ->call('save')
@@ -595,8 +590,7 @@ test('edit transfer opens with pre-filled data for both sides', function () {
         ->assertSet('transactionType', 'transfer')
         ->assertSet('accountId', $fromAccount->id)
         ->assertSet('transferToAccountId', $toAccount->id)
-        ->assertSet('transferAmount', '100.00')
-        ->assertSet('transferDescription', 'savings transfer');
+        ->assertSet('descriptionInput', '100.00 savings transfer');
 });
 
 test('edit transfer updates both sides', function () {
@@ -628,8 +622,7 @@ test('edit transfer updates both sides', function () {
     Livewire::actingAs($user)
         ->test(TransactionModal::class)
         ->dispatch('edit-transaction', id: $debit->id)
-        ->set('transferAmount', '200')
-        ->set('transferDescription', 'updated transfer')
+        ->set('descriptionInput', '200 updated transfer')
         ->call('save')
         ->assertSet('showModal', false);
 
@@ -944,8 +937,7 @@ test('plan mode allows transfer transaction type', function () {
         ->dispatch('open-transaction-modal', date: '2026-03-15')
         ->set('mode', 'plan')
         ->set('transactionType', 'transfer')
-        ->set('transferAmount', '500')
-        ->set('transferDescription', 'monthly savings')
+        ->set('descriptionInput', '500 monthly savings')
         ->set('accountId', $fromAccount->id)
         ->set('transferToAccountId', $toAccount->id)
         ->call('save')
@@ -1132,8 +1124,7 @@ test('planned transfer requires transfer_to_account_id', function () {
         ->dispatch('open-transaction-modal', date: '2026-03-15')
         ->set('mode', 'plan')
         ->set('transactionType', 'transfer')
-        ->set('transferAmount', '500')
-        ->set('transferDescription', 'savings')
+        ->set('descriptionInput', '500 savings')
         ->set('accountId', $account->id)
         ->set('transferToAccountId', null)
         ->call('save')
@@ -1149,8 +1140,7 @@ test('planned transfer cannot use same account for both sides', function () {
         ->dispatch('open-transaction-modal', date: '2026-03-15')
         ->set('mode', 'plan')
         ->set('transactionType', 'transfer')
-        ->set('transferAmount', '500')
-        ->set('transferDescription', 'savings')
+        ->set('descriptionInput', '500 savings')
         ->set('accountId', $account->id)
         ->set('transferToAccountId', $account->id)
         ->call('save')
@@ -1180,8 +1170,7 @@ test('editing planned transfer opens with pre-filled transfer data', function ()
         ->assertSet('transactionType', 'transfer')
         ->assertSet('accountId', $fromAccount->id)
         ->assertSet('transferToAccountId', $toAccount->id)
-        ->assertSet('transferAmount', '500.00')
-        ->assertSet('transferDescription', 'monthly savings');
+        ->assertSet('descriptionInput', '500.00 monthly savings');
 });
 
 // ── Type Selector UI (#118) ────────────────────────────────────
@@ -1197,10 +1186,10 @@ test('dropdown type selector shown when adding new transaction', function () {
         ->assertSeeHtml("\$set('transactionType', 'transfer')");
 });
 
-test('static heading shown when editing transaction', function () {
+test('static heading shown when editing basiq transaction', function () {
     $user = User::factory()->create();
     $account = Account::factory()->for($user)->create();
-    $transaction = Transaction::factory()->for($user)->for($account)->manual()->create();
+    $transaction = Transaction::factory()->for($user)->for($account)->fromBasiq()->create();
 
     Livewire::actingAs($user)
         ->test(TransactionModal::class)
@@ -1208,6 +1197,75 @@ test('static heading shown when editing transaction', function () {
         ->assertDontSeeHtml("\$set('transactionType', 'expense')")
         ->assertDontSeeHtml("\$set('transactionType', 'income')")
         ->assertDontSeeHtml("\$set('transactionType', 'transfer')");
+});
+
+test('editing manual expense shows expense and income options but not transfer', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $transaction = Transaction::factory()->for($user)->for($account)->manual()->create([
+        'direction' => TransactionDirection::Debit,
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('edit-transaction', id: $transaction->id)
+        ->assertSeeHtml("\$set('transactionType', 'expense')")
+        ->assertSeeHtml("\$set('transactionType', 'income')")
+        ->assertDontSeeHtml("\$set('transactionType', 'transfer')");
+});
+
+test('editing transfer shows only transfer option', function () {
+    $user = User::factory()->create();
+    $fromAccount = Account::factory()->for($user)->create();
+    $toAccount = Account::factory()->for($user)->create();
+
+    $debit = Transaction::factory()->for($user)->create([
+        'account_id' => $fromAccount->id,
+        'amount' => 10000,
+        'direction' => TransactionDirection::Debit,
+        'source' => TransactionSource::Manual,
+    ]);
+
+    $credit = Transaction::factory()->for($user)->create([
+        'account_id' => $toAccount->id,
+        'amount' => 10000,
+        'direction' => TransactionDirection::Credit,
+        'source' => TransactionSource::Manual,
+        'transfer_pair_id' => $debit->id,
+    ]);
+
+    $debit->update(['transfer_pair_id' => $credit->id]);
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('edit-transaction', id: $debit->id)
+        ->assertDontSeeHtml("\$set('transactionType', 'expense')")
+        ->assertDontSeeHtml("\$set('transactionType', 'income')")
+        ->assertSeeHtml("\$set('transactionType', 'transfer')");
+});
+
+test('switching expense to income during edit saves correct direction', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $transaction = Transaction::factory()->for($user)->for($account)->manual()->create([
+        'amount' => 5000,
+        'direction' => TransactionDirection::Debit,
+        'description' => 'refund item',
+        'post_date' => '2026-03-15',
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('edit-transaction', id: $transaction->id)
+        ->assertSet('transactionType', 'expense')
+        ->set('transactionType', 'income')
+        ->call('save')
+        ->assertSet('showModal', false)
+        ->assertHasNoErrors();
+
+    $transaction->refresh();
+    expect($transaction)
+        ->direction->toBe(TransactionDirection::Credit);
 });
 
 test('updating planned transfer saves both account ids', function () {
@@ -1230,8 +1288,7 @@ test('updating planned transfer saves both account ids', function () {
         ->test(TransactionModal::class)
         ->dispatch('edit-planned-transaction', id: $planned->id)
         ->set('transferToAccountId', $newToAccount->id)
-        ->set('transferAmount', '750')
-        ->set('transferDescription', 'updated savings')
+        ->set('descriptionInput', '750 updated savings')
         ->call('save')
         ->assertHasNoErrors()
         ->assertSet('showModal', false);
@@ -1372,12 +1429,12 @@ test('switching from transfer to expense hides notes field', function () {
         ->set('transactionType', 'transfer')
         ->assertSee(__('Transfer description'))
         ->set('transactionType', 'expense')
-        ->assertSet('transferDescription', '')
+        ->assertSet('notes', '')
         ->assertDontSee(__('Notes'))
         ->assertDontSee(__('Transfer description'));
 });
 
-test('switching from transfer clears transfer fields before save', function () {
+test('switching from transfer clears notes before save', function () {
     $user = User::factory()->create();
     $account = Account::factory()->for($user)->create();
     $category = Category::factory()->create();
@@ -1386,11 +1443,9 @@ test('switching from transfer clears transfer fields before save', function () {
         ->test(TransactionModal::class)
         ->dispatch('open-transaction-modal', date: '2026-03-15')
         ->set('transactionType', 'transfer')
-        ->set('transferDescription', 'Transfer memo that should be cleared')
-        ->set('transferAmount', '100')
+        ->set('notes', 'Transfer memo that should be cleared')
         ->set('transactionType', 'expense')
-        ->assertSet('transferDescription', '')
-        ->assertSet('transferAmount', '')
+        ->assertSet('notes', '')
         ->set('descriptionInput', '50 Groceries')
         ->set('accountId', $account->id)
         ->set('categoryId', $category->id)
@@ -1403,110 +1458,124 @@ test('switching from transfer clears transfer fields before save', function () {
         ->notes->toBeNull();
 });
 
-// ── Transfer Form Redesign (#124) ─────────────────────────────
+// ── Phase 2 Display Fixes ───────────────────────────────────────
 
-test('transfer amount validation rejects zero', function () {
+test('negative amount displays as positive when editing transaction', function () {
     $user = User::factory()->create();
-    $fromAccount = Account::factory()->for($user)->create();
-    $toAccount = Account::factory()->for($user)->create();
+    $account = Account::factory()->for($user)->create();
+    $transaction = Transaction::factory()->for($user)->for($account)->fromBasiq()->create([
+        'amount' => -4250,
+        'description' => 'bank charge',
+    ]);
 
     Livewire::actingAs($user)
         ->test(TransactionModal::class)
-        ->dispatch('open-transaction-modal', date: '2026-03-15')
-        ->set('transactionType', 'transfer')
-        ->set('transferAmount', '0')
-        ->set('accountId', $fromAccount->id)
-        ->set('transferToAccountId', $toAccount->id)
+        ->dispatch('edit-transaction', id: $transaction->id)
+        ->assertSet('descriptionInput', '42.50 bank charge');
+});
+
+test('negative amount displays as positive when editing planned transaction', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $planned = PlannedTransaction::factory()->for($user)->for($account)->monthly()->create([
+        'amount' => -5000,
+        'description' => 'subscription',
+        'start_date' => '2026-04-01',
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('edit-planned-transaction', id: $planned->id)
+        ->assertSet('descriptionInput', '50.00 subscription');
+});
+
+test('header date is editable for manual transaction', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $transaction = Transaction::factory()->for($user)->for($account)->manual()->create([
+        'amount' => 1000,
+        'description' => 'test',
+        'post_date' => '2026-03-15',
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('edit-transaction', id: $transaction->id)
+        ->assertSeeHtml('wire:model.live="date"')
+        ->set('date', '2026-03-20')
         ->call('save')
-        ->assertHasErrors(['transferAmount']);
+        ->assertHasNoErrors()
+        ->assertSet('showModal', false);
 
-    expect(Transaction::query()->where('user_id', $user->id)->count())->toBe(0);
+    $transaction->refresh();
+    expect($transaction->post_date->format('Y-m-d'))->toBe('2026-03-20');
 });
 
-test('transfer amount validation rejects non-numeric', function () {
+test('header date is read-only badge for basiq transaction', function () {
     $user = User::factory()->create();
-    $fromAccount = Account::factory()->for($user)->create();
-    $toAccount = Account::factory()->for($user)->create();
+    $account = Account::factory()->for($user)->create();
+    $transaction = Transaction::factory()->for($user)->for($account)->fromBasiq()->create([
+        'post_date' => '2026-03-15',
+    ]);
 
     Livewire::actingAs($user)
         ->test(TransactionModal::class)
-        ->dispatch('open-transaction-modal', date: '2026-03-15')
-        ->set('transactionType', 'transfer')
-        ->set('transferAmount', 'abc')
-        ->set('accountId', $fromAccount->id)
-        ->set('transferToAccountId', $toAccount->id)
+        ->dispatch('edit-transaction', id: $transaction->id)
+        ->assertDontSeeHtml('wire:model.live="date"')
+        ->assertSee('Sun 15 Mar 2026');
+});
+
+test('originalWasTransfer resets after save', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $transaction = Transaction::factory()->for($user)->for($account)->manual()->create([
+        'amount' => 1000,
+        'description' => 'test',
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('edit-transaction', id: $transaction->id)
+        ->set('descriptionInput', '10.00 test')
         ->call('save')
-        ->assertHasErrors(['transferAmount']);
+        ->assertSet('originalWasTransfer', false);
 });
 
-test('transfer description maps to transaction description not notes', function () {
+test('editing planned expense shows expense and income options but not transfer', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $planned = PlannedTransaction::factory()->for($user)->for($account)->monthly()->create([
+        'direction' => TransactionDirection::Debit,
+        'start_date' => '2026-04-01',
+        'amount' => 5000,
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('edit-planned-transaction', id: $planned->id)
+        ->assertSeeHtml("\$set('transactionType', 'expense')")
+        ->assertSeeHtml("\$set('transactionType', 'income')")
+        ->assertDontSeeHtml("\$set('transactionType', 'transfer')");
+});
+
+test('editing planned transfer shows only transfer option', function () {
     $user = User::factory()->create();
     $fromAccount = Account::factory()->for($user)->create();
     $toAccount = Account::factory()->for($user)->create();
 
-    Livewire::actingAs($user)
-        ->test(TransactionModal::class)
-        ->dispatch('open-transaction-modal', date: '2026-03-15')
-        ->set('transactionType', 'transfer')
-        ->set('transferAmount', '250')
-        ->set('transferDescription', 'rent contribution')
-        ->set('accountId', $fromAccount->id)
-        ->set('transferToAccountId', $toAccount->id)
-        ->call('save');
-
-    $debit = Transaction::query()
-        ->where('user_id', $user->id)
-        ->where('direction', TransactionDirection::Debit)
-        ->first();
-
-    expect($debit)
-        ->description->toBe('rent contribution')
-        ->notes->toBeNull();
-});
-
-test('switching to transfer clears descriptionInput', function () {
-    $user = User::factory()->create();
+    $planned = PlannedTransaction::factory()->for($user)->create([
+        'account_id' => $fromAccount->id,
+        'transfer_to_account_id' => $toAccount->id,
+        'amount' => 50000,
+        'direction' => TransactionDirection::Debit,
+        'start_date' => '2026-04-01',
+        'frequency' => RecurrenceFrequency::EveryMonth,
+    ]);
 
     Livewire::actingAs($user)
         ->test(TransactionModal::class)
-        ->dispatch('open-transaction-modal', date: '2026-03-15')
-        ->set('descriptionInput', '50 groceries')
-        ->set('transactionType', 'transfer')
-        ->assertSet('descriptionInput', '');
-});
-
-test('swap accounts swaps from and to', function () {
-    $user = User::factory()->create();
-    $fromAccount = Account::factory()->for($user)->create();
-    $toAccount = Account::factory()->for($user)->create();
-
-    Livewire::actingAs($user)
-        ->test(TransactionModal::class)
-        ->dispatch('open-transaction-modal', date: '2026-03-15')
-        ->set('transactionType', 'transfer')
-        ->set('accountId', $fromAccount->id)
-        ->set('transferToAccountId', $toAccount->id)
-        ->call('swapAccounts')
-        ->assertSet('accountId', $toAccount->id)
-        ->assertSet('transferToAccountId', $fromAccount->id);
-});
-
-test('transfer form hides parsed amount box', function () {
-    $user = User::factory()->create();
-
-    Livewire::actingAs($user)
-        ->test(TransactionModal::class)
-        ->dispatch('open-transaction-modal', date: '2026-03-15')
-        ->set('transactionType', 'transfer')
-        ->assertDontSee(__('Parsed amount'));
-});
-
-test('non-transfer form shows parsed amount box', function () {
-    $user = User::factory()->create();
-
-    Livewire::actingAs($user)
-        ->test(TransactionModal::class)
-        ->dispatch('open-transaction-modal', date: '2026-03-15')
-        ->set('transactionType', 'expense')
-        ->assertSee(__('Parsed amount'));
+        ->dispatch('edit-planned-transaction', id: $planned->id)
+        ->assertDontSeeHtml("\$set('transactionType', 'expense')")
+        ->assertDontSeeHtml("\$set('transactionType', 'income')")
+        ->assertSeeHtml("\$set('transactionType', 'transfer')");
 });


### PR DESCRIPTION
## Summary

- Remove hardcoded "Australian Dollar" text from parsed amount display
- Use `abs()` so negative amounts from Basiq display as positive in edit form
- Replace static date badge with editable date input (Basiq keeps read-only badge)
- Allow expense ↔ income type switching when editing (transfer conversion blocked via `$originalWasTransfer` until #134 lands)

## Related

Closes #138
Foundation tickets: #134, #135, #136

## Test plan

- [x] `op test.filter TransactionModalTest` — 88 passed
- [x] `op ci` — 806 passed, 0 failures, PHPStan + Pint clean