### PR TITLE
feat: pipeline orchestrator and RunTransactionAnalysisJob (#162)

### DIFF
--- a/app/Jobs/RunTransactionAnalysisJob.php
+++ b/app/Jobs/RunTransactionAnalysisJob.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Jobs;
+
+use App\Enums\PipelineTrigger;
+use App\Models\User;
+use App\Services\TransactionAnalysisPipeline;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Queue\Middleware\WithoutOverlapping;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+final class RunTransactionAnalysisJob implements ShouldBeUnique, ShouldQueue
+{
+    use Queueable;
+
+    public int $tries = 1;
+
+    public int $timeout = 300;
+
+    public int $uniqueFor = 300;
+
+    public function __construct(
+        public readonly User $user,
+    ) {}
+
+    public function uniqueId(): int
+    {
+        return $this->user->id;
+    }
+
+    /** @return array<int, object> */
+    public function middleware(): array
+    {
+        return [
+            new WithoutOverlapping("analysis-user-{$this->user->id}"),
+        ];
+    }
+
+    public function handle(TransactionAnalysisPipeline $pipeline): void
+    {
+        $pipeline->run($this->user, PipelineTrigger::Sync);
+    }
+
+    public function failed(Throwable $exception): void
+    {
+        Log::error('RunTransactionAnalysisJob failed', [
+            'userId' => $this->user->id,
+            'exception' => $exception,
+        ]);
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -8,6 +8,7 @@ use App\Contracts\BasiqServiceContract;
 use App\Contracts\GitHubServiceContract;
 use App\Services\BasiqService;
 use App\Services\GitHubService;
+use App\Services\TransactionAnalysisPipeline;
 use Carbon\CarbonImmutable;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\DB;
@@ -35,6 +36,10 @@ final class AppServiceProvider extends ServiceProvider
         ));
 
         $this->app->alias(GitHubServiceContract::class, GitHubService::class);
+
+        $this->app->singleton(TransactionAnalysisPipeline::class, fn (): TransactionAnalysisPipeline => new TransactionAnalysisPipeline(
+            stages: [],
+        ));
     }
 
     /**

--- a/app/Services/TransactionAnalysisPipeline.php
+++ b/app/Services/TransactionAnalysisPipeline.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Contracts\PipelineStageContract;
+use App\DTOs\PipelineContext;
+use App\Enums\PipelineRunStatus;
+use App\Enums\PipelineTrigger;
+use App\Enums\SuggestionStatus;
+use App\Models\AnalysisSuggestion;
+use App\Models\PipelineAuditEntry;
+use App\Models\PipelineRun;
+use App\Models\User;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+final readonly class TransactionAnalysisPipeline
+{
+    /** @param list<PipelineStageContract> $stages */
+    public function __construct(
+        private array $stages,
+    ) {}
+
+    public function run(User $user, PipelineTrigger $trigger): PipelineRun
+    {
+        $isFirstSync = $user->primary_account_id === null && ! $user->hasPayCycleConfigured();
+
+        $pipelineRun = PipelineRun::create([
+            'user_id' => $user->id,
+            'trigger' => $trigger,
+            'status' => PipelineRunStatus::Running,
+            'is_first_sync' => $isFirstSync,
+            'stages_completed' => [],
+            'stages_skipped' => [],
+            'stages_failed' => [],
+            'started_at' => now(),
+        ]);
+
+        AnalysisSuggestion::query()
+            ->where('user_id', $user->id)
+            ->pending()
+            ->update([
+                'status' => SuggestionStatus::Superseded,
+                'resolved_at' => now(),
+            ]);
+
+        $context = new PipelineContext(
+            user: $user,
+            pipelineRun: $pipelineRun,
+            isFirstSync: $isFirstSync,
+        );
+
+        $stagesCompleted = [];
+        $stagesSkipped = [];
+        $stagesFailed = [];
+
+        foreach ($this->stages as $stage) {
+            if (! $stage->shouldRun($context)) {
+                $stagesSkipped[] = $stage->key();
+
+                continue;
+            }
+
+            try {
+                $result = $stage->execute($context);
+
+                if ($result->success) {
+                    $stagesCompleted[] = $stage->key();
+
+                    PipelineAuditEntry::create([
+                        'pipeline_run_id' => $pipelineRun->id,
+                        'stage' => $stage->key(),
+                        'action' => 'completed',
+                        'metadata' => ['suggestion_ids' => $result->suggestionIds],
+                    ]);
+
+                    continue;
+                }
+
+                $stagesFailed[] = ['stage' => $stage->key(), 'error' => $result->error];
+
+                PipelineAuditEntry::create([
+                    'pipeline_run_id' => $pipelineRun->id,
+                    'stage' => $stage->key(),
+                    'action' => 'failed',
+                    'metadata' => ['error' => $result->error],
+                ]);
+
+                Log::error('Pipeline stage failed', [
+                    'stage' => $stage->key(),
+                    'pipelineRunId' => $pipelineRun->id,
+                    'error' => $result->error,
+                ]);
+            } catch (Throwable $e) {
+                $stagesFailed[] = ['stage' => $stage->key(), 'error' => $e->getMessage()];
+
+                PipelineAuditEntry::create([
+                    'pipeline_run_id' => $pipelineRun->id,
+                    'stage' => $stage->key(),
+                    'action' => 'failed',
+                    'metadata' => ['error' => $e->getMessage()],
+                ]);
+
+                Log::error('Pipeline stage failed', [
+                    'stage' => $stage->key(),
+                    'pipelineRunId' => $pipelineRun->id,
+                    'error' => $e->getMessage(),
+                    'exception' => $e,
+                ]);
+
+                continue;
+            }
+        }
+
+        $status = $this->determineStatus($stagesCompleted, $stagesFailed);
+
+        $pipelineRun->update([
+            'status' => $status,
+            'stages_completed' => $stagesCompleted,
+            'stages_skipped' => $stagesSkipped,
+            'stages_failed' => $stagesFailed,
+            'completed_at' => now(),
+        ]);
+
+        return $pipelineRun;
+    }
+
+    /** @param list<string> $completed
+     *  @param list<array{stage: string, error: string}> $failed */
+    private function determineStatus(array $completed, array $failed): PipelineRunStatus
+    {
+        if ($failed === []) {
+            return PipelineRunStatus::Completed;
+        }
+
+        if ($completed !== []) {
+            return PipelineRunStatus::PartialFailure;
+        }
+
+        return PipelineRunStatus::Failed;
+    }
+}

--- a/tests/Feature/Jobs/RunTransactionAnalysisJobTest.php
+++ b/tests/Feature/Jobs/RunTransactionAnalysisJobTest.php
@@ -1,0 +1,71 @@
+<?php
+
+/** @noinspection StaticClosureCanBeUsedInspection */
+
+declare(strict_types=1);
+
+use App\Enums\PipelineTrigger;
+use App\Jobs\RunTransactionAnalysisJob;
+use App\Models\PipelineRun;
+use App\Models\User;
+use App\Services\TransactionAnalysisPipeline;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Illuminate\Queue\Middleware\WithoutOverlapping;
+use Illuminate\Support\Facades\Log;
+
+test('job implements ShouldBeUnique with user-scoped uniqueId', function () {
+    $user = User::factory()->create();
+    $job = new RunTransactionAnalysisJob($user);
+
+    expect($job)
+        ->toBeInstanceOf(ShouldBeUnique::class)
+        ->and($job->uniqueId())->toBe($user->id)
+        ->and($job->uniqueFor)->toBe(300);
+});
+
+test('job has WithoutOverlapping middleware keyed on user', function () {
+    $user = User::factory()->create();
+    $job = new RunTransactionAnalysisJob($user);
+
+    $middleware = $job->middleware();
+
+    expect($middleware)->toHaveCount(1)
+        ->and($middleware[0])->toBeInstanceOf(WithoutOverlapping::class);
+});
+
+test('job has correct tries and timeout configuration', function () {
+    $user = User::factory()->create();
+    $job = new RunTransactionAnalysisJob($user);
+
+    expect($job->tries)->toBe(1)
+        ->and($job->timeout)->toBe(300);
+});
+
+test('handle resolves pipeline and calls run', function () {
+    $user = User::factory()->create();
+    $job = new RunTransactionAnalysisJob($user);
+
+    $pipeline = new TransactionAnalysisPipeline(stages: []);
+    $job->handle($pipeline);
+
+    expect(PipelineRun::count())->toBe(1);
+
+    $run = PipelineRun::first();
+    expect($run)
+        ->user_id->toBe($user->id)
+        ->trigger->toBe(PipelineTrigger::Sync);
+});
+
+test('failed method logs the exception with user context', function () {
+    $user = User::factory()->create();
+    $job = new RunTransactionAnalysisJob($user);
+    $exception = new RuntimeException('Pipeline exploded');
+
+    Log::shouldReceive('error')
+        ->once()
+        ->with('RunTransactionAnalysisJob failed', Mockery::on(fn ($ctx) => $ctx['userId'] === $user->id
+            && $ctx['exception'] === $exception,
+        ));
+
+    $job->failed($exception);
+});

--- a/tests/Feature/Services/TransactionAnalysisPipelineTest.php
+++ b/tests/Feature/Services/TransactionAnalysisPipelineTest.php
@@ -1,0 +1,403 @@
+<?php
+
+/** @noinspection StaticClosureCanBeUsedInspection */
+
+declare(strict_types=1);
+
+use App\Contracts\PipelineStageContract;
+use App\DTOs\PipelineContext;
+use App\DTOs\StageResult;
+use App\Enums\PipelineRunStatus;
+use App\Enums\PipelineTrigger;
+use App\Enums\SuggestionStatus;
+use App\Models\AnalysisSuggestion;
+use App\Models\PipelineAuditEntry;
+use App\Models\PipelineRun;
+use App\Models\User;
+use App\Services\TransactionAnalysisPipeline;
+use Illuminate\Support\Facades\Log;
+
+function makePassingStage(string $key = 'test-stage', bool $shouldRun = true): PipelineStageContract
+{
+    return new readonly class($key, $shouldRun) implements PipelineStageContract
+    {
+        public function __construct(
+            private string $stageKey,
+            private bool $runs,
+        ) {}
+
+        public function key(): string
+        {
+            return $this->stageKey;
+        }
+
+        public function label(): string
+        {
+            return 'Test Stage';
+        }
+
+        public function shouldRun(PipelineContext $context): bool
+        {
+            return $this->runs;
+        }
+
+        public function execute(PipelineContext $context): StageResult
+        {
+            return new StageResult(success: true, stage: $this->stageKey, suggestionIds: [1, 2]);
+        }
+    };
+}
+
+function makeFailingStage(string $key = 'fail-stage', string $error = 'Stage error'): PipelineStageContract
+{
+    return new readonly class($key, $error) implements PipelineStageContract
+    {
+        public function __construct(
+            private string $stageKey,
+            private string $error,
+        ) {}
+
+        public function key(): string
+        {
+            return $this->stageKey;
+        }
+
+        public function label(): string
+        {
+            return 'Failing Stage';
+        }
+
+        public function shouldRun(PipelineContext $context): bool
+        {
+            return true;
+        }
+
+        public function execute(PipelineContext $context): StageResult
+        {
+            throw new RuntimeException($this->error);
+        }
+    };
+}
+
+function makeGracefullyFailingStage(string $key = 'graceful-fail-stage', string $error = 'Graceful failure'): PipelineStageContract
+{
+    return new readonly class($key, $error) implements PipelineStageContract
+    {
+        public function __construct(
+            private string $stageKey,
+            private string $error,
+        ) {}
+
+        public function key(): string
+        {
+            return $this->stageKey;
+        }
+
+        public function label(): string
+        {
+            return 'Gracefully Failing Stage';
+        }
+
+        public function shouldRun(PipelineContext $context): bool
+        {
+            return true;
+        }
+
+        public function execute(PipelineContext $context): StageResult
+        {
+            return new StageResult(success: false, stage: $this->stageKey, error: $this->error);
+        }
+    };
+}
+
+function makeSkippedStage(string $key = 'skip-stage'): PipelineStageContract
+{
+    return makePassingStage($key, shouldRun: false);
+}
+
+test('creates pipeline run with running status and returns completed run', function () {
+    $user = User::factory()->create();
+    $pipeline = new TransactionAnalysisPipeline(stages: []);
+
+    $run = $pipeline->run($user, PipelineTrigger::Sync);
+
+    expect($run)
+        ->toBeInstanceOf(PipelineRun::class)
+        ->user_id->toBe($user->id)
+        ->trigger->toBe(PipelineTrigger::Sync)
+        ->status->toBe(PipelineRunStatus::Completed);
+});
+
+test('determines isFirstSync correctly when user has no primary account and no pay cycle', function () {
+    $user = User::factory()->create([
+        'primary_account_id' => null,
+        'pay_amount' => null,
+        'pay_frequency' => null,
+        'next_pay_date' => null,
+    ]);
+    $pipeline = new TransactionAnalysisPipeline(stages: []);
+
+    $run = $pipeline->run($user, PipelineTrigger::Sync);
+
+    expect($run->is_first_sync)->toBeTrue();
+});
+
+test('determines isFirstSync as false when user has primary account', function () {
+    $user = User::factory()->create();
+    $account = App\Models\Account::factory()->for($user)->create();
+    $user->update(['primary_account_id' => $account->id]);
+    $user->refresh();
+
+    $pipeline = new TransactionAnalysisPipeline(stages: []);
+
+    $run = $pipeline->run($user, PipelineTrigger::Sync);
+
+    expect($run->is_first_sync)->toBeFalse();
+});
+
+test('supersedes previous pending suggestions before running stages', function () {
+    $user = User::factory()->create();
+    $existingRun = PipelineRun::factory()->for($user)->completed()->create();
+
+    $pendingSuggestion = AnalysisSuggestion::factory()->create([
+        'pipeline_run_id' => $existingRun->id,
+        'user_id' => $user->id,
+        'status' => SuggestionStatus::Pending,
+    ]);
+
+    $pipeline = new TransactionAnalysisPipeline(stages: []);
+    $pipeline->run($user, PipelineTrigger::Sync);
+
+    $pendingSuggestion->refresh();
+    expect($pendingSuggestion->status)->toBe(SuggestionStatus::Superseded)
+        ->and($pendingSuggestion->resolved_at)->not->toBeNull();
+});
+
+test('does not supersede accepted or rejected suggestions', function () {
+    $user = User::factory()->create();
+    $existingRun = PipelineRun::factory()->for($user)->completed()->create();
+
+    $accepted = AnalysisSuggestion::factory()->accepted()->create([
+        'pipeline_run_id' => $existingRun->id,
+        'user_id' => $user->id,
+    ]);
+
+    $rejected = AnalysisSuggestion::factory()->rejected()->create([
+        'pipeline_run_id' => $existingRun->id,
+        'user_id' => $user->id,
+    ]);
+
+    $pipeline = new TransactionAnalysisPipeline(stages: []);
+    $pipeline->run($user, PipelineTrigger::Sync);
+
+    $accepted->refresh();
+    $rejected->refresh();
+
+    expect($accepted->status)->toBe(SuggestionStatus::Accepted)
+        ->and($rejected->status)->toBe(SuggestionStatus::Rejected);
+});
+
+test('executes stages in order and tracks completed stages', function () {
+    $user = User::factory()->create();
+    $pipeline = new TransactionAnalysisPipeline(stages: [
+        makePassingStage('stage-a'),
+        makePassingStage('stage-b'),
+        makePassingStage('stage-c'),
+    ]);
+
+    $run = $pipeline->run($user, PipelineTrigger::Sync);
+
+    expect($run->stages_completed)->toBe(['stage-a', 'stage-b', 'stage-c'])
+        ->and($run->stages_skipped)->toBe([])
+        ->and($run->stages_failed)->toBe([]);
+});
+
+test('skips stages where shouldRun returns false', function () {
+    $user = User::factory()->create();
+    $pipeline = new TransactionAnalysisPipeline(stages: [
+        makePassingStage('stage-a'),
+        makeSkippedStage('stage-b'),
+        makePassingStage('stage-c'),
+    ]);
+
+    $run = $pipeline->run($user, PipelineTrigger::Sync);
+
+    expect($run->stages_completed)->toBe(['stage-a', 'stage-c'])
+        ->and($run->stages_skipped)->toBe(['stage-b']);
+});
+
+test('isolates stage failures and continues to next stage', function () {
+    Log::shouldReceive('error')
+        ->once()
+        ->with('Pipeline stage failed', Mockery::type('array'));
+
+    $user = User::factory()->create();
+    $pipeline = new TransactionAnalysisPipeline(stages: [
+        makePassingStage('stage-a'),
+        makeFailingStage('stage-b', 'Something broke'),
+        makePassingStage('stage-c'),
+    ]);
+
+    $run = $pipeline->run($user, PipelineTrigger::Sync);
+
+    expect($run->stages_completed)->toBe(['stage-a', 'stage-c'])
+        ->and($run->stages_failed)->toBe([['stage' => 'stage-b', 'error' => 'Something broke']]);
+});
+
+test('sets status to Completed when all stages succeed', function () {
+    $user = User::factory()->create();
+    $pipeline = new TransactionAnalysisPipeline(stages: [
+        makePassingStage('stage-a'),
+        makePassingStage('stage-b'),
+    ]);
+
+    $run = $pipeline->run($user, PipelineTrigger::Sync);
+
+    expect($run->status)->toBe(PipelineRunStatus::Completed);
+});
+
+test('sets status to PartialFailure when some stages fail', function () {
+    Log::shouldReceive('error')->once();
+
+    $user = User::factory()->create();
+    $pipeline = new TransactionAnalysisPipeline(stages: [
+        makePassingStage('stage-a'),
+        makeFailingStage('stage-b'),
+    ]);
+
+    $run = $pipeline->run($user, PipelineTrigger::Sync);
+
+    expect($run->status)->toBe(PipelineRunStatus::PartialFailure);
+});
+
+test('sets status to Failed when all stages fail', function () {
+    Log::shouldReceive('error')->twice();
+
+    $user = User::factory()->create();
+    $pipeline = new TransactionAnalysisPipeline(stages: [
+        makeFailingStage('stage-a'),
+        makeFailingStage('stage-b'),
+    ]);
+
+    $run = $pipeline->run($user, PipelineTrigger::Sync);
+
+    expect($run->status)->toBe(PipelineRunStatus::Failed);
+});
+
+test('sets status to Completed when all stages are skipped', function () {
+    $user = User::factory()->create();
+    $pipeline = new TransactionAnalysisPipeline(stages: [
+        makeSkippedStage('stage-a'),
+        makeSkippedStage('stage-b'),
+    ]);
+
+    $run = $pipeline->run($user, PipelineTrigger::Sync);
+
+    expect($run->status)->toBe(PipelineRunStatus::Completed);
+});
+
+test('creates audit entries for completed stages', function () {
+    $user = User::factory()->create();
+    $pipeline = new TransactionAnalysisPipeline(stages: [
+        makePassingStage('stage-a'),
+    ]);
+
+    $run = $pipeline->run($user, PipelineTrigger::Sync);
+
+    $audit = PipelineAuditEntry::where('pipeline_run_id', $run->id)->first();
+    expect($audit)
+        ->stage->toBe('stage-a')
+        ->action->toBe('completed')
+        ->and($audit->metadata)->toHaveKey('suggestion_ids');
+});
+
+test('creates audit entries for failed stages with error details', function () {
+    Log::shouldReceive('error')->once();
+
+    $user = User::factory()->create();
+    $pipeline = new TransactionAnalysisPipeline(stages: [
+        makeFailingStage('stage-a', 'Boom'),
+    ]);
+
+    $run = $pipeline->run($user, PipelineTrigger::Sync);
+
+    $audit = PipelineAuditEntry::where('pipeline_run_id', $run->id)->first();
+    expect($audit)
+        ->stage->toBe('stage-a')
+        ->action->toBe('failed')
+        ->and($audit->metadata)->toBe(['error' => 'Boom']);
+});
+
+test('sets completed_at timestamp on final update', function () {
+    $user = User::factory()->create();
+    $pipeline = new TransactionAnalysisPipeline(stages: [
+        makePassingStage('stage-a'),
+    ]);
+
+    $run = $pipeline->run($user, PipelineTrigger::Sync);
+
+    expect($run->completed_at)->not->toBeNull();
+});
+
+test('runs with empty stages array without error', function () {
+    $user = User::factory()->create();
+    $pipeline = new TransactionAnalysisPipeline(stages: []);
+
+    $run = $pipeline->run($user, PipelineTrigger::Sync);
+
+    expect($run->status)->toBe(PipelineRunStatus::Completed)
+        ->and($run->stages_completed)->toBe([])
+        ->and($run->stages_skipped)->toBe([])
+        ->and($run->stages_failed)->toBe([])
+        ->and($run->completed_at)->not->toBeNull();
+});
+
+test('records stage as failed when StageResult returns success false', function () {
+    Log::shouldReceive('error')->once()
+        ->with('Pipeline stage failed', Mockery::on(fn ($ctx) => $ctx['error'] === 'No accounts found'));
+
+    $user = User::factory()->create();
+    $pipeline = new TransactionAnalysisPipeline(stages: [
+        makeGracefullyFailingStage('stage-a', 'No accounts found'),
+    ]);
+
+    $run = $pipeline->run($user, PipelineTrigger::Sync);
+
+    expect($run->stages_failed)->toBe([['stage' => 'stage-a', 'error' => 'No accounts found']])
+        ->and($run->stages_completed)->toBe([])
+        ->and($run->status)->toBe(PipelineRunStatus::Failed);
+});
+
+test('creates failed audit entry for graceful StageResult failure', function () {
+    Log::shouldReceive('error')->once();
+
+    $user = User::factory()->create();
+    $pipeline = new TransactionAnalysisPipeline(stages: [
+        makeGracefullyFailingStage('stage-a', 'Missing data'),
+    ]);
+
+    $run = $pipeline->run($user, PipelineTrigger::Sync);
+
+    $audit = PipelineAuditEntry::where('pipeline_run_id', $run->id)->first();
+    expect($audit)
+        ->stage->toBe('stage-a')
+        ->action->toBe('failed')
+        ->and($audit->metadata)->toBe(['error' => 'Missing data']);
+});
+
+test('mixes graceful failures with passing stages for PartialFailure status', function () {
+    Log::shouldReceive('error')->once();
+
+    $user = User::factory()->create();
+    $pipeline = new TransactionAnalysisPipeline(stages: [
+        makePassingStage('stage-a'),
+        makeGracefullyFailingStage('stage-b', 'Insufficient data'),
+        makePassingStage('stage-c'),
+    ]);
+
+    $run = $pipeline->run($user, PipelineTrigger::Sync);
+
+    expect($run->status)->toBe(PipelineRunStatus::PartialFailure)
+        ->and($run->stages_completed)->toBe(['stage-a', 'stage-c'])
+        ->and($run->stages_failed)->toBe([['stage' => 'stage-b', 'error' => 'Insufficient data']]);
+});


### PR DESCRIPTION
## Summary

- Implements `TransactionAnalysisPipeline` orchestrator service that loops through registered `PipelineStageContract` stages with per-stage error isolation, status tracking, and audit logging
- Adds `RunTransactionAnalysisJob` queued job following `SyncTransactionsJob` pattern with `ShouldBeUnique`, `WithoutOverlapping`, `tries=1`, `timeout=300`
- Registers `TransactionAnalysisPipeline` singleton in `AppServiceProvider` with empty stages array (concrete stages are future tickets #163+)

## Details

**Orchestrator (`TransactionAnalysisPipeline`):**
- Creates `PipelineRun` record, supersedes pending suggestions, loops stages with try/catch isolation
- Determines `isFirstSync` from user's `primary_account_id` and `hasPayCycleConfigured()`
- Final status derived from completed/failed arrays: `Completed`, `PartialFailure`, or `Failed`
- Creates `PipelineAuditEntry` for each stage outcome

**Job (`RunTransactionAnalysisJob`):**
- Per-user uniqueness via `ShouldBeUnique` + `WithoutOverlapping`
- `tries=1` (no retries — each run creates a PipelineRun, retrying would create duplicates)
- Hardcodes `PipelineTrigger::Sync` (manual trigger comes from a different entry point)

## Test plan

- [x] 16 feature tests for `TransactionAnalysisPipeline` covering: status determination, error isolation, stage skipping, audit entries, suggestion superseding, `isFirstSync` logic, and empty stages edge case
- [x] 5 feature tests for `RunTransactionAnalysisJob` covering: uniqueness, middleware, configuration, handle delegation, and failure logging
- [x] `op lint.dirty` — Pint clean
- [x] `op ci` — full CI green (1086 passed, PHPStan clean)

Closes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)