### PR TITLE
feat: [135] Transfer conversion during edit

### DIFF
--- a/app/Livewire/TransactionModal.php
+++ b/app/Livewire/TransactionModal.php
@@ -13,10 +13,12 @@ use App\Models\Category;
 use App\Models\PlannedTransaction;
 use App\Models\Transaction;
 use App\Support\AmountParser;
+use App\Support\AmountParseResult;
 use Carbon\CarbonImmutable;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\Rule;
 use Illuminate\View\View;
+use Livewire\Attributes\Locked;
 use Livewire\Attributes\On;
 use Livewire\Component;
 use Throwable;
@@ -27,6 +29,7 @@ final class TransactionModal extends Component
 
     public ?int $editingTransactionId = null;
 
+    #[Locked]
     public bool $isBasiqTransaction = false;
 
     public string $transactionType = 'expense';
@@ -55,6 +58,7 @@ final class TransactionModal extends Component
 
     public ?string $untilDate = null;
 
+    #[Locked]
     public bool $originalWasTransfer = false;
 
     #[On('open-transaction-modal')]
@@ -182,21 +186,7 @@ final class TransactionModal extends Component
 
         $this->validate($this->formRules());
 
-        if ($this->editingPlannedTransactionId) {
-            $saved = $this->updatePlannedTransaction();
-        } elseif ($this->mode === 'plan') {
-            $saved = $this->createPlannedTransaction();
-        } elseif ($this->editingTransactionId) {
-            $saved = $this->isTransfer()
-                ? $this->updateTransfer()
-                : $this->updateTransaction();
-        } else {
-            $saved = $this->transactionType === 'transfer'
-                ? $this->createTransfer()
-                : $this->createTransaction();
-        }
-
-        if (! $saved) {
+        if (! $this->resolveSave()) {
             return;
         }
 
@@ -285,6 +275,39 @@ final class TransactionModal extends Component
         $this->showModal = false;
         $this->resetForm();
         $this->dispatch('transaction-saved');
+    }
+
+    /**
+     * @throws Throwable
+     */
+    private function resolveSave(): bool
+    {
+        if ($this->editingPlannedTransactionId) {
+            return $this->updatePlannedTransaction();
+        }
+
+        if ($this->mode === 'plan') {
+            return $this->createPlannedTransaction();
+        }
+
+        if (! $this->editingTransactionId) {
+            return $this->transactionType === 'transfer'
+                ? $this->createTransfer()
+                : $this->createTransaction();
+        }
+
+        if ($this->isBasiqTransaction) {
+            return $this->updateTransaction();
+        }
+
+        $nowIsTransfer = $this->transactionType === 'transfer';
+
+        return match (true) {
+            ! $this->originalWasTransfer && ! $nowIsTransfer => $this->updateTransaction(),
+            $this->originalWasTransfer && $nowIsTransfer => $this->updateTransfer(),
+            ! $this->originalWasTransfer && $nowIsTransfer => $this->convertToTransfer(),
+            default => $this->convertFromTransfer(),
+        };
     }
 
     private function createTransaction(): bool
@@ -433,13 +456,13 @@ final class TransactionModal extends Component
 
     private function updateTransaction(): bool
     {
-        $transaction = Transaction::query()
-            ->where('user_id', auth()->id())
-            ->find($this->editingTransactionId);
+        $resolved = $this->resolveTransactionWithParsedAmount();
 
-        if (! $transaction) {
+        if ($resolved === false) {
             return false;
         }
+
+        [$transaction, $parsed] = $resolved;
 
         if ($transaction->source === TransactionSource::Basiq) {
             $transaction->createChild([
@@ -449,14 +472,6 @@ final class TransactionModal extends Component
             ]);
 
             return true;
-        }
-
-        $parsed = AmountParser::parse($this->descriptionInput);
-
-        if ($parsed->amount <= 0) {
-            $this->addError('descriptionInput', __('The amount must be greater than zero.'));
-
-            return false;
         }
 
         $transaction->createChild([
@@ -478,6 +493,135 @@ final class TransactionModal extends Component
      * @throws Throwable
      */
     private function updateTransfer(): bool
+    {
+        $resolved = $this->resolveTransferPairWithParsedAmount();
+
+        if ($resolved === false) {
+            return false;
+        }
+
+        [$debitSide, $creditSide, $parsed] = $resolved;
+
+        DB::transaction(function () use ($debitSide, $creditSide, $parsed): void {
+            $shared = [
+                'category_id' => $this->categoryId,
+                'amount' => $parsed->amount,
+                'description' => $parsed->description,
+                'post_date' => $this->date,
+                'notes' => $this->notes !== '' ? $this->notes : null,
+            ];
+
+            $debitChild = $debitSide->createChild($shared + ['account_id' => $this->accountId]);
+            $creditChild = $creditSide->createChild($shared + ['account_id' => $this->transferToAccountId]);
+
+            $debitChild->update(['transfer_pair_id' => $creditChild->id]);
+            $creditChild->update(['transfer_pair_id' => $debitChild->id]);
+        });
+
+        return true;
+    }
+
+    /**
+     * @throws Throwable
+     */
+    private function convertToTransfer(): bool
+    {
+        $resolved = $this->resolveTransactionWithParsedAmount();
+
+        if ($resolved === false) {
+            return false;
+        }
+
+        [$transaction, $parsed] = $resolved;
+
+        DB::transaction(function () use ($transaction, $parsed): void {
+            $shared = [
+                'amount' => $parsed->amount,
+                'description' => $parsed->description,
+                'post_date' => $this->date,
+                'category_id' => $this->categoryId,
+                'notes' => $this->notes !== '' ? $this->notes : null,
+            ];
+
+            $debitChild = $transaction->createChild($shared + [
+                'account_id' => $this->accountId,
+                'direction' => TransactionDirection::Debit,
+            ]);
+
+            $credit = Transaction::query()->create($shared + [
+                'user_id' => auth()->id(),
+                'account_id' => $this->transferToAccountId,
+                'direction' => TransactionDirection::Credit,
+                'source' => TransactionSource::Manual,
+                'status' => TransactionStatus::Posted,
+            ]);
+
+            $debitChild->update(['transfer_pair_id' => $credit->id]);
+            $credit->update(['transfer_pair_id' => $debitChild->id]);
+        });
+
+        return true;
+    }
+
+    /**
+     * @throws Throwable
+     */
+    private function convertFromTransfer(): bool
+    {
+        $resolved = $this->resolveTransferPairWithParsedAmount();
+
+        if ($resolved === false) {
+            return false;
+        }
+
+        [$debitSide, $creditSide, $parsed] = $resolved;
+
+        $direction = $this->transactionType === 'expense'
+            ? TransactionDirection::Debit
+            : TransactionDirection::Credit;
+
+        DB::transaction(function () use ($debitSide, $creditSide, $parsed, $direction): void {
+            $debitSide->createChild([
+                'account_id' => $this->accountId,
+                'direction' => $direction,
+                'amount' => $parsed->amount,
+                'description' => $parsed->description,
+                'post_date' => $this->date,
+                'category_id' => $this->categoryId,
+                'notes' => $this->notes !== '' ? $this->notes : null,
+                'transfer_pair_id' => null,
+            ]);
+
+            $creditSide->delete();
+        });
+
+        return true;
+    }
+
+    /** @return array{Transaction, AmountParseResult}|false */
+    private function resolveTransactionWithParsedAmount(): array|false
+    {
+        $transaction = Transaction::query()
+            ->where('user_id', auth()->id())
+            ->find($this->editingTransactionId);
+
+        if (! $transaction) {
+            return false;
+        }
+
+        $parsed = AmountParser::parse($this->descriptionInput);
+
+        if ($parsed->amount <= 0) {
+            $this->addError('descriptionInput', __('The amount must be greater than zero.'));
+
+            return false;
+        }
+
+        return [$transaction, $parsed];
+    }
+
+    /** @return array{Transaction, Transaction, AmountParseResult}|false */
+    private function resolveTransferPairWithParsedAmount(): array|false
     {
         $transaction = Transaction::query()
             ->where('user_id', auth()->id())
@@ -503,39 +647,15 @@ final class TransactionModal extends Component
             return false;
         }
 
-        DB::transaction(function () use ($transaction, $pair, $parsed): void {
-            $shared = [
-                'category_id' => $this->categoryId,
-                'amount' => $parsed->amount,
-                'description' => $parsed->description,
-                'post_date' => $this->date,
-                'notes' => $this->notes !== '' ? $this->notes : null,
-            ];
+        $debitSide = $transaction->direction === TransactionDirection::Debit ? $transaction : $pair;
+        $creditSide = $transaction->direction === TransactionDirection::Credit ? $transaction : $pair;
 
-            $debitSide = $transaction->direction === TransactionDirection::Debit ? $transaction : $pair;
-            $creditSide = $transaction->direction === TransactionDirection::Credit ? $transaction : $pair;
-
-            $debitChild = $debitSide->createChild($shared + ['account_id' => $this->accountId]);
-            $creditChild = $creditSide->createChild($shared + ['account_id' => $this->transferToAccountId]);
-
-            $debitChild->update(['transfer_pair_id' => $creditChild->id]);
-            $creditChild->update(['transfer_pair_id' => $debitChild->id]);
-        });
-
-        return true;
+        return [$debitSide, $creditSide, $parsed];
     }
 
     private function isTransfer(): bool
     {
-        if (! $this->editingTransactionId) {
-            return $this->transactionType === 'transfer';
-        }
-
-        return Transaction::query()
-            ->where('id', $this->editingTransactionId)
-            ->where('user_id', auth()->id())
-            ->whereNotNull('transfer_pair_id')
-            ->exists();
+        return $this->transactionType === 'transfer';
     }
 
     private function resetForm(): void

--- a/resources/views/livewire/transaction-modal.blade.php
+++ b/resources/views/livewire/transaction-modal.blade.php
@@ -58,19 +58,15 @@
                             </flux:button>
 
                             <flux:menu>
-                                @if(!$originalWasTransfer || (!$editingTransactionId && !$editingPlannedTransactionId))
-                                    <flux:menu.item wire:click="$set('transactionType', 'expense')" class="text-red-600 dark:text-red-400">
-                                        {{ __('expense') }}
-                                    </flux:menu.item>
-                                    <flux:menu.item wire:click="$set('transactionType', 'income')" class="text-green-600 dark:text-green-400">
-                                        {{ __('income') }}
-                                    </flux:menu.item>
-                                @endif
-                                @if($originalWasTransfer || (!$editingTransactionId && !$editingPlannedTransactionId))
-                                    <flux:menu.item wire:click="$set('transactionType', 'transfer')" class="text-amber-600 dark:text-amber-400">
-                                        {{ __('transfer between accounts') }}
-                                    </flux:menu.item>
-                                @endif
+                                <flux:menu.item wire:click="$set('transactionType', 'expense')" class="text-red-600 dark:text-red-400">
+                                    {{ __('expense') }}
+                                </flux:menu.item>
+                                <flux:menu.item wire:click="$set('transactionType', 'income')" class="text-green-600 dark:text-green-400">
+                                    {{ __('income') }}
+                                </flux:menu.item>
+                                <flux:menu.item wire:click="$set('transactionType', 'transfer')" class="text-amber-600 dark:text-amber-400">
+                                    {{ __('transfer between accounts') }}
+                                </flux:menu.item>
                             </flux:menu>
                         </flux:dropdown>
                     @endif

--- a/tests/Feature/Livewire/TransactionModalTest.php
+++ b/tests/Feature/Livewire/TransactionModalTest.php
@@ -1256,7 +1256,7 @@ test('static heading shown when editing basiq transaction', function () {
         ->assertDontSeeHtml("\$set('transactionType', 'transfer')");
 });
 
-test('editing manual expense shows expense and income options but not transfer', function () {
+test('editing manual expense shows all type options including transfer', function () {
     $user = User::factory()->create();
     $account = Account::factory()->for($user)->create();
     $transaction = Transaction::factory()->for($user)->for($account)->manual()->create([
@@ -1268,10 +1268,10 @@ test('editing manual expense shows expense and income options but not transfer',
         ->dispatch('edit-transaction', id: $transaction->id)
         ->assertSeeHtml("\$set('transactionType', 'expense')")
         ->assertSeeHtml("\$set('transactionType', 'income')")
-        ->assertDontSeeHtml("\$set('transactionType', 'transfer')");
+        ->assertSeeHtml("\$set('transactionType', 'transfer')");
 });
 
-test('editing transfer shows only transfer option', function () {
+test('editing transfer shows all type options including expense and income', function () {
     $user = User::factory()->create();
     $fromAccount = Account::factory()->for($user)->create();
     $toAccount = Account::factory()->for($user)->create();
@@ -1296,8 +1296,8 @@ test('editing transfer shows only transfer option', function () {
     Livewire::actingAs($user)
         ->test(TransactionModal::class)
         ->dispatch('edit-transaction', id: $debit->id)
-        ->assertDontSeeHtml("\$set('transactionType', 'expense')")
-        ->assertDontSeeHtml("\$set('transactionType', 'income')")
+        ->assertSeeHtml("\$set('transactionType', 'expense')")
+        ->assertSeeHtml("\$set('transactionType', 'income')")
         ->assertSeeHtml("\$set('transactionType', 'transfer')");
 });
 
@@ -1613,7 +1613,7 @@ test('originalWasTransfer resets after save', function () {
         ->assertSet('originalWasTransfer', false);
 });
 
-test('editing planned expense shows expense and income options but not transfer', function () {
+test('editing planned expense shows all type options including transfer', function () {
     $user = User::factory()->create();
     $account = Account::factory()->for($user)->create();
     $planned = PlannedTransaction::factory()->for($user)->for($account)->monthly()->create([
@@ -1627,10 +1627,10 @@ test('editing planned expense shows expense and income options but not transfer'
         ->dispatch('edit-planned-transaction', id: $planned->id)
         ->assertSeeHtml("\$set('transactionType', 'expense')")
         ->assertSeeHtml("\$set('transactionType', 'income')")
-        ->assertDontSeeHtml("\$set('transactionType', 'transfer')");
+        ->assertSeeHtml("\$set('transactionType', 'transfer')");
 });
 
-test('editing planned transfer shows only transfer option', function () {
+test('editing planned transfer shows all type options including expense and income', function () {
     $user = User::factory()->create();
     $fromAccount = Account::factory()->for($user)->create();
     $toAccount = Account::factory()->for($user)->create();
@@ -1647,8 +1647,8 @@ test('editing planned transfer shows only transfer option', function () {
     Livewire::actingAs($user)
         ->test(TransactionModal::class)
         ->dispatch('edit-planned-transaction', id: $planned->id)
-        ->assertDontSeeHtml("\$set('transactionType', 'expense')")
-        ->assertDontSeeHtml("\$set('transactionType', 'income')")
+        ->assertSeeHtml("\$set('transactionType', 'expense')")
+        ->assertSeeHtml("\$set('transactionType', 'income')")
         ->assertSeeHtml("\$set('transactionType', 'transfer')");
 });
 
@@ -1778,4 +1778,456 @@ test('openForEdit resolves superseded parent to latest child', function () {
         ->test(TransactionModal::class)
         ->dispatch('edit-transaction', id: $parent->id)
         ->assertSet('editingTransactionId', $child->id);
+});
+
+// ── Transfer Conversion (#135) ──────────────────────────────────
+
+test('converting expense to transfer creates child and new credit side', function () {
+    $user = User::factory()->create();
+    $fromAccount = Account::factory()->for($user)->create();
+    $toAccount = Account::factory()->for($user)->create();
+
+    $expense = Transaction::factory()->for($user)->create([
+        'account_id' => $fromAccount->id,
+        'amount' => 5000,
+        'direction' => TransactionDirection::Debit,
+        'description' => 'original expense',
+        'post_date' => '2026-03-15',
+        'source' => TransactionSource::Manual,
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('edit-transaction', id: $expense->id)
+        ->set('transactionType', 'transfer')
+        ->set('descriptionInput', '50.00 transfer to savings')
+        ->set('transferToAccountId', $toAccount->id)
+        ->call('save')
+        ->assertSet('showModal', false)
+        ->assertHasNoErrors();
+
+    $expense->refresh();
+    expect($expense->direction)->toBe(TransactionDirection::Debit)
+        ->and($expense->description)->toBe('original expense');
+
+    $debitChild = Transaction::query()
+        ->where('parent_transaction_id', $expense->id)
+        ->first();
+
+    expect($debitChild)
+        ->not->toBeNull()
+        ->direction->toBe(TransactionDirection::Debit)
+        ->account_id->toBe($fromAccount->id)
+        ->amount->toBe(5000)
+        ->transfer_pair_id->not->toBeNull();
+
+    $creditSide = Transaction::query()->find($debitChild->transfer_pair_id);
+
+    expect($creditSide)
+        ->not->toBeNull()
+        ->direction->toBe(TransactionDirection::Credit)
+        ->account_id->toBe($toAccount->id)
+        ->amount->toBe(5000)
+        ->transfer_pair_id->toBe($debitChild->id)
+        ->parent_transaction_id->toBeNull();
+
+    $currentIds = Transaction::query()
+        ->where('user_id', $user->id)
+        ->current()
+        ->pluck('id');
+
+    expect($currentIds)
+        ->toContain($debitChild->id)
+        ->toContain($creditSide->id)
+        ->not->toContain($expense->id);
+});
+
+test('converting income to transfer creates child as debit side and new credit side', function () {
+    $user = User::factory()->create();
+    $fromAccount = Account::factory()->for($user)->create();
+    $toAccount = Account::factory()->for($user)->create();
+
+    $income = Transaction::factory()->for($user)->create([
+        'account_id' => $fromAccount->id,
+        'amount' => 10000,
+        'direction' => TransactionDirection::Credit,
+        'description' => 'original income',
+        'post_date' => '2026-03-15',
+        'source' => TransactionSource::Manual,
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('edit-transaction', id: $income->id)
+        ->set('transactionType', 'transfer')
+        ->set('descriptionInput', '100.00 move to savings')
+        ->set('transferToAccountId', $toAccount->id)
+        ->call('save')
+        ->assertSet('showModal', false)
+        ->assertHasNoErrors();
+
+    $debitChild = Transaction::query()
+        ->where('parent_transaction_id', $income->id)
+        ->first();
+
+    expect($debitChild)
+        ->not->toBeNull()
+        ->direction->toBe(TransactionDirection::Debit);
+
+    $creditSide = Transaction::query()->find($debitChild->transfer_pair_id);
+
+    expect($creditSide)
+        ->not->toBeNull()
+        ->direction->toBe(TransactionDirection::Credit)
+        ->account_id->toBe($toAccount->id);
+});
+
+test('converting transfer to expense creates child without pair and soft-deletes credit side', function () {
+    $user = User::factory()->create();
+    $fromAccount = Account::factory()->for($user)->create();
+    $toAccount = Account::factory()->for($user)->create();
+
+    $debit = Transaction::factory()->for($user)->create([
+        'account_id' => $fromAccount->id,
+        'amount' => 5000,
+        'direction' => TransactionDirection::Debit,
+        'description' => 'transfer out',
+        'post_date' => '2026-03-15',
+        'source' => TransactionSource::Manual,
+    ]);
+
+    $credit = Transaction::factory()->for($user)->create([
+        'account_id' => $toAccount->id,
+        'amount' => 5000,
+        'direction' => TransactionDirection::Credit,
+        'description' => 'transfer out',
+        'post_date' => '2026-03-15',
+        'source' => TransactionSource::Manual,
+        'transfer_pair_id' => $debit->id,
+    ]);
+
+    $debit->update(['transfer_pair_id' => $credit->id]);
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('edit-transaction', id: $debit->id)
+        ->set('transactionType', 'expense')
+        ->set('descriptionInput', '50.00 now just an expense')
+        ->call('save')
+        ->assertSet('showModal', false)
+        ->assertHasNoErrors();
+
+    $child = Transaction::query()
+        ->where('parent_transaction_id', $debit->id)
+        ->first();
+
+    expect($child)
+        ->not->toBeNull()
+        ->direction->toBe(TransactionDirection::Debit)
+        ->transfer_pair_id->toBeNull()
+        ->amount->toBe(5000)
+        ->and(Transaction::query()->find($credit->id))->toBeNull()
+        ->and(Transaction::withTrashed()->find($credit->id))->not->toBeNull();
+
+    $currentIds = Transaction::query()
+        ->where('user_id', $user->id)
+        ->current()
+        ->pluck('id');
+
+    expect($currentIds)
+        ->toContain($child->id)
+        ->not->toContain($debit->id)
+        ->not->toContain($credit->id);
+});
+
+test('converting transfer to income creates child with credit direction and soft-deletes credit side', function () {
+    $user = User::factory()->create();
+    $fromAccount = Account::factory()->for($user)->create();
+    $toAccount = Account::factory()->for($user)->create();
+
+    $debit = Transaction::factory()->for($user)->create([
+        'account_id' => $fromAccount->id,
+        'amount' => 8000,
+        'direction' => TransactionDirection::Debit,
+        'description' => 'transfer',
+        'post_date' => '2026-03-15',
+        'source' => TransactionSource::Manual,
+    ]);
+
+    $credit = Transaction::factory()->for($user)->create([
+        'account_id' => $toAccount->id,
+        'amount' => 8000,
+        'direction' => TransactionDirection::Credit,
+        'description' => 'transfer',
+        'post_date' => '2026-03-15',
+        'source' => TransactionSource::Manual,
+        'transfer_pair_id' => $debit->id,
+    ]);
+
+    $debit->update(['transfer_pair_id' => $credit->id]);
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('edit-transaction', id: $debit->id)
+        ->set('transactionType', 'income')
+        ->set('descriptionInput', '80.00 actually income')
+        ->call('save')
+        ->assertSet('showModal', false)
+        ->assertHasNoErrors();
+
+    $child = Transaction::query()
+        ->where('parent_transaction_id', $debit->id)
+        ->first();
+
+    expect($child)
+        ->not->toBeNull()
+        ->direction->toBe(TransactionDirection::Credit)
+        ->transfer_pair_id
+        ->toBeNull()
+        ->and(Transaction::query()->find($credit->id))->toBeNull();
+});
+
+test('converting expense to transfer requires transfer_to_account_id', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+
+    $expense = Transaction::factory()->for($user)->for($account)->manual()->create([
+        'amount' => 5000,
+        'direction' => TransactionDirection::Debit,
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('edit-transaction', id: $expense->id)
+        ->set('transactionType', 'transfer')
+        ->set('descriptionInput', '50.00 transfer')
+        ->set('transferToAccountId', null)
+        ->call('save')
+        ->assertHasErrors(['transferToAccountId']);
+});
+
+test('converting expense to transfer rejects same account for both sides', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+
+    $expense = Transaction::factory()->for($user)->for($account)->manual()->create([
+        'amount' => 5000,
+        'direction' => TransactionDirection::Debit,
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('edit-transaction', id: $expense->id)
+        ->set('transactionType', 'transfer')
+        ->set('descriptionInput', '50.00 transfer')
+        ->set('transferToAccountId', $account->id)
+        ->call('save')
+        ->assertHasErrors(['transferToAccountId']);
+});
+
+test('re-editing converted transaction works correctly', function () {
+    $user = User::factory()->create();
+    $fromAccount = Account::factory()->for($user)->create();
+    $toAccount = Account::factory()->for($user)->create();
+
+    $expense = Transaction::factory()->for($user)->create([
+        'account_id' => $fromAccount->id,
+        'amount' => 5000,
+        'direction' => TransactionDirection::Debit,
+        'description' => 'original',
+        'post_date' => '2026-03-15',
+        'source' => TransactionSource::Manual,
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('edit-transaction', id: $expense->id)
+        ->set('transactionType', 'transfer')
+        ->set('descriptionInput', '50.00 transfer')
+        ->set('transferToAccountId', $toAccount->id)
+        ->call('save');
+
+    $debitChild = Transaction::query()
+        ->where('parent_transaction_id', $expense->id)
+        ->first();
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('edit-transaction', id: $debitChild->id)
+        ->assertSet('transactionType', 'transfer')
+        ->assertSet('originalWasTransfer', true)
+        ->set('descriptionInput', '75.00 updated transfer')
+        ->call('save')
+        ->assertHasNoErrors();
+
+    $grandchild = Transaction::query()
+        ->where('parent_transaction_id', $debitChild->id)
+        ->first();
+
+    expect($grandchild)
+        ->not->toBeNull()
+        ->amount->toBe(7500)
+        ->transfer_pair_id->not->toBeNull();
+});
+
+test('deleting converted transfer deletes both sides', function () {
+    $user = User::factory()->create();
+    $fromAccount = Account::factory()->for($user)->create();
+    $toAccount = Account::factory()->for($user)->create();
+
+    $expense = Transaction::factory()->for($user)->create([
+        'account_id' => $fromAccount->id,
+        'amount' => 5000,
+        'direction' => TransactionDirection::Debit,
+        'description' => 'original',
+        'post_date' => '2026-03-15',
+        'source' => TransactionSource::Manual,
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('edit-transaction', id: $expense->id)
+        ->set('transactionType', 'transfer')
+        ->set('descriptionInput', '50.00 transfer')
+        ->set('transferToAccountId', $toAccount->id)
+        ->call('save');
+
+    $debitChild = Transaction::query()
+        ->where('parent_transaction_id', $expense->id)
+        ->first();
+
+    $creditSide = Transaction::query()->find($debitChild->transfer_pair_id);
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('edit-transaction', id: $debitChild->id)
+        ->call('deleteTransaction');
+
+    expect(Transaction::query()->find($debitChild->id))->toBeNull()
+        ->and(Transaction::query()->find($creditSide->id))->toBeNull()
+        ->and(Transaction::withTrashed()->find($debitChild->id))->not->toBeNull()
+        ->and(Transaction::withTrashed()->find($creditSide->id))->not->toBeNull();
+});
+
+test('planned expense can be converted to planned transfer', function () {
+    $user = User::factory()->create();
+    $fromAccount = Account::factory()->for($user)->create();
+    $toAccount = Account::factory()->for($user)->create();
+
+    $planned = PlannedTransaction::factory()->for($user)->create([
+        'account_id' => $fromAccount->id,
+        'amount' => 5000,
+        'direction' => TransactionDirection::Debit,
+        'description' => 'expense',
+        'start_date' => '2026-04-01',
+        'frequency' => RecurrenceFrequency::EveryMonth,
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('edit-planned-transaction', id: $planned->id)
+        ->set('transactionType', 'transfer')
+        ->set('descriptionInput', '50.00 transfer')
+        ->set('transferToAccountId', $toAccount->id)
+        ->call('save')
+        ->assertSet('showModal', false)
+        ->assertHasNoErrors();
+
+    $planned->refresh();
+    expect($planned->transfer_to_account_id)->toBe($toAccount->id);
+});
+
+test('planned transfer can be converted to planned expense', function () {
+    $user = User::factory()->create();
+    $fromAccount = Account::factory()->for($user)->create();
+    $toAccount = Account::factory()->for($user)->create();
+
+    $planned = PlannedTransaction::factory()->for($user)->create([
+        'account_id' => $fromAccount->id,
+        'transfer_to_account_id' => $toAccount->id,
+        'amount' => 5000,
+        'direction' => TransactionDirection::Debit,
+        'description' => 'transfer',
+        'start_date' => '2026-04-01',
+        'frequency' => RecurrenceFrequency::EveryMonth,
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('edit-planned-transaction', id: $planned->id)
+        ->set('transactionType', 'expense')
+        ->set('descriptionInput', '50.00 expense')
+        ->call('save')
+        ->assertSet('showModal', false)
+        ->assertHasNoErrors();
+
+    $planned->refresh();
+    expect($planned->transfer_to_account_id)->toBeNull()
+        ->and($planned->direction)->toBe(TransactionDirection::Debit);
+});
+
+test('basiq transaction cannot be converted to transfer via tampered transactionType', function () {
+    $user = User::factory()->create();
+    $fromAccount = Account::factory()->for($user)->create();
+    $toAccount = Account::factory()->for($user)->create();
+    $category = Category::factory()->create(['is_hidden' => false]);
+    $transaction = Transaction::factory()->for($user)->for($fromAccount)->fromBasiq()->create([
+        'amount' => 3000,
+        'direction' => TransactionDirection::Debit,
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('edit-transaction', id: $transaction->id)
+        ->set('transactionType', 'transfer')
+        ->set('transferToAccountId', $toAccount->id)
+        ->set('categoryId', $category->id)
+        ->call('save')
+        ->assertSet('showModal', false)
+        ->assertDispatched('transaction-saved');
+
+    expect(Transaction::query()->where('transfer_pair_id', '!=', null)->count())->toBe(0);
+
+    $child = Transaction::query()
+        ->where('parent_transaction_id', $transaction->id)
+        ->first();
+
+    expect($child)
+        ->not->toBeNull()
+        ->category_id->toBe($category->id)
+        ->transfer_pair_id->toBeNull();
+});
+
+test('basiq transaction cannot be converted to income via tampered transactionType', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $category = Category::factory()->create(['is_hidden' => false]);
+    $transaction = Transaction::factory()->for($user)->for($account)->fromBasiq()->create([
+        'amount' => 5000,
+        'direction' => TransactionDirection::Debit,
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('edit-transaction', id: $transaction->id)
+        ->set('transactionType', 'income')
+        ->set('categoryId', $category->id)
+        ->set('notes', 'Tampered direction')
+        ->call('save')
+        ->assertSet('showModal', false)
+        ->assertDispatched('transaction-saved');
+
+    $transaction->refresh();
+    expect($transaction->direction)->toBe(TransactionDirection::Debit);
+
+    $child = Transaction::query()
+        ->where('parent_transaction_id', $transaction->id)
+        ->first();
+
+    expect($child)
+        ->not->toBeNull()
+        ->category_id->toBe($category->id)
+        ->notes->toBe('Tampered direction')
+        ->direction->toBe(TransactionDirection::Debit)
+        ->amount->toBe(5000);
 });


### PR DESCRIPTION
## Summary

- Allows users to freely convert between expense, income, and transfer types when editing transactions
- Adds `convertToTransfer()` (creates debit child + new credit side, cross-linked) and `convertFromTransfer()` (creates child with severed pair, soft-deletes credit side)
- Unlocks the type dropdown in the Blade template so all 3 options are always visible during edit (Basiq transactions remain protected)

## Implementation Details

**4-path routing in `save()`** — Uses `match(true)` with `$originalWasTransfer × $nowIsTransfer` to dispatch: `updateTransaction`, `updateTransfer`, `convertToTransfer`, or `convertFromTransfer`.

**`isTransfer()` simplified** — Now checks user intent (`$this->transactionType === 'transfer'`) instead of querying the DB for `transfer_pair_id`, fixing the chicken-and-egg validation problem during conversion.

**Extracted helpers** — `resolveTransactionWithParsedAmount()` and `resolveTransferPairWithParsedAmount()` remove duplicated load+parse boilerplate across all 4 edit methods.

**Planned transactions** — Get conversion for free via the existing `updatePlannedTransaction()` which already reads `$this->transactionType`.

Closes #135

## Test plan

- [x] 4 existing dropdown restriction tests updated to assert all options visible
- [x] 10 new conversion tests: expense→transfer, income→transfer, transfer→expense, transfer→income, validation (missing account, same account), re-editing after conversion, deletion after conversion, planned expense↔transfer
- [x] Full CI: 838 passed, 0 failures, PHPStan clean, Pint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)