### PR TITLE
feat: pipeline foundation — migrations, models, enums, contract, DTOs (#161)

### DIFF
--- a/app/Contracts/PipelineStageContract.php
+++ b/app/Contracts/PipelineStageContract.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Contracts;
+
+use App\DTOs\PipelineContext;
+use App\DTOs\StageResult;
+
+interface PipelineStageContract
+{
+    public function key(): string;
+
+    public function label(): string;
+
+    public function shouldRun(PipelineContext $context): bool;
+
+    public function execute(PipelineContext $context): StageResult;
+}

--- a/app/DTOs/PipelineContext.php
+++ b/app/DTOs/PipelineContext.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTOs;
+
+use App\Models\PipelineRun;
+use App\Models\User;
+use Spatie\LaravelData\Dto;
+
+final class PipelineContext extends Dto
+{
+    public function __construct(
+        public readonly User $user,
+        public readonly PipelineRun $pipelineRun,
+        public readonly bool $isFirstSync,
+    ) {}
+}

--- a/app/DTOs/StageResult.php
+++ b/app/DTOs/StageResult.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTOs;
+
+use Spatie\LaravelData\Dto;
+
+final class StageResult extends Dto
+{
+    /**
+     * @param  list<int>  $suggestionIds
+     */
+    public function __construct(
+        public readonly bool $success,
+        public readonly string $stage,
+        public readonly ?string $error = null,
+        public readonly array $suggestionIds = [],
+    ) {}
+}

--- a/app/Enums/PipelineRunStatus.php
+++ b/app/Enums/PipelineRunStatus.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+enum PipelineRunStatus: string
+{
+    case Running = 'running';
+    case Completed = 'completed';
+    case PartialFailure = 'partial-failure';
+    case Failed = 'failed';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Running => 'Running',
+            self::Completed => 'Completed',
+            self::PartialFailure => 'Partial Failure',
+            self::Failed => 'Failed',
+        };
+    }
+}

--- a/app/Enums/PipelineTrigger.php
+++ b/app/Enums/PipelineTrigger.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+enum PipelineTrigger: string
+{
+    case Sync = 'sync';
+    case Manual = 'manual';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Sync => 'Sync',
+            self::Manual => 'Manual',
+        };
+    }
+}

--- a/app/Enums/SuggestionStatus.php
+++ b/app/Enums/SuggestionStatus.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+enum SuggestionStatus: string
+{
+    case Pending = 'pending';
+    case Accepted = 'accepted';
+    case Rejected = 'rejected';
+    case Superseded = 'superseded';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Pending => 'Pending',
+            self::Accepted => 'Accepted',
+            self::Rejected => 'Rejected',
+            self::Superseded => 'Superseded',
+        };
+    }
+}

--- a/app/Enums/SuggestionType.php
+++ b/app/Enums/SuggestionType.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+enum SuggestionType: string
+{
+    case PrimaryAccount = 'primary-account';
+    case PayCycle = 'pay-cycle';
+    case RecurringTransaction = 'recurring-transaction';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::PrimaryAccount => 'Primary Account',
+            self::PayCycle => 'Pay Cycle',
+            self::RecurringTransaction => 'Recurring Transaction',
+        };
+    }
+}

--- a/app/Models/AnalysisSuggestion.php
+++ b/app/Models/AnalysisSuggestion.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Enums\SuggestionStatus;
+use App\Enums\SuggestionType;
+use Carbon\CarbonImmutable;
+use Database\Factories\AnalysisSuggestionFactory;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * @property int $id
+ * @property int $user_id
+ * @property int $pipeline_run_id
+ * @property SuggestionType $type
+ * @property SuggestionStatus $status
+ * @property array<string, mixed> $payload
+ * @property CarbonImmutable|null $resolved_at
+ * @property CarbonImmutable $created_at
+ * @property CarbonImmutable $updated_at
+ */
+final class AnalysisSuggestion extends Model
+{
+    /** @use HasFactory<AnalysisSuggestionFactory> */
+    use HasFactory;
+
+    /**
+     * @var list<string>
+     */
+    protected $fillable = [
+        'user_id',
+        'pipeline_run_id',
+        'type',
+        'status',
+        'payload',
+        'resolved_at',
+    ];
+
+    /** @return BelongsTo<User, $this> */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /** @return BelongsTo<PipelineRun, $this> */
+    public function pipelineRun(): BelongsTo
+    {
+        return $this->belongsTo(PipelineRun::class);
+    }
+
+    /**
+     * @param  Builder<AnalysisSuggestion>  $query
+     * @return Builder<AnalysisSuggestion>
+     */
+    public function scopePending(Builder $query): Builder
+    {
+        return $query->where('status', SuggestionStatus::Pending);
+    }
+
+    /**
+     * @param  Builder<AnalysisSuggestion>  $query
+     * @return Builder<AnalysisSuggestion>
+     */
+    public function scopeOfType(Builder $query, SuggestionType $type): Builder
+    {
+        return $query->where('type', $type);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'type' => SuggestionType::class,
+            'status' => SuggestionStatus::class,
+            'payload' => 'array',
+            'resolved_at' => 'datetime',
+        ];
+    }
+}

--- a/app/Models/PipelineAuditEntry.php
+++ b/app/Models/PipelineAuditEntry.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Carbon\CarbonImmutable;
+use Database\Factories\PipelineAuditEntryFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+
+/**
+ * @property int $id
+ * @property int $pipeline_run_id
+ * @property string $stage
+ * @property string $action
+ * @property string|null $subject_type
+ * @property int|null $subject_id
+ * @property array<string, mixed>|null $metadata
+ * @property CarbonImmutable $created_at
+ * @property CarbonImmutable $updated_at
+ */
+final class PipelineAuditEntry extends Model
+{
+    /** @use HasFactory<PipelineAuditEntryFactory> */
+    use HasFactory;
+
+    /**
+     * @var list<string>
+     */
+    protected $fillable = [
+        'pipeline_run_id',
+        'stage',
+        'action',
+        'subject_type',
+        'subject_id',
+        'metadata',
+    ];
+
+    /** @return BelongsTo<PipelineRun, $this> */
+    public function pipelineRun(): BelongsTo
+    {
+        return $this->belongsTo(PipelineRun::class);
+    }
+
+    /** @return MorphTo<Model, $this> */
+    public function subject(): MorphTo
+    {
+        return $this->morphTo();
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'metadata' => 'array',
+        ];
+    }
+}

--- a/app/Models/PipelineRun.php
+++ b/app/Models/PipelineRun.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Enums\PipelineRunStatus;
+use App\Enums\PipelineTrigger;
+use Carbon\CarbonImmutable;
+use Database\Factories\PipelineRunFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+/**
+ * @property int $id
+ * @property int $user_id
+ * @property PipelineTrigger $trigger
+ * @property PipelineRunStatus $status
+ * @property bool $is_first_sync
+ * @property array<int, string>|null $stages_completed
+ * @property array<int, string>|null $stages_skipped
+ * @property array<int, mixed>|null $stages_failed
+ * @property CarbonImmutable $started_at
+ * @property CarbonImmutable|null $completed_at
+ * @property CarbonImmutable $created_at
+ * @property CarbonImmutable $updated_at
+ */
+final class PipelineRun extends Model
+{
+    /** @use HasFactory<PipelineRunFactory> */
+    use HasFactory;
+
+    /**
+     * @var list<string>
+     */
+    protected $fillable = [
+        'user_id',
+        'trigger',
+        'status',
+        'is_first_sync',
+        'stages_completed',
+        'stages_skipped',
+        'stages_failed',
+        'started_at',
+        'completed_at',
+    ];
+
+    /** @return BelongsTo<User, $this> */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /** @return HasMany<AnalysisSuggestion, $this> */
+    public function suggestions(): HasMany
+    {
+        return $this->hasMany(AnalysisSuggestion::class);
+    }
+
+    /** @return HasMany<PipelineAuditEntry, $this> */
+    public function auditEntries(): HasMany
+    {
+        return $this->hasMany(PipelineAuditEntry::class);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'trigger' => PipelineTrigger::class,
+            'status' => PipelineRunStatus::class,
+            'is_first_sync' => 'boolean',
+            'stages_completed' => 'array',
+            'stages_skipped' => 'array',
+            'stages_failed' => 'array',
+            'started_at' => 'datetime',
+            'completed_at' => 'datetime',
+        ];
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -11,6 +11,7 @@ use App\Enums\TransactionDirection;
 use Carbon\CarbonImmutable;
 use Database\Factories\UserFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
@@ -22,6 +23,7 @@ use Laravel\Fortify\TwoFactorAuthenticatable;
  * @property int|null $pay_amount
  * @property PayFrequency|null $pay_frequency
  * @property CarbonImmutable|null $next_pay_date
+ * @property int|null $primary_account_id
  */
 final class User extends Authenticatable
 {
@@ -42,6 +44,7 @@ final class User extends Authenticatable
         'pay_amount',
         'pay_frequency',
         'next_pay_date',
+        'primary_account_id',
     ];
 
     /**
@@ -96,6 +99,24 @@ final class User extends Authenticatable
     public function basiqRefreshLogs(): HasMany
     {
         return $this->hasMany(BasiqRefreshLog::class);
+    }
+
+    /** @return BelongsTo<Account, $this> */
+    public function primaryAccount(): BelongsTo
+    {
+        return $this->belongsTo(Account::class, 'primary_account_id');
+    }
+
+    /** @return HasMany<PipelineRun, $this> */
+    public function pipelineRuns(): HasMany
+    {
+        return $this->hasMany(PipelineRun::class);
+    }
+
+    /** @return HasMany<AnalysisSuggestion, $this> */
+    public function analysisSuggestions(): HasMany
+    {
+        return $this->hasMany(AnalysisSuggestion::class);
     }
 
     public function hasPayCycleConfigured(): bool

--- a/database/factories/AnalysisSuggestionFactory.php
+++ b/database/factories/AnalysisSuggestionFactory.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Enums\SuggestionStatus;
+use App\Enums\SuggestionType;
+use App\Models\AnalysisSuggestion;
+use App\Models\PipelineRun;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<AnalysisSuggestion>
+ */
+final class AnalysisSuggestionFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'pipeline_run_id' => PipelineRun::factory(),
+            'type' => SuggestionType::PrimaryAccount,
+            'status' => SuggestionStatus::Pending,
+            'payload' => [],
+        ];
+    }
+
+    public function configure(): self
+    {
+        return $this->afterMaking(function (AnalysisSuggestion $suggestion) {
+            if (! $suggestion->user_id) {
+                $suggestion->user_id = PipelineRun::find($suggestion->pipeline_run_id)?->user_id;
+            }
+        });
+    }
+
+    public function accepted(): self
+    {
+        return $this->state(fn (array $attributes) => [
+            'status' => SuggestionStatus::Accepted,
+            'resolved_at' => now(),
+        ]);
+    }
+
+    public function rejected(): self
+    {
+        return $this->state(fn (array $attributes) => [
+            'status' => SuggestionStatus::Rejected,
+            'resolved_at' => now(),
+        ]);
+    }
+
+    public function superseded(): self
+    {
+        return $this->state(fn (array $attributes) => [
+            'status' => SuggestionStatus::Superseded,
+            'resolved_at' => now(),
+        ]);
+    }
+
+    public function payCycle(): self
+    {
+        return $this->state(fn (array $attributes) => [
+            'type' => SuggestionType::PayCycle,
+        ]);
+    }
+
+    public function recurringTransaction(): self
+    {
+        return $this->state(fn (array $attributes) => [
+            'type' => SuggestionType::RecurringTransaction,
+        ]);
+    }
+}

--- a/database/factories/PipelineAuditEntryFactory.php
+++ b/database/factories/PipelineAuditEntryFactory.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\AnalysisSuggestion;
+use App\Models\PipelineAuditEntry;
+use App\Models\PipelineRun;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<PipelineAuditEntry>
+ */
+final class PipelineAuditEntryFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'pipeline_run_id' => PipelineRun::factory(),
+            'stage' => 'test-stage',
+            'action' => 'test-action',
+        ];
+    }
+
+    public function withMetadata(): self
+    {
+        return $this->state(fn (array $attributes) => [
+            'metadata' => ['key' => 'value', 'count' => 42],
+        ]);
+    }
+
+    public function forSuggestion(AnalysisSuggestion $suggestion): self
+    {
+        return $this->state(fn (array $attributes) => [
+            'pipeline_run_id' => $suggestion->pipeline_run_id,
+            'subject_type' => $suggestion->getMorphClass(),
+            'subject_id' => $suggestion->id,
+        ]);
+    }
+}

--- a/database/factories/PipelineRunFactory.php
+++ b/database/factories/PipelineRunFactory.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Enums\PipelineRunStatus;
+use App\Enums\PipelineTrigger;
+use App\Models\PipelineRun;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<PipelineRun>
+ */
+final class PipelineRunFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+            'trigger' => PipelineTrigger::Sync,
+            'status' => PipelineRunStatus::Running,
+            'is_first_sync' => false,
+            'started_at' => now(),
+        ];
+    }
+
+    public function completed(): self
+    {
+        return $this->state(fn (array $attributes) => [
+            'status' => PipelineRunStatus::Completed,
+            'stages_completed' => ['primary-account', 'pay-cycle', 'recurring-transaction'],
+            'completed_at' => now(),
+        ]);
+    }
+
+    public function failed(): self
+    {
+        return $this->state(fn (array $attributes) => [
+            'status' => PipelineRunStatus::Failed,
+            'stages_failed' => [['stage' => 'primary-account', 'error' => 'Test error']],
+            'completed_at' => now(),
+        ]);
+    }
+
+    public function partialFailure(): self
+    {
+        return $this->state(fn (array $attributes) => [
+            'status' => PipelineRunStatus::PartialFailure,
+            'stages_completed' => ['primary-account'],
+            'stages_failed' => [['stage' => 'pay-cycle', 'error' => 'Test error']],
+            'completed_at' => now(),
+        ]);
+    }
+
+    public function firstSync(): self
+    {
+        return $this->state(fn (array $attributes) => [
+            'is_first_sync' => true,
+        ]);
+    }
+
+    public function manual(): self
+    {
+        return $this->state(fn (array $attributes) => [
+            'trigger' => PipelineTrigger::Manual,
+        ]);
+    }
+}

--- a/database/migrations/2026_04_12_120001_add_primary_account_id_to_users_table.php
+++ b/database/migrations/2026_04_12_120001_add_primary_account_id_to_users_table.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->foreignId('primary_account_id')->nullable()->constrained('accounts')->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('primary_account_id');
+        });
+    }
+};

--- a/database/migrations/2026_04_12_120002_create_pipeline_runs_table.php
+++ b/database/migrations/2026_04_12_120002_create_pipeline_runs_table.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('pipeline_runs', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->string('trigger');
+            $table->string('status');
+            $table->boolean('is_first_sync')->default(false);
+            $table->json('stages_completed')->nullable();
+            $table->json('stages_skipped')->nullable();
+            $table->json('stages_failed')->nullable();
+            $table->timestamp('started_at');
+            $table->timestamp('completed_at')->nullable();
+            $table->timestamps();
+
+            $table->index(['user_id', 'status']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('pipeline_runs');
+    }
+};

--- a/database/migrations/2026_04_12_120003_create_analysis_suggestions_table.php
+++ b/database/migrations/2026_04_12_120003_create_analysis_suggestions_table.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('analysis_suggestions', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('pipeline_run_id')->constrained()->cascadeOnDelete();
+            $table->string('type');
+            $table->string('status')->default('pending');
+            $table->json('payload');
+            $table->timestamp('resolved_at')->nullable();
+            $table->timestamps();
+
+            $table->index(['user_id', 'type', 'status']);
+            $table->index(['pipeline_run_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('analysis_suggestions');
+    }
+};

--- a/database/migrations/2026_04_12_120004_create_pipeline_audit_entries_table.php
+++ b/database/migrations/2026_04_12_120004_create_pipeline_audit_entries_table.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('pipeline_audit_entries', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('pipeline_run_id')->constrained()->cascadeOnDelete();
+            $table->string('stage');
+            $table->string('action');
+            $table->nullableMorphs('subject');
+            $table->json('metadata')->nullable();
+            $table->timestamps();
+
+            $table->index(['pipeline_run_id', 'stage']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('pipeline_audit_entries');
+    }
+};

--- a/tests/Feature/Models/AnalysisSuggestionTest.php
+++ b/tests/Feature/Models/AnalysisSuggestionTest.php
@@ -1,0 +1,149 @@
+<?php
+
+/** @noinspection StaticClosureCanBeUsedInspection */
+
+declare(strict_types=1);
+
+use App\Enums\SuggestionStatus;
+use App\Enums\SuggestionType;
+use App\Models\AnalysisSuggestion;
+use App\Models\PipelineRun;
+use App\Models\User;
+
+test('factory creates a valid analysis suggestion', function () {
+    $suggestion = AnalysisSuggestion::factory()->create();
+
+    expect($suggestion)->toBeInstanceOf(AnalysisSuggestion::class)
+        ->and($suggestion->exists)->toBeTrue();
+});
+
+test('default factory creates a pending primary account suggestion', function () {
+    $suggestion = AnalysisSuggestion::factory()->create();
+
+    expect($suggestion->type)->toBe(SuggestionType::PrimaryAccount)
+        ->and($suggestion->status)->toBe(SuggestionStatus::Pending)
+        ->and($suggestion->payload)->toBe([]);
+});
+
+test('default factory derives user from pipeline run', function () {
+    $suggestion = AnalysisSuggestion::factory()->create();
+
+    expect($suggestion->user_id)->toBe($suggestion->pipelineRun->user_id);
+});
+
+test('accepted state sets accepted status with resolved_at', function () {
+    $suggestion = AnalysisSuggestion::factory()->accepted()->create();
+
+    expect($suggestion->status)->toBe(SuggestionStatus::Accepted)
+        ->and($suggestion->resolved_at)->not->toBeNull();
+});
+
+test('rejected state sets rejected status with resolved_at', function () {
+    $suggestion = AnalysisSuggestion::factory()->rejected()->create();
+
+    expect($suggestion->status)->toBe(SuggestionStatus::Rejected)
+        ->and($suggestion->resolved_at)->not->toBeNull();
+});
+
+test('superseded state sets superseded status with resolved_at', function () {
+    $suggestion = AnalysisSuggestion::factory()->superseded()->create();
+
+    expect($suggestion->status)->toBe(SuggestionStatus::Superseded)
+        ->and($suggestion->resolved_at)->not->toBeNull();
+});
+
+test('pay cycle state sets pay cycle type', function () {
+    $suggestion = AnalysisSuggestion::factory()->payCycle()->create();
+
+    expect($suggestion->type)->toBe(SuggestionType::PayCycle);
+});
+
+test('recurring transaction state sets recurring transaction type', function () {
+    $suggestion = AnalysisSuggestion::factory()->recurringTransaction()->create();
+
+    expect($suggestion->type)->toBe(SuggestionType::RecurringTransaction);
+});
+
+test('belongs to a user', function () {
+    $user = User::factory()->create();
+    $suggestion = AnalysisSuggestion::factory()->create(['user_id' => $user->id]);
+
+    expect($suggestion->user->id)->toBe($user->id);
+});
+
+test('belongs to a pipeline run', function () {
+    $run = PipelineRun::factory()->create();
+    $suggestion = AnalysisSuggestion::factory()->for($run)->create([
+        'user_id' => $run->user_id,
+    ]);
+
+    expect($suggestion->pipelineRun->id)->toBe($run->id);
+});
+
+test('pending scope filters pending suggestions', function () {
+    $user = User::factory()->create();
+    $run = PipelineRun::factory()->for($user)->create();
+
+    AnalysisSuggestion::factory()->for($run)->create([
+        'user_id' => $user->id,
+        'status' => SuggestionStatus::Pending,
+    ]);
+    AnalysisSuggestion::factory()->accepted()->for($run)->create([
+        'user_id' => $user->id,
+    ]);
+
+    expect(AnalysisSuggestion::query()->pending()->count())->toBe(1);
+});
+
+test('ofType scope filters by suggestion type', function () {
+    $user = User::factory()->create();
+    $run = PipelineRun::factory()->for($user)->create();
+
+    AnalysisSuggestion::factory()->for($run)->create([
+        'user_id' => $user->id,
+        'type' => SuggestionType::PrimaryAccount,
+    ]);
+    AnalysisSuggestion::factory()->payCycle()->for($run)->create([
+        'user_id' => $user->id,
+    ]);
+
+    expect(AnalysisSuggestion::query()->ofType(SuggestionType::PayCycle)->count())->toBe(1);
+});
+
+test('type is cast to SuggestionType enum', function () {
+    $suggestion = AnalysisSuggestion::factory()->create();
+
+    expect($suggestion->type)->toBeInstanceOf(SuggestionType::class);
+});
+
+test('status is cast to SuggestionStatus enum', function () {
+    $suggestion = AnalysisSuggestion::factory()->create();
+
+    expect($suggestion->status)->toBeInstanceOf(SuggestionStatus::class);
+});
+
+test('payload is cast to array', function () {
+    $payload = ['account_id' => 1, 'confidence' => 0.95];
+    $suggestion = AnalysisSuggestion::factory()->create(['payload' => $payload]);
+
+    expect($suggestion->payload)->toBe($payload);
+});
+
+test('cascades on user delete', function () {
+    $user = User::factory()->create();
+    $run = PipelineRun::factory()->for($user)->create();
+    AnalysisSuggestion::factory()->for($run)->create(['user_id' => $user->id]);
+
+    $user->delete();
+
+    expect(AnalysisSuggestion::query()->count())->toBe(0);
+});
+
+test('cascades on pipeline run delete', function () {
+    $run = PipelineRun::factory()->create();
+    AnalysisSuggestion::factory()->for($run)->create(['user_id' => $run->user_id]);
+
+    $run->delete();
+
+    expect(AnalysisSuggestion::query()->count())->toBe(0);
+});

--- a/tests/Feature/Models/PipelineAuditEntryTest.php
+++ b/tests/Feature/Models/PipelineAuditEntryTest.php
@@ -1,0 +1,72 @@
+<?php
+
+/** @noinspection StaticClosureCanBeUsedInspection */
+
+declare(strict_types=1);
+
+use App\Models\AnalysisSuggestion;
+use App\Models\PipelineAuditEntry;
+use App\Models\PipelineRun;
+
+test('factory creates a valid pipeline audit entry', function () {
+    $entry = PipelineAuditEntry::factory()->create();
+
+    expect($entry)->toBeInstanceOf(PipelineAuditEntry::class)
+        ->and($entry->exists)->toBeTrue();
+});
+
+test('default factory creates entry with test stage and action', function () {
+    $entry = PipelineAuditEntry::factory()->create();
+
+    expect($entry->stage)->toBe('test-stage')
+        ->and($entry->action)->toBe('test-action')
+        ->and($entry->metadata)->toBeNull();
+});
+
+test('withMetadata state sets metadata', function () {
+    $entry = PipelineAuditEntry::factory()->withMetadata()->create();
+
+    expect($entry->metadata)->toBeArray()
+        ->and($entry->metadata)->toHaveKey('key')
+        ->and($entry->metadata)->toHaveKey('count');
+});
+
+test('belongs to a pipeline run', function () {
+    $run = PipelineRun::factory()->create();
+    $entry = PipelineAuditEntry::factory()->for($run)->create();
+
+    expect($entry->pipelineRun->id)->toBe($run->id);
+});
+
+test('morph subject relationship resolves to suggestion', function () {
+    $suggestion = AnalysisSuggestion::factory()->create();
+    $entry = PipelineAuditEntry::factory()
+        ->forSuggestion($suggestion)
+        ->create();
+
+    expect($entry->subject)->toBeInstanceOf(AnalysisSuggestion::class)
+        ->and($entry->subject->id)->toBe($suggestion->id)
+        ->and($entry->pipeline_run_id)->toBe($suggestion->pipeline_run_id);
+});
+
+test('metadata is cast to array', function () {
+    $metadata = ['stage_duration_ms' => 150, 'records_processed' => 42];
+    $entry = PipelineAuditEntry::factory()->create(['metadata' => $metadata]);
+
+    expect($entry->metadata)->toBe($metadata);
+});
+
+test('metadata defaults to null', function () {
+    $entry = PipelineAuditEntry::factory()->create();
+
+    expect($entry->metadata)->toBeNull();
+});
+
+test('cascades on pipeline run delete', function () {
+    $run = PipelineRun::factory()->create();
+    PipelineAuditEntry::factory()->for($run)->create();
+
+    $run->delete();
+
+    expect(PipelineAuditEntry::query()->count())->toBe(0);
+});

--- a/tests/Feature/Models/PipelineRunTest.php
+++ b/tests/Feature/Models/PipelineRunTest.php
@@ -1,0 +1,136 @@
+<?php
+
+/** @noinspection StaticClosureCanBeUsedInspection */
+
+declare(strict_types=1);
+
+use App\Enums\PipelineRunStatus;
+use App\Enums\PipelineTrigger;
+use App\Models\AnalysisSuggestion;
+use App\Models\PipelineAuditEntry;
+use App\Models\PipelineRun;
+use App\Models\User;
+
+test('factory creates a valid pipeline run', function () {
+    $run = PipelineRun::factory()->create();
+
+    expect($run)->toBeInstanceOf(PipelineRun::class)
+        ->and($run->exists)->toBeTrue();
+});
+
+test('default factory creates a running sync pipeline run', function () {
+    $run = PipelineRun::factory()->create();
+
+    expect($run->trigger)->toBe(PipelineTrigger::Sync)
+        ->and($run->status)->toBe(PipelineRunStatus::Running)
+        ->and($run->is_first_sync)->toBeFalse();
+});
+
+test('completed state sets completed status with stages', function () {
+    $run = PipelineRun::factory()->completed()->create();
+
+    expect($run->status)->toBe(PipelineRunStatus::Completed)
+        ->and($run->stages_completed)->toBeArray()
+        ->and($run->completed_at)->not->toBeNull();
+});
+
+test('failed state sets failed status with error details', function () {
+    $run = PipelineRun::factory()->failed()->create();
+
+    expect($run->status)->toBe(PipelineRunStatus::Failed)
+        ->and($run->stages_failed)->toBeArray()
+        ->and($run->completed_at)->not->toBeNull();
+});
+
+test('partial failure state sets partial failure status', function () {
+    $run = PipelineRun::factory()->partialFailure()->create();
+
+    expect($run->status)->toBe(PipelineRunStatus::PartialFailure)
+        ->and($run->stages_completed)->toBeArray()
+        ->and($run->stages_failed)->toBeArray();
+});
+
+test('first sync state sets is_first_sync flag', function () {
+    $run = PipelineRun::factory()->firstSync()->create();
+
+    expect($run->is_first_sync)->toBeTrue();
+});
+
+test('manual state sets manual trigger', function () {
+    $run = PipelineRun::factory()->manual()->create();
+
+    expect($run->trigger)->toBe(PipelineTrigger::Manual);
+});
+
+test('belongs to a user', function () {
+    $user = User::factory()->create();
+    $run = PipelineRun::factory()->for($user)->create();
+
+    expect($run->user->id)->toBe($user->id);
+});
+
+test('has many suggestions', function () {
+    $run = PipelineRun::factory()->create();
+    AnalysisSuggestion::factory()->count(3)->for($run)->create([
+        'user_id' => $run->user_id,
+    ]);
+
+    expect($run->suggestions)->toHaveCount(3);
+});
+
+test('has many audit entries', function () {
+    $run = PipelineRun::factory()->create();
+    PipelineAuditEntry::factory()->count(3)->for($run)->create();
+
+    expect($run->auditEntries)->toHaveCount(3);
+});
+
+test('trigger is cast to PipelineTrigger enum', function () {
+    $run = PipelineRun::factory()->create();
+
+    expect($run->trigger)->toBeInstanceOf(PipelineTrigger::class);
+});
+
+test('status is cast to PipelineRunStatus enum', function () {
+    $run = PipelineRun::factory()->create();
+
+    expect($run->status)->toBeInstanceOf(PipelineRunStatus::class);
+});
+
+test('stages_completed is cast to array', function () {
+    $stages = ['primary-account', 'pay-cycle'];
+    $run = PipelineRun::factory()->create(['stages_completed' => $stages]);
+
+    expect($run->stages_completed)->toBe($stages);
+});
+
+test('stages_skipped is cast to array', function () {
+    $stages = ['recurring-transaction'];
+    $run = PipelineRun::factory()->create(['stages_skipped' => $stages]);
+
+    expect($run->stages_skipped)->toBe($stages);
+});
+
+test('stages_failed is cast to array', function () {
+    $stages = [['stage' => 'pay-cycle', 'error' => 'Test error']];
+    $run = PipelineRun::factory()->create(['stages_failed' => $stages]);
+
+    expect($run->stages_failed)->toBe($stages);
+});
+
+test('json fields default to null', function () {
+    $run = PipelineRun::factory()->create();
+
+    expect($run->stages_completed)->toBeNull()
+        ->and($run->stages_skipped)->toBeNull()
+        ->and($run->stages_failed)->toBeNull();
+});
+
+test('cascades on user delete', function () {
+    $user = User::factory()->create();
+    PipelineRun::factory()->for($user)->create();
+
+    $user->delete();
+
+    expect(PipelineRun::query()->count())->toBe(0);
+});

--- a/tests/Feature/Models/UserTest.php
+++ b/tests/Feature/Models/UserTest.php
@@ -6,7 +6,9 @@ declare(strict_types=1);
 
 use App\Enums\PayFrequency;
 use App\Models\Account;
+use App\Models\AnalysisSuggestion;
 use App\Models\Budget;
+use App\Models\PipelineRun;
 use App\Models\Transaction;
 use App\Models\User;
 use Illuminate\Database\QueryException;
@@ -231,4 +233,29 @@ test('withPayCycle factory state sets all pay cycle fields', function () {
     expect($user->pay_amount)->not->toBeNull()
         ->and($user->pay_frequency)->toBe(PayFrequency::Fortnightly)
         ->and($user->next_pay_date)->not->toBeNull();
+});
+
+test('user has primary account relationship', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $user->update(['primary_account_id' => $account->id]);
+
+    expect($user->fresh()->primaryAccount->id)->toBe($account->id);
+});
+
+test('user has pipeline runs relationship', function () {
+    $user = User::factory()->create();
+    PipelineRun::factory()->count(3)->for($user)->create();
+
+    expect($user->pipelineRuns)->toHaveCount(3)
+        ->each(fn (Pest\Expectation $run) => $run->toBeInstanceOf(PipelineRun::class));
+});
+
+test('user has analysis suggestions relationship', function () {
+    $user = User::factory()->create();
+    $run = PipelineRun::factory()->for($user)->create();
+    AnalysisSuggestion::factory()->count(3)->for($run)->create(['user_id' => $user->id]);
+
+    expect($user->analysisSuggestions)->toHaveCount(3)
+        ->each(fn (Pest\Expectation $suggestion) => $suggestion->toBeInstanceOf(AnalysisSuggestion::class));
 });

--- a/tests/Unit/Enums/PipelineRunStatusTest.php
+++ b/tests/Unit/Enums/PipelineRunStatusTest.php
@@ -1,0 +1,32 @@
+<?php
+
+/** @noinspection StaticClosureCanBeUsedInspection */
+
+declare(strict_types=1);
+
+use App\Enums\PipelineRunStatus;
+
+test('all pipeline run status cases exist', function () {
+    expect(PipelineRunStatus::cases())->toHaveCount(4);
+});
+
+test('pipeline run status has correct backing values', function () {
+    expect(PipelineRunStatus::Running->value)->toBe('running')
+        ->and(PipelineRunStatus::Completed->value)->toBe('completed')
+        ->and(PipelineRunStatus::PartialFailure->value)->toBe('partial-failure')
+        ->and(PipelineRunStatus::Failed->value)->toBe('failed');
+});
+
+test('pipeline run status resolves from backing value', function () {
+    expect(PipelineRunStatus::from('running'))->toBe(PipelineRunStatus::Running)
+        ->and(PipelineRunStatus::from('completed'))->toBe(PipelineRunStatus::Completed)
+        ->and(PipelineRunStatus::from('partial-failure'))->toBe(PipelineRunStatus::PartialFailure)
+        ->and(PipelineRunStatus::from('failed'))->toBe(PipelineRunStatus::Failed);
+});
+
+test('pipeline run status has labels', function () {
+    expect(PipelineRunStatus::Running->label())->toBe('Running')
+        ->and(PipelineRunStatus::Completed->label())->toBe('Completed')
+        ->and(PipelineRunStatus::PartialFailure->label())->toBe('Partial Failure')
+        ->and(PipelineRunStatus::Failed->label())->toBe('Failed');
+});

--- a/tests/Unit/Enums/PipelineTriggerTest.php
+++ b/tests/Unit/Enums/PipelineTriggerTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/** @noinspection StaticClosureCanBeUsedInspection */
+
+declare(strict_types=1);
+
+use App\Enums\PipelineTrigger;
+
+test('all pipeline trigger cases exist', function () {
+    expect(PipelineTrigger::cases())->toHaveCount(2);
+});
+
+test('pipeline trigger has correct backing values', function () {
+    expect(PipelineTrigger::Sync->value)->toBe('sync')
+        ->and(PipelineTrigger::Manual->value)->toBe('manual');
+});
+
+test('pipeline trigger resolves from backing value', function () {
+    expect(PipelineTrigger::from('sync'))->toBe(PipelineTrigger::Sync)
+        ->and(PipelineTrigger::from('manual'))->toBe(PipelineTrigger::Manual);
+});
+
+test('pipeline trigger has labels', function () {
+    expect(PipelineTrigger::Sync->label())->toBe('Sync')
+        ->and(PipelineTrigger::Manual->label())->toBe('Manual');
+});

--- a/tests/Unit/Enums/SuggestionStatusTest.php
+++ b/tests/Unit/Enums/SuggestionStatusTest.php
@@ -1,0 +1,32 @@
+<?php
+
+/** @noinspection StaticClosureCanBeUsedInspection */
+
+declare(strict_types=1);
+
+use App\Enums\SuggestionStatus;
+
+test('all suggestion status cases exist', function () {
+    expect(SuggestionStatus::cases())->toHaveCount(4);
+});
+
+test('suggestion status has correct backing values', function () {
+    expect(SuggestionStatus::Pending->value)->toBe('pending')
+        ->and(SuggestionStatus::Accepted->value)->toBe('accepted')
+        ->and(SuggestionStatus::Rejected->value)->toBe('rejected')
+        ->and(SuggestionStatus::Superseded->value)->toBe('superseded');
+});
+
+test('suggestion status resolves from backing value', function () {
+    expect(SuggestionStatus::from('pending'))->toBe(SuggestionStatus::Pending)
+        ->and(SuggestionStatus::from('accepted'))->toBe(SuggestionStatus::Accepted)
+        ->and(SuggestionStatus::from('rejected'))->toBe(SuggestionStatus::Rejected)
+        ->and(SuggestionStatus::from('superseded'))->toBe(SuggestionStatus::Superseded);
+});
+
+test('suggestion status has labels', function () {
+    expect(SuggestionStatus::Pending->label())->toBe('Pending')
+        ->and(SuggestionStatus::Accepted->label())->toBe('Accepted')
+        ->and(SuggestionStatus::Rejected->label())->toBe('Rejected')
+        ->and(SuggestionStatus::Superseded->label())->toBe('Superseded');
+});

--- a/tests/Unit/Enums/SuggestionTypeTest.php
+++ b/tests/Unit/Enums/SuggestionTypeTest.php
@@ -1,0 +1,29 @@
+<?php
+
+/** @noinspection StaticClosureCanBeUsedInspection */
+
+declare(strict_types=1);
+
+use App\Enums\SuggestionType;
+
+test('all suggestion type cases exist', function () {
+    expect(SuggestionType::cases())->toHaveCount(3);
+});
+
+test('suggestion type has correct backing values', function () {
+    expect(SuggestionType::PrimaryAccount->value)->toBe('primary-account')
+        ->and(SuggestionType::PayCycle->value)->toBe('pay-cycle')
+        ->and(SuggestionType::RecurringTransaction->value)->toBe('recurring-transaction');
+});
+
+test('suggestion type resolves from backing value', function () {
+    expect(SuggestionType::from('primary-account'))->toBe(SuggestionType::PrimaryAccount)
+        ->and(SuggestionType::from('pay-cycle'))->toBe(SuggestionType::PayCycle)
+        ->and(SuggestionType::from('recurring-transaction'))->toBe(SuggestionType::RecurringTransaction);
+});
+
+test('suggestion type has labels', function () {
+    expect(SuggestionType::PrimaryAccount->label())->toBe('Primary Account')
+        ->and(SuggestionType::PayCycle->label())->toBe('Pay Cycle')
+        ->and(SuggestionType::RecurringTransaction->label())->toBe('Recurring Transaction');
+});


### PR DESCRIPTION
## Summary

- Add 4 string-backed enums (`PipelineTrigger`, `PipelineRunStatus`, `SuggestionType`, `SuggestionStatus`) with `label()` methods
- Add 4 migrations: `primary_account_id` FK on users, `pipeline_runs`, `analysis_suggestions`, and `pipeline_audit_entries` tables
- Add 3 models (`PipelineRun`, `AnalysisSuggestion`, `PipelineAuditEntry`) with factories, relationships, enum casts, and scopes
- Add `PipelineStageContract` interface and 2 DTOs (`PipelineContext`, `StageResult`) using Spatie Data
- Update `User` model with `primaryAccount()`, `pipelineRuns()`, and `analysisSuggestions()` relationships

## Test plan

- [x] 16 enum unit tests (4 per enum: cases exist, backing values, from(), labels)
- [x] 17 PipelineRun model tests (factory states, relationships, casts, cascade delete)
- [x] 16 AnalysisSuggestion model tests (factory states, scopes, relationships, cascade delete)
- [x] 8 PipelineAuditEntry model tests (factory states, morph relationship, cascade delete)
- [x] 3 new User relationship tests (primaryAccount, pipelineRuns, analysisSuggestions)
- [x] Migrations: migrate → rollback → re-migrate all clean
- [x] Full CI: Pint pass, PHPStan 0 errors, 1064 tests pass (2464 assertions)

Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)