### PR TITLE
feat: [134] Parent-child transaction architecture

### DIFF
--- a/app/Livewire/CalendarView.php
+++ b/app/Livewire/CalendarView.php
@@ -62,6 +62,7 @@ final class CalendarView extends Component
 
         $allTransactions = Transaction::query()
             ->where('user_id', auth()->id())
+            ->current()
             ->whereBetween('post_date', [$gridStart, $gridEnd])
             ->with('category:id,name')
             ->orderBy('post_date')

--- a/app/Livewire/CategoryEditor.php
+++ b/app/Livewire/CategoryEditor.php
@@ -109,6 +109,7 @@ final class CategoryEditor extends Component
         $this->deletingCategoryName = $category->fullPath();
         $this->deletingTransactionCount = $category->transactions()
             ->where('user_id', auth()->id())
+            ->current()
             ->count();
         $this->showDeleteConfirm = true;
     }
@@ -138,7 +139,7 @@ final class CategoryEditor extends Component
 
         $categories = Category::query()
             ->with(['parent.parent'])
-            ->withCount(['transactions' => fn ($q) => $q->where('user_id', auth()->id())])
+            ->withCount(['transactions' => fn ($q) => $q->where('user_id', auth()->id())->current()])
             ->when(! $this->showHidden, fn ($q) => $q->visible())
             ->when($search !== '', fn ($q) => $q->where(function ($q) use ($search) {
                 $q->where('name', 'like', "%{$search}%")
@@ -160,6 +161,7 @@ final class CategoryEditor extends Component
             ? Transaction::query()
                 ->where('category_id', $this->selectedCategoryId)
                 ->where('user_id', auth()->id())
+                ->current()
                 ->with('account:id,name')
                 ->orderByDesc('post_date')
                 ->limit(50)

--- a/app/Livewire/SpendingByCategory.php
+++ b/app/Livewire/SpendingByCategory.php
@@ -28,6 +28,7 @@ final class SpendingByCategory extends Component
     {
         $rows = Transaction::query()
             ->where('user_id', auth()->id())
+            ->current()
             ->where('direction', TransactionDirection::Debit)
             ->where('post_date', '>=', $this->periodStart())
             ->selectRaw('category_id, SUM(amount) as total')

--- a/app/Livewire/SpendingOverTime.php
+++ b/app/Livewire/SpendingOverTime.php
@@ -47,6 +47,7 @@ final class SpendingOverTime extends Component
         $rows = Transaction::query()
             ->join('accounts', 'transactions.account_id', '=', 'accounts.id')
             ->where('transactions.user_id', auth()->id())
+            ->current()
             ->whereColumn('accounts.user_id', 'transactions.user_id')
             ->where('transactions.post_date', '>=', $start)
             ->selectRaw("{$groupExpression} as period_date, transactions.account_id, accounts.name as account_name, {$netExpression} as total")
@@ -92,6 +93,7 @@ final class SpendingOverTime extends Component
 
     /**
      * @param  'day'|'week'|'month'  $aggregation
+     * @param  CarbonImmutable  $start
      * @param  Collection<string, Collection<int, stdClass>>  $grouped
      * @return array<int, array{date: string, total: int, accounts: array<int, array{name: string, total: int}>}>
      */

--- a/app/Livewire/TransactionList.php
+++ b/app/Livewire/TransactionList.php
@@ -106,6 +106,7 @@ final class TransactionList extends Component
 
         $transactions = Transaction::query()
             ->where('user_id', auth()->id())
+            ->current()
             ->when($directionEnum, fn ($q, $dir) => $q->where('direction', $dir))
             ->when($this->account, fn ($q, $id) => $q->where('account_id', $id))
             ->when($this->category, fn ($q, $id) => $q->where('category_id', $id))

--- a/app/Livewire/TransactionModal.php
+++ b/app/Livewire/TransactionModal.php
@@ -69,9 +69,7 @@ final class TransactionModal extends Component
     #[On('edit-transaction')]
     public function openForEdit(int $id): void
     {
-        $transaction = Transaction::query()
-            ->where('user_id', auth()->id())
-            ->find($id);
+        $transaction = Transaction::findCurrentVersion($id, auth()->id());
 
         if (! $transaction) {
             return;
@@ -227,7 +225,7 @@ final class TransactionModal extends Component
             return;
         }
 
-        if ($transaction->source === TransactionSource::Basiq) {
+        if ($transaction->source === TransactionSource::Basiq && $transaction->parent_transaction_id === null) {
             return;
         }
 
@@ -444,7 +442,7 @@ final class TransactionModal extends Component
         }
 
         if ($transaction->source === TransactionSource::Basiq) {
-            $transaction->update([
+            $transaction->createChild([
                 'category_id' => $this->categoryId,
                 'notes' => $this->notes !== '' ? $this->notes : null,
                 'clean_description' => $this->cleanDescription !== '' ? $this->cleanDescription : null,
@@ -461,7 +459,7 @@ final class TransactionModal extends Component
             return false;
         }
 
-        $transaction->update([
+        $transaction->createChild([
             'account_id' => $this->accountId,
             'category_id' => $this->categoryId,
             'amount' => $parsed->amount,
@@ -517,8 +515,11 @@ final class TransactionModal extends Component
             $debitSide = $transaction->direction === TransactionDirection::Debit ? $transaction : $pair;
             $creditSide = $transaction->direction === TransactionDirection::Credit ? $transaction : $pair;
 
-            $debitSide->update($shared + ['account_id' => $this->accountId]);
-            $creditSide->update($shared + ['account_id' => $this->transferToAccountId]);
+            $debitChild = $debitSide->createChild($shared + ['account_id' => $this->accountId]);
+            $creditChild = $creditSide->createChild($shared + ['account_id' => $this->transferToAccountId]);
+
+            $debitChild->update(['transfer_pair_id' => $creditChild->id]);
+            $creditChild->update(['transfer_pair_id' => $debitChild->id]);
         });
 
         return true;

--- a/app/Models/Budget.php
+++ b/app/Models/Budget.php
@@ -73,7 +73,7 @@ final class Budget extends Model
 
     public function remaining(): int
     {
-        return $this->limit_amount - $this->transactions()->where('user_id', $this->user_id)->sum('amount');
+        return $this->limit_amount - $this->transactions()->where('user_id', $this->user_id)->current()->sum('amount');
     }
 
     /**

--- a/app/Models/Transaction.php
+++ b/app/Models/Transaction.php
@@ -14,6 +14,8 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 /**
  * @property int $id
@@ -35,14 +37,18 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property TransactionSource $source
  * @property int|null $transfer_pair_id
  * @property int|null $planned_transaction_id
+ * @property int|null $parent_transaction_id
  * @property string|null $notes
  * @property CarbonImmutable $created_at
  * @property CarbonImmutable $updated_at
+ * @property CarbonImmutable|null $deleted_at
  */
 final class Transaction extends Model
 {
     /** @use HasFactory<TransactionFactory> */
     use HasFactory;
+
+    use SoftDeletes;
 
     /**
      * @var list<string>
@@ -66,8 +72,34 @@ final class Transaction extends Model
         'source',
         'transfer_pair_id',
         'planned_transaction_id',
+        'parent_transaction_id',
         'notes',
     ];
+
+    public static function findCurrentVersion(int $id, int $userId): ?self
+    {
+        $current = self::query()
+            ->where('user_id', $userId)
+            ->find($id);
+
+        if (! $current) {
+            return null;
+        }
+
+        while (true) {
+            $child = self::query()
+                ->where('user_id', $userId)
+                ->where('parent_transaction_id', $current->id)
+                ->latest('id')
+                ->first();
+
+            if (! $child) {
+                return $current;
+            }
+
+            $current = $child;
+        }
+    }
 
     /** @return BelongsTo<User, $this> */
     public function user(): BelongsTo
@@ -97,6 +129,43 @@ final class Transaction extends Model
     public function transferPair(): BelongsTo
     {
         return $this->belongsTo(self::class, 'transfer_pair_id');
+    }
+
+    /** @return BelongsTo<self, $this> */
+    public function parent(): BelongsTo
+    {
+        return $this->belongsTo(self::class, 'parent_transaction_id');
+    }
+
+    /** @return HasMany<self, $this> */
+    public function children(): HasMany
+    {
+        return $this->hasMany(self::class, 'parent_transaction_id');
+    }
+
+    /**
+     * @param  Builder<self>  $query
+     * @return Builder<self>
+     */
+    public function scopeCurrent(Builder $query): Builder
+    {
+        return $query->whereDoesntHave('children', fn (Builder $q) => $q->whereNull('deleted_at'));
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    public function createChild(array $overrides = []): self
+    {
+        $excluded = ['id', 'created_at', 'updated_at', 'deleted_at', 'parent_transaction_id', 'basiq_id'];
+
+        $attributes = collect($this->getAttributes())
+            ->except($excluded)
+            ->toArray();
+
+        $attributes['parent_transaction_id'] = $this->id;
+
+        return self::query()->create(array_merge($attributes, $overrides));
     }
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -133,6 +133,7 @@ final class User extends Authenticatable
         }
 
         $totalDebits = $this->transactions()
+            ->current()
             ->where('direction', TransactionDirection::Debit)
             ->where('post_date', '>=', now()->subDays($lookbackDays))
             ->sum('amount');

--- a/app/Services/ReconciliationMatcher.php
+++ b/app/Services/ReconciliationMatcher.php
@@ -27,6 +27,7 @@ final readonly class ReconciliationMatcher
 
         return Transaction::query()
             ->where('user_id', $planned->user_id)
+            ->current()
             ->where('account_id', $planned->account_id)
             ->where('direction', $planned->direction)
             ->whereNull('planned_transaction_id')
@@ -48,6 +49,7 @@ final readonly class ReconciliationMatcher
 
         return Transaction::query()
             ->where('user_id', $planned->user_id)
+            ->current()
             ->where('planned_transaction_id', $planned->id)
             ->whereBetween('post_date', [$dateFrom, $dateTo])
             ->with('account:id,name')

--- a/database/factories/TransactionFactory.php
+++ b/database/factories/TransactionFactory.php
@@ -106,4 +106,18 @@ final class TransactionFactory extends Factory
             'notes' => fake()->sentence(),
         ]);
     }
+
+    public function withParent(): self
+    {
+        return $this->state(fn (array $attributes) => [
+            'parent_transaction_id' => Transaction::factory(),
+        ]);
+    }
+
+    public function softDeleted(): self
+    {
+        return $this->state(fn (array $attributes) => [
+            'deleted_at' => now(),
+        ]);
+    }
 }

--- a/database/migrations/2026_04_04_030659_add_parent_child_and_soft_deletes_to_transactions_table.php
+++ b/database/migrations/2026_04_04_030659_add_parent_child_and_soft_deletes_to_transactions_table.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('transactions', function (Blueprint $table) {
+            $table->foreignId('parent_transaction_id')
+                ->nullable()
+                ->after('planned_transaction_id')
+                ->constrained('transactions')
+                ->nullOnDelete();
+
+            $table->softDeletes();
+
+            $table->index(['parent_transaction_id', 'deleted_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('transactions', function (Blueprint $table) {
+            $table->dropIndex(['parent_transaction_id', 'deleted_at']);
+            $table->dropConstrainedForeignId('parent_transaction_id');
+            $table->dropSoftDeletes();
+        });
+    }
+};

--- a/pint.json
+++ b/pint.json
@@ -23,6 +23,7 @@
     "modernize_types_casting": true,
     "new_with_parentheses": false,
     "no_superfluous_elseif": true,
+    "no_superfluous_phpdoc_tags": false,
     "no_useless_else": true,
     "no_multiple_statements_per_line": true,
     "ordered_class_elements": {

--- a/tests/Feature/Livewire/TransactionModalTest.php
+++ b/tests/Feature/Livewire/TransactionModalTest.php
@@ -333,7 +333,7 @@ test('basiq transaction sets read-only flag', function () {
         ->assertSet('editingTransactionId', $transaction->id);
 });
 
-test('basiq transaction allows updating category and notes', function () {
+test('basiq transaction allows updating category and notes via child', function () {
     $user = User::factory()->create();
     $account = Account::factory()->for($user)->create();
     $category = Category::factory()->create(['is_hidden' => false]);
@@ -353,13 +353,24 @@ test('basiq transaction allows updating category and notes', function () {
         ->assertDispatched('transaction-saved');
 
     $transaction->refresh();
-    expect($transaction)
+    expect($transaction->category_id)->toBeNull()
+        ->and($transaction->notes)->toBeNull();
+
+    $child = Transaction::query()
+        ->where('parent_transaction_id', $transaction->id)
+        ->first();
+
+    expect($child)
+        ->not->toBeNull()
         ->category_id->toBe($category->id)
         ->notes->toBe('Groceries for the week')
-        ->clean_description->toBe('Woolworths groceries');
+        ->clean_description->toBe('Woolworths groceries')
+        ->basiq_id->toBeNull()
+        ->amount->toBe($transaction->amount)
+        ->account_id->toBe($transaction->account_id);
 });
 
-test('manual transaction allows updating all fields', function () {
+test('manual transaction creates child with updated fields', function () {
     $user = User::factory()->create();
     $account = Account::factory()->for($user)->create();
     $newAccount = Account::factory()->for($user)->create();
@@ -385,6 +396,15 @@ test('manual transaction allows updating all fields', function () {
 
     $transaction->refresh();
     expect($transaction)
+        ->amount->toBe(4250)
+        ->description->toBe('coffee');
+
+    $child = Transaction::query()
+        ->where('parent_transaction_id', $transaction->id)
+        ->first();
+
+    expect($child)
+        ->not->toBeNull()
         ->amount->toBe(9999)
         ->direction->toBe(TransactionDirection::Credit)
         ->description->toBe('fancy dinner')
@@ -394,7 +414,7 @@ test('manual transaction allows updating all fields', function () {
         ->notes->toBe('Anniversary dinner');
 });
 
-test('updates existing transaction instead of creating new', function () {
+test('editing creates child record instead of mutating original', function () {
     $user = User::factory()->create();
     $account = Account::factory()->for($user)->create();
     $transaction = Transaction::factory()->for($user)->for($account)->manual()->create([
@@ -411,8 +431,17 @@ test('updates existing transaction instead of creating new', function () {
         ->call('save');
 
     expect(Transaction::query()->where('user_id', $user->id)->count())
-        ->toBe($originalCount)
-        ->and($transaction->fresh()->description)->toBe('updated');
+        ->toBe($originalCount + 1)
+        ->and($transaction->fresh()->description)->toBe('original');
+
+    $child = Transaction::query()
+        ->where('parent_transaction_id', $transaction->id)
+        ->first();
+
+    expect($child)
+        ->not->toBeNull()
+        ->description->toBe('updated')
+        ->amount->toBe(2000);
 });
 
 test('dispatches transaction-saved event on update', function () {
@@ -431,7 +460,7 @@ test('dispatches transaction-saved event on update', function () {
         ->assertDispatched('transaction-saved');
 });
 
-test('basiq transaction does not modify amount or account on save', function () {
+test('basiq transaction parent remains immutable on save', function () {
     $user = User::factory()->create();
     $account = Account::factory()->for($user)->create();
     $transaction = Transaction::factory()->for($user)->for($account)->fromBasiq()->create([
@@ -454,7 +483,17 @@ test('basiq transaction does not modify amount or account on save', function () 
         ->amount->toBe($originalAmount)
         ->post_date->format('Y-m-d')->toBe($originalDate)
         ->account_id->toBe($originalAccountId)
-        ->notes->toBe('Updated note');
+        ->notes->toBeNull();
+
+    $child = Transaction::query()
+        ->where('parent_transaction_id', $transaction->id)
+        ->first();
+
+    expect($child)
+        ->not->toBeNull()
+        ->notes->toBe('Updated note')
+        ->amount->toBe($originalAmount)
+        ->account_id->toBe($originalAccountId);
 });
 
 test('resets form after edit save including edit-specific properties', function () {
@@ -593,7 +632,7 @@ test('edit transfer opens with pre-filled data for both sides', function () {
         ->assertSet('descriptionInput', '100.00 savings transfer');
 });
 
-test('edit transfer updates both sides', function () {
+test('edit transfer creates child pairs cross-linked to each other', function () {
     $user = User::factory()->create();
     $fromAccount = Account::factory()->for($user)->create();
     $toAccount = Account::factory()->for($user)->create();
@@ -628,17 +667,33 @@ test('edit transfer updates both sides', function () {
 
     $debit->refresh();
     $credit->refresh();
+    expect($debit->amount)->toBe(10000)
+        ->and($debit->description)->toBe('original')
+        ->and($credit->amount)->toBe(10000)
+        ->and($credit->description)->toBe('original');
 
-    expect($debit)
+    $debitChild = Transaction::query()
+        ->where('parent_transaction_id', $debit->id)
+        ->first();
+    $creditChild = Transaction::query()
+        ->where('parent_transaction_id', $credit->id)
+        ->first();
+
+    expect($debitChild)
+        ->not->toBeNull()
         ->amount->toBe(20000)
-        ->description
-        ->toBe('updated transfer')
-        ->and($credit)
+        ->description->toBe('updated transfer')
+        ->direction->toBe(TransactionDirection::Debit)
+        ->transfer_pair_id->toBe($creditChild->id)
+        ->and($creditChild)
+        ->not->toBeNull()
         ->amount->toBe(20000)
-        ->description->toBe('updated transfer');
+        ->description->toBe('updated transfer')
+        ->direction->toBe(TransactionDirection::Credit)
+        ->transfer_pair_id->toBe($debitChild->id);
 });
 
-test('delete transfer removes both sides', function () {
+test('delete transfer soft-deletes both sides', function () {
     $user = User::factory()->create();
     $fromAccount = Account::factory()->for($user)->create();
     $toAccount = Account::factory()->for($user)->create();
@@ -667,10 +722,11 @@ test('delete transfer removes both sides', function () {
         ->assertSet('showModal', false)
         ->assertDispatched('transaction-saved');
 
-    expect(Transaction::query()->where('user_id', $user->id)->count())->toBe(0);
+    expect(Transaction::query()->where('user_id', $user->id)->count())->toBe(0)
+        ->and(Transaction::withTrashed()->where('user_id', $user->id)->count())->toBe(2);
 });
 
-test('delete non-transfer removes single transaction', function () {
+test('delete non-transfer soft-deletes single transaction', function () {
     $user = User::factory()->create();
     $account = Account::factory()->for($user)->create();
     $transaction = Transaction::factory()->for($user)->for($account)->manual()->create();
@@ -681,7 +737,8 @@ test('delete non-transfer removes single transaction', function () {
         ->call('deleteTransaction')
         ->assertSet('showModal', false);
 
-    expect(Transaction::query()->where('id', $transaction->id)->exists())->toBeFalse();
+    expect(Transaction::query()->where('id', $transaction->id)->exists())->toBeFalse()
+        ->and(Transaction::withTrashed()->where('id', $transaction->id)->exists())->toBeTrue();
 });
 
 test('cannot delete basiq transaction', function () {
@@ -1244,7 +1301,7 @@ test('editing transfer shows only transfer option', function () {
         ->assertSeeHtml("\$set('transactionType', 'transfer')");
 });
 
-test('switching expense to income during edit saves correct direction', function () {
+test('switching expense to income during edit creates child with correct direction', function () {
     $user = User::factory()->create();
     $account = Account::factory()->for($user)->create();
     $transaction = Transaction::factory()->for($user)->for($account)->manual()->create([
@@ -1264,7 +1321,14 @@ test('switching expense to income during edit saves correct direction', function
         ->assertHasNoErrors();
 
     $transaction->refresh();
-    expect($transaction)
+    expect($transaction->direction)->toBe(TransactionDirection::Debit);
+
+    $child = Transaction::query()
+        ->where('parent_transaction_id', $transaction->id)
+        ->first();
+
+    expect($child)
+        ->not->toBeNull()
         ->direction->toBe(TransactionDirection::Credit);
 });
 
@@ -1507,8 +1571,16 @@ test('header date is editable for manual transaction', function () {
         ->assertHasNoErrors()
         ->assertSet('showModal', false);
 
+    $child = Transaction::query()
+        ->where('parent_transaction_id', $transaction->id)
+        ->first();
+
+    expect($child)
+        ->not->toBeNull()
+        ->post_date->format('Y-m-d')->toBe('2026-03-20');
+
     $transaction->refresh();
-    expect($transaction->post_date->format('Y-m-d'))->toBe('2026-03-20');
+    expect($transaction->post_date->format('Y-m-d'))->toBe('2026-03-15');
 });
 
 test('header date is read-only badge for basiq transaction', function () {
@@ -1578,4 +1650,132 @@ test('editing planned transfer shows only transfer option', function () {
         ->assertDontSeeHtml("\$set('transactionType', 'expense')")
         ->assertDontSeeHtml("\$set('transactionType', 'income')")
         ->assertSeeHtml("\$set('transactionType', 'transfer')");
+});
+
+// ── Parent-Child Architecture (#134) ─────────────────────────────
+
+test('editing an already-edited transaction creates grandchild', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+
+    $original = Transaction::factory()->for($user)->for($account)->manual()->create([
+        'amount' => 1000,
+        'description' => 'original',
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('edit-transaction', id: $original->id)
+        ->set('descriptionInput', '20.00 first edit')
+        ->call('save');
+
+    $child = Transaction::query()
+        ->where('parent_transaction_id', $original->id)
+        ->first();
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('edit-transaction', id: $child->id)
+        ->set('descriptionInput', '30.00 second edit')
+        ->call('save');
+
+    $grandchild = Transaction::query()
+        ->where('parent_transaction_id', $child->id)
+        ->first();
+
+    expect($grandchild)
+        ->not->toBeNull()
+        ->description->toBe('second edit')
+        ->amount->toBe(3000);
+
+    $currentIds = Transaction::query()
+        ->where('user_id', $user->id)
+        ->current()
+        ->pluck('id');
+
+    expect($currentIds)->toContain($grandchild->id)
+        ->not->toContain($original->id)
+        ->not->toContain($child->id);
+});
+
+test('deleting a child resurfaces the parent as current', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+
+    $parent = Transaction::factory()->for($user)->for($account)->manual()->create([
+        'amount' => 1000,
+        'description' => 'original',
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('edit-transaction', id: $parent->id)
+        ->set('descriptionInput', '20.00 edited')
+        ->call('save');
+
+    $child = Transaction::query()
+        ->where('parent_transaction_id', $parent->id)
+        ->first();
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('edit-transaction', id: $child->id)
+        ->call('deleteTransaction');
+
+    $currentIds = Transaction::query()
+        ->where('user_id', $user->id)
+        ->current()
+        ->pluck('id');
+
+    expect($currentIds)->toContain($parent->id);
+});
+
+test('cannot delete basiq original but can delete basiq child', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $category = Category::factory()->create(['is_hidden' => false]);
+
+    $basiqOriginal = Transaction::factory()->for($user)->for($account)->fromBasiq()->create();
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('edit-transaction', id: $basiqOriginal->id)
+        ->set('categoryId', $category->id)
+        ->call('save');
+
+    $child = Transaction::query()
+        ->where('parent_transaction_id', $basiqOriginal->id)
+        ->first();
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('edit-transaction', id: $basiqOriginal->id)
+        ->call('deleteTransaction');
+
+    expect(Transaction::query()->find($basiqOriginal->id))->not->toBeNull();
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('edit-transaction', id: $child->id)
+        ->call('deleteTransaction');
+
+    expect(Transaction::query()->find($child->id))->toBeNull()
+        ->and(Transaction::withTrashed()->find($child->id))->not->toBeNull();
+});
+
+test('openForEdit resolves superseded parent to latest child', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+
+    $parent = Transaction::factory()->for($user)->for($account)->manual()->create([
+        'amount' => 1000,
+        'description' => 'original',
+    ]);
+
+    $child = $parent->createChild(['description' => 'edited']);
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('edit-transaction', id: $parent->id)
+        ->assertSet('editingTransactionId', $child->id);
 });

--- a/tests/Feature/Models/TransactionTest.php
+++ b/tests/Feature/Models/TransactionTest.php
@@ -215,11 +215,20 @@ test('transfer pair relationship returns a transaction', function () {
         ->and($transaction->transferPair->id)->toBe($pair->id);
 });
 
-test('deleting transfer pair nullifies transfer_pair_id', function () {
+test('soft-deleting transfer pair preserves transfer_pair_id', function () {
     $pair = Transaction::factory()->create();
     $transaction = Transaction::factory()->create(['transfer_pair_id' => $pair->id]);
 
     $pair->delete();
+
+    expect($transaction->fresh()->transfer_pair_id)->toBe($pair->id);
+});
+
+test('force-deleting transfer pair nullifies transfer_pair_id', function () {
+    $pair = Transaction::factory()->create();
+    $transaction = Transaction::factory()->create(['transfer_pair_id' => $pair->id]);
+
+    $pair->forceDelete();
 
     expect($transaction->fresh()->transfer_pair_id)->toBeNull();
 });
@@ -241,6 +250,222 @@ test('withNotes factory state populates notes', function () {
 
     expect($transaction->notes)->not->toBeNull()
         ->and($transaction->notes)->toBeString();
+});
+
+// ── Parent-Child Architecture (#134) ─────────────────────────────
+
+test('parent relationship returns parent transaction', function () {
+    $parent = Transaction::factory()->create();
+    $child = Transaction::factory()->create(['parent_transaction_id' => $parent->id]);
+
+    expect($child->parent)->toBeInstanceOf(Transaction::class)
+        ->and($child->parent->id)->toBe($parent->id);
+});
+
+test('children relationship returns child transactions', function () {
+    $parent = Transaction::factory()->create();
+    Transaction::factory()->count(2)->create(['parent_transaction_id' => $parent->id]);
+
+    expect($parent->children)->toHaveCount(2)
+        ->each(fn (Pest\Expectation $child) => $child->toBeInstanceOf(Transaction::class));
+});
+
+test('createChild copies all fields and sets parent_transaction_id', function () {
+    $parent = Transaction::factory()->withCategory()->withNotes()->create([
+        'amount' => 5000,
+        'description' => 'original coffee',
+        'post_date' => '2026-03-15',
+    ]);
+
+    $child = $parent->createChild();
+
+    expect($child->parent_transaction_id)->toBe($parent->id)
+        ->and($child->user_id)->toBe($parent->user_id)
+        ->and($child->account_id)->toBe($parent->account_id)
+        ->and($child->category_id)->toBe($parent->category_id)
+        ->and($child->amount)->toBe($parent->amount)
+        ->and($child->direction)->toBe($parent->direction)
+        ->and($child->description)->toBe($parent->description)
+        ->and($child->post_date->format('Y-m-d'))->toBe('2026-03-15')
+        ->and($child->notes)->toBe($parent->notes)
+        ->and($child->id)->not->toBe($parent->id);
+});
+
+test('createChild applies overrides on top of copied fields', function () {
+    $parent = Transaction::factory()->create([
+        'amount' => 5000,
+        'description' => 'original',
+    ]);
+
+    $child = $parent->createChild([
+        'amount' => 9999,
+        'description' => 'updated',
+    ]);
+
+    expect($child->amount)->toBe(9999)
+        ->and($child->description)->toBe('updated')
+        ->and($child->account_id)->toBe($parent->account_id);
+});
+
+test('scopeCurrent excludes transactions with live children', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+
+    $parent = Transaction::factory()->for($user)->for($account)->create();
+    Transaction::factory()->for($user)->for($account)->create([
+        'parent_transaction_id' => $parent->id,
+    ]);
+
+    $current = Transaction::query()
+        ->where('user_id', $user->id)
+        ->current()
+        ->pluck('id');
+
+    expect($current)->not->toContain($parent->id);
+});
+
+test('scopeCurrent includes transactions with no children', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+
+    $standalone = Transaction::factory()->for($user)->for($account)->create();
+
+    $current = Transaction::query()
+        ->where('user_id', $user->id)
+        ->current()
+        ->pluck('id');
+
+    expect($current)->toContain($standalone->id);
+});
+
+test('scopeCurrent includes parent whose child is soft-deleted', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+
+    $parent = Transaction::factory()->for($user)->for($account)->create();
+    $child = Transaction::factory()->for($user)->for($account)->create([
+        'parent_transaction_id' => $parent->id,
+    ]);
+
+    $child->delete();
+
+    $current = Transaction::query()
+        ->where('user_id', $user->id)
+        ->current()
+        ->pluck('id');
+
+    expect($current)->toContain($parent->id);
+});
+
+test('soft delete sets deleted_at and excludes from default queries', function () {
+    $transaction = Transaction::factory()->create();
+
+    $transaction->delete();
+
+    expect(Transaction::query()->find($transaction->id))->toBeNull()
+        ->and(Transaction::withTrashed()->find($transaction->id))->not->toBeNull()
+        ->and(Transaction::withTrashed()->find($transaction->id)->deleted_at)->not->toBeNull();
+});
+
+test('findCurrentVersion returns child when parent has one', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+
+    $parent = Transaction::factory()->for($user)->for($account)->create();
+    $child = Transaction::factory()->for($user)->for($account)->create([
+        'parent_transaction_id' => $parent->id,
+    ]);
+
+    $found = Transaction::findCurrentVersion($parent->id, $user->id);
+
+    expect($found->id)->toBe($child->id);
+});
+
+test('findCurrentVersion returns self when no children', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+
+    $standalone = Transaction::factory()->for($user)->for($account)->create();
+
+    $found = Transaction::findCurrentVersion($standalone->id, $user->id);
+
+    expect($found->id)->toBe($standalone->id);
+});
+
+test('findCurrentVersion walks full chain from original ancestor', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+
+    $grandparent = Transaction::factory()->for($user)->for($account)->create();
+    $parent = Transaction::factory()->for($user)->for($account)->create([
+        'parent_transaction_id' => $grandparent->id,
+    ]);
+    $child = $parent->createChild(['description' => 'grandchild']);
+
+    $found = Transaction::findCurrentVersion($grandparent->id, $user->id);
+
+    expect($found->id)->toBe($child->id);
+});
+
+test('createChild does not copy basiq_id from parent', function () {
+    $parent = Transaction::factory()->fromBasiq()->create();
+
+    $child = $parent->createChild();
+
+    expect($child->basiq_id)->toBeNull()
+        ->and($parent->basiq_id)->not->toBeNull();
+});
+
+test('findCurrentVersion walks chain from middle node', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+
+    $grandparent = Transaction::factory()->for($user)->for($account)->create();
+    $parent = Transaction::factory()->for($user)->for($account)->create([
+        'parent_transaction_id' => $grandparent->id,
+    ]);
+    $child = $parent->createChild(['description' => 'grandchild']);
+
+    $found = Transaction::findCurrentVersion($parent->id, $user->id);
+
+    expect($found->id)->toBe($child->id);
+});
+
+test('withParent factory state sets parent_transaction_id', function () {
+    $transaction = Transaction::factory()->withParent()->create();
+
+    expect($transaction->parent_transaction_id)->not->toBeNull()
+        ->and($transaction->parent)->toBeInstanceOf(Transaction::class);
+});
+
+test('softDeleted factory state sets deleted_at', function () {
+    $transaction = Transaction::factory()->softDeleted()->create();
+
+    expect(Transaction::query()->find($transaction->id))->toBeNull()
+        ->and(Transaction::withTrashed()->find($transaction->id)->deleted_at)->not->toBeNull();
+});
+
+test('deleting parent with nullOnDelete sets child parent_transaction_id to null', function () {
+    $parent = Transaction::factory()->create();
+    $child = Transaction::factory()->create(['parent_transaction_id' => $parent->id]);
+
+    $parent->forceDelete();
+
+    expect($child->fresh()->parent_transaction_id)->toBeNull();
+});
+
+test('createChild preserves planned_transaction_id from parent', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $planned = App\Models\PlannedTransaction::factory()->for($user)->for($account)->create();
+
+    $parent = Transaction::factory()->for($user)->for($account)->create([
+        'planned_transaction_id' => $planned->id,
+    ]);
+
+    $child = $parent->createChild();
+
+    expect($child->planned_transaction_id)->toBe($planned->id);
 });
 
 test('backfill sets source to basiq for transactions with basiq_id', function () {


### PR DESCRIPTION
## Summary

Implements immutable transaction history for issue #134 — the foundation ticket that unblocks #135 (Transfer Conversion) and #136 (Enter/Plan Mode Conversion).

- **Edit = create child**: When a user "edits" any transaction, a new child record is created referencing the original via `parent_transaction_id`. The original is never mutated.
- **Delete = soft-archive**: `SoftDeletes` replaces hard-deletes. No transaction is ever destroyed.
- **`scopeCurrent()`**: All 10 query sites across 8 files now chain `->current()` to exclude superseded parents from display and aggregation.
- **Basiq immutability**: Bank-synced originals (`source = basiq`) cannot be deleted. User edit overlays (children) can be soft-deleted to resurface the original.
- **Transfer child pairs**: Editing a transfer creates two child records cross-linked to each other, preserving both original sides.

## Changes

| Area | What |
|------|------|
| Migration | `parent_transaction_id` FK + `deleted_at` + composite index |
| Transaction model | `SoftDeletes`, `parent()`/`children()`, `scopeCurrent()`, `createChild()`, `findCurrentVersion()` |
| Factory | `withParent()` and `softDeleted()` states |
| TransactionModal | Edit → child, delete → soft-delete, transfer edit → child pairs, openForEdit → `findCurrentVersion()` |
| 10 query sites | `TransactionList`, `SpendingByCategory`, `SpendingOverTime`, `CalendarView`, `ReconciliationMatcher` (2), `CategoryEditor` (3), `User`, `Budget` |
| Pint config | Disabled `no_superfluous_phpdoc_tags` to resolve conflict with PHPStan generics |
| Tests | 16 new model tests, 4 new modal tests, 7 updated modal tests, 1 split into soft/force-delete |

## Test plan

- [ ] `op test.filter TransactionTest` — 88 pass (parent-child relationships, scopes, createChild, findCurrentVersion, soft deletes, factory states)
- [ ] `op test.filter TransactionModalTest` — 92 pass (child creation on edit, soft-delete on delete, grandchild chains, Basiq child deletion, transfer child pairs, superseded parent resolution)
- [ ] `op ci` — 826 passed, 0 failures, PHPStan 0 errors, Pint clean
- [ ] Verify existing SyncTransactionsJob tests still pass (22 tests, independent of parent-child)
- [ ] Verify PlannedTransaction tests still pass (36 tests, no schema changes)

Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)