### PR TITLE
feat: IdentifyRecurringTransactionsStage (#163)

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -8,6 +8,7 @@ use App\Contracts\BasiqServiceContract;
 use App\Contracts\GitHubServiceContract;
 use App\Services\BasiqService;
 use App\Services\GitHubService;
+use App\Services\PipelineStages\IdentifyRecurringTransactionsStage;
 use App\Services\TransactionAnalysisPipeline;
 use Carbon\CarbonImmutable;
 use Illuminate\Support\Facades\Date;
@@ -38,7 +39,9 @@ final class AppServiceProvider extends ServiceProvider
         $this->app->alias(GitHubServiceContract::class, GitHubService::class);
 
         $this->app->singleton(TransactionAnalysisPipeline::class, fn (): TransactionAnalysisPipeline => new TransactionAnalysisPipeline(
-            stages: [],
+            stages: [
+                new IdentifyRecurringTransactionsStage,
+            ],
         ));
     }
 

--- a/app/Services/PipelineStages/IdentifyRecurringTransactionsStage.php
+++ b/app/Services/PipelineStages/IdentifyRecurringTransactionsStage.php
@@ -1,0 +1,389 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\PipelineStages;
+
+use App\Contracts\PipelineStageContract;
+use App\DTOs\PipelineContext;
+use App\DTOs\StageResult;
+use App\Enums\RecurrenceFrequency;
+use App\Enums\SuggestionStatus;
+use App\Enums\SuggestionType;
+use App\Enums\TransactionSource;
+use App\Models\AnalysisSuggestion;
+use App\Models\PipelineAuditEntry;
+use App\Models\PlannedTransaction;
+use App\Models\Transaction;
+use App\Models\User;
+use Illuminate\Support\Collection;
+
+final readonly class IdentifyRecurringTransactionsStage implements PipelineStageContract
+{
+    private const string STAGE_KEY = 'identify-recurring-transactions';
+
+    private const float AMOUNT_TOLERANCE = 0.05;
+
+    private const float MIN_CONFIDENCE = 0.40;
+
+    /** @var list<array{0: int, 1: int, 2: RecurrenceFrequency}> */
+    private const array FREQUENCY_RANGES = [
+        [5, 9, RecurrenceFrequency::EveryWeek],
+        [12, 16, RecurrenceFrequency::Every2Weeks],
+        [19, 23, RecurrenceFrequency::Every3Weeks],
+        [27, 35, RecurrenceFrequency::EveryMonth],
+        [80, 100, RecurrenceFrequency::Every3Months],
+        [160, 200, RecurrenceFrequency::Every6Months],
+        [340, 395, RecurrenceFrequency::EveryYear],
+    ];
+
+    public function key(): string
+    {
+        return self::STAGE_KEY;
+    }
+
+    public function label(): string
+    {
+        return 'Identify Recurring Transactions';
+    }
+
+    public function shouldRun(PipelineContext $context): bool
+    {
+        return true;
+    }
+
+    public function execute(PipelineContext $context): StageResult
+    {
+        $transactions = $this->loadUnmatchedTransactions($context->user);
+
+        if ($transactions->isEmpty()) {
+            return new StageResult(success: true, stage: self::STAGE_KEY, suggestionIds: []);
+        }
+
+        $groups = $transactions->groupBy(
+            fn (Transaction $txn): string => $this->normalizeDescription($txn).'|'.$txn->direction->value.'|'.$txn->account_id,
+        );
+
+        $suggestionIds = [];
+
+        foreach ($groups as $group) {
+            if ($group->count() < 2) {
+                continue;
+            }
+
+            $analysis = $this->analyzeGroup($group);
+
+            if ($analysis === null) {
+                continue;
+            }
+
+            $normalizedDescription = $this->normalizeDescription($group->first());
+            $accountId = $group->first()->account_id;
+
+            if ($this->shouldSkip($context->user, $normalizedDescription, $accountId, $analysis['frequency'], $analysis['median_amount'], $context->pipelineRun->id)) {
+                continue;
+            }
+
+            $payload = $this->buildPayload($group, $normalizedDescription, $analysis['median_amount'], $analysis['frequency'], $analysis['confidence']);
+
+            $suggestion = AnalysisSuggestion::create([
+                'user_id' => $context->user->id,
+                'pipeline_run_id' => $context->pipelineRun->id,
+                'type' => SuggestionType::RecurringTransaction,
+                'status' => SuggestionStatus::Pending,
+                'payload' => $payload,
+            ]);
+
+            $suggestionIds[] = $suggestion->id;
+        }
+
+        return new StageResult(success: true, stage: self::STAGE_KEY, suggestionIds: $suggestionIds);
+    }
+
+    /** @return Collection<int, Transaction> */
+    private function loadUnmatchedTransactions(User $user): Collection
+    {
+        return Transaction::query()
+            ->where('user_id', $user->id)
+            ->where('source', TransactionSource::Basiq)
+            ->whereNull('planned_transaction_id')
+            ->current()
+            ->get();
+    }
+
+    private function normalizeDescription(Transaction $transaction): string
+    {
+        if ($transaction->merchant_name !== null && $transaction->merchant_name !== '') {
+            return mb_strtoupper(mb_trim($transaction->merchant_name));
+        }
+
+        if ($transaction->clean_description !== null && $transaction->clean_description !== '') {
+            return mb_strtoupper(mb_trim($transaction->clean_description));
+        }
+
+        return $this->cleanRawDescription($transaction->description);
+    }
+
+    private function cleanRawDescription(string $description): string
+    {
+        $cleaned = preg_replace('/\s+\d{4,}.*$/', '', $description);
+        $cleaned = preg_replace('/\s+\d{1,2}[\/\-]\d{1,2}$/', '', $cleaned);
+        $cleaned = preg_replace('/\s+[A-Z]{2}$/', '', $cleaned);
+
+        $words = explode(' ', mb_trim($cleaned));
+        $deduped = [];
+        $seen = [];
+
+        foreach ($words as $word) {
+            $upper = mb_strtoupper($word);
+
+            if (! in_array($upper, $seen, true)) {
+                $deduped[] = $word;
+                $seen[] = $upper;
+            }
+        }
+
+        return mb_strtoupper(mb_trim(implode(' ', $deduped)));
+    }
+
+    /**
+     * @param  Collection<int, Transaction>  $group
+     * @return array{frequency: RecurrenceFrequency, median_amount: int, confidence: float}|null
+     */
+    private function analyzeGroup(Collection $group): ?array
+    {
+        $amounts = $group->pluck('amount');
+        $medianAmount = $this->calculateMedian($amounts);
+
+        if (! $this->checkAmountConsistency($amounts, $medianAmount)) {
+            return null;
+        }
+
+        $intervals = $this->calculateIntervals($group);
+
+        if ($intervals->isEmpty()) {
+            return null;
+        }
+
+        $medianInterval = $this->calculateMedian($intervals);
+        $frequency = $this->mapIntervalToFrequency($medianInterval);
+
+        if ($frequency === null) {
+            return null;
+        }
+
+        $amountCV = $this->coefficientOfVariation($amounts);
+        $intervalCV = $this->coefficientOfVariation($intervals);
+        $confidence = $this->calculateConfidence($group->count(), $amountCV, $intervalCV);
+
+        if ($confidence < self::MIN_CONFIDENCE) {
+            return null;
+        }
+
+        return [
+            'frequency' => $frequency,
+            'median_amount' => (int) round($medianAmount),
+            'confidence' => $confidence,
+        ];
+    }
+
+    /** @param Collection<int, mixed> $values */
+    private function calculateMedian(Collection $values): float
+    {
+        $sorted = $values->sort()->values();
+        $count = $sorted->count();
+
+        if ($count % 2 === 0) {
+            return ($sorted[$count / 2 - 1] + $sorted[$count / 2]) / 2.0;
+        }
+
+        return (float) $sorted[intdiv($count, 2)];
+    }
+
+    /** @param Collection<int, mixed> $amounts */
+    private function checkAmountConsistency(Collection $amounts, float $median): bool
+    {
+        if ($median === 0.0) {
+            return $amounts->every(fn (int|float $amount): bool => $amount === 0);
+        }
+
+        return $amounts->every(
+            fn (int|float $amount): bool => abs($amount - $median) / abs($median) <= self::AMOUNT_TOLERANCE,
+        );
+    }
+
+    /**
+     * @param  Collection<int, Transaction>  $group
+     * @return Collection<int, int>
+     */
+    private function calculateIntervals(Collection $group): Collection
+    {
+        $sorted = $group->sortBy('post_date')->values();
+        $intervals = collect();
+
+        for ($i = 1; $i < $sorted->count(); $i++) {
+            $days = $sorted[$i - 1]->post_date->diffInDays($sorted[$i]->post_date);
+            $intervals->push((int) $days);
+        }
+
+        return $intervals;
+    }
+
+    private function mapIntervalToFrequency(float $medianInterval): ?RecurrenceFrequency
+    {
+        foreach (self::FREQUENCY_RANGES as [$min, $max, $frequency]) {
+            if ($medianInterval >= $min && $medianInterval <= $max) {
+                return $frequency;
+            }
+        }
+
+        return null;
+    }
+
+    /** @param Collection<int, mixed> $values */
+    private function coefficientOfVariation(Collection $values): float
+    {
+        $count = $values->count();
+
+        if ($count < 2) {
+            return 0.0;
+        }
+
+        $mean = (float) $values->avg();
+
+        if ($mean === 0.0) {
+            return 0.0;
+        }
+
+        $variance = $values->reduce(
+            fn (float $carry, int|float $value): float => $carry + ($value - $mean) ** 2,
+            0.0,
+        ) / $count;
+
+        return sqrt($variance) / abs($mean);
+    }
+
+    private function calculateConfidence(int $count, float $amountCV, float $intervalCV): float
+    {
+        $matchCountScore = min(1.0, log($count, 2) / log(12, 2));
+        $amountScore = max(0.0, 1.0 - ($amountCV / 0.05));
+        $intervalScore = max(0.0, 1.0 - ($intervalCV * 2));
+
+        $confidence = (0.30 * $matchCountScore) + (0.35 * $amountScore) + (0.35 * $intervalScore);
+
+        return round($confidence, 2);
+    }
+
+    private function shouldSkip(User $user, string $description, int $accountId, RecurrenceFrequency $frequency, int $medianAmount, int $pipelineRunId): bool
+    {
+        if ($this->hasAcceptedSuggestion($user, $description, $accountId)) {
+            $this->createSkipAudit($pipelineRunId, 'existing_accepted_suggestion', $description, $accountId);
+
+            return true;
+        }
+
+        if ($this->hasMatchingPlannedTransaction($user, $description, $accountId, $frequency, $medianAmount)) {
+            $this->createSkipAudit($pipelineRunId, 'existing_planned_transaction', $description, $accountId);
+
+            return true;
+        }
+
+        if ($this->hasRecentRejection($user, $description, $accountId)) {
+            $this->createSkipAudit($pipelineRunId, 'recently_rejected', $description, $accountId);
+
+            return true;
+        }
+
+        return false;
+    }
+
+    private function hasAcceptedSuggestion(User $user, string $description, int $accountId): bool
+    {
+        return AnalysisSuggestion::query()
+            ->where('user_id', $user->id)
+            ->ofType(SuggestionType::RecurringTransaction)
+            ->where('status', SuggestionStatus::Accepted)
+            ->where('payload->description', $description)
+            ->where('payload->account_id', $accountId)
+            ->exists();
+    }
+
+    private function hasMatchingPlannedTransaction(User $user, string $description, int $accountId, RecurrenceFrequency $frequency, int $medianAmount): bool
+    {
+        return PlannedTransaction::query()
+            ->where('user_id', $user->id)
+            ->where('account_id', $accountId)
+            ->where('frequency', $frequency)
+            ->where('is_active', true)
+            ->whereRaw('UPPER(description) = ?', [$description])
+            ->get()
+            ->contains(function (PlannedTransaction $planned) use ($medianAmount): bool {
+                if ($medianAmount === 0) {
+                    return $planned->amount === 0;
+                }
+
+                return abs($planned->amount - $medianAmount) / abs($medianAmount) <= self::AMOUNT_TOLERANCE;
+            });
+    }
+
+    private function hasRecentRejection(User $user, string $description, int $accountId): bool
+    {
+        return AnalysisSuggestion::query()
+            ->where('user_id', $user->id)
+            ->ofType(SuggestionType::RecurringTransaction)
+            ->where('status', SuggestionStatus::Rejected)
+            ->where('resolved_at', '>=', now()->subDays(90))
+            ->where('payload->description', $description)
+            ->where('payload->account_id', $accountId)
+            ->exists();
+    }
+
+    private function createSkipAudit(int $pipelineRunId, string $reason, string $description, int $accountId): void
+    {
+        PipelineAuditEntry::create([
+            'pipeline_run_id' => $pipelineRunId,
+            'stage' => self::STAGE_KEY,
+            'action' => 'skipped',
+            'metadata' => [
+                'reason' => $reason,
+                'description' => $description,
+                'account_id' => $accountId,
+            ],
+        ]);
+    }
+
+    /**
+     * @param  Collection<int, Transaction>  $group
+     * @return array<string, mixed>
+     */
+    private function buildPayload(Collection $group, string $normalizedDescription, int $medianAmount, RecurrenceFrequency $frequency, float $confidence): array
+    {
+        $first = $group->first();
+        $sorted = $group->sortBy('post_date');
+
+        $cleanDescription = $first->merchant_name
+            ?? $first->clean_description
+            ?? $normalizedDescription;
+
+        $categoryId = $group
+            ->pluck('category_id')
+            ->filter()
+            ->countBy()
+            ->sortDesc()
+            ->keys()
+            ->first();
+
+        return [
+            'description' => $normalizedDescription,
+            'clean_description' => $cleanDescription,
+            'amount' => $medianAmount,
+            'direction' => $first->direction->value,
+            'frequency' => $frequency->value,
+            'account_id' => $first->account_id,
+            'category_id' => $categoryId,
+            'matched_transaction_ids' => $group->pluck('id')->values()->all(),
+            'start_date' => $sorted->first()->post_date->toDateString(),
+            'confidence_score' => $confidence,
+        ];
+    }
+}

--- a/tests/Feature/Services/PipelineStages/IdentifyRecurringTransactionsStageTest.php
+++ b/tests/Feature/Services/PipelineStages/IdentifyRecurringTransactionsStageTest.php
@@ -1,0 +1,708 @@
+<?php
+
+/** @noinspection StaticClosureCanBeUsedInspection */
+
+declare(strict_types=1);
+
+use App\DTOs\PipelineContext;
+use App\Enums\RecurrenceFrequency;
+use App\Enums\SuggestionType;
+use App\Enums\TransactionDirection;
+use App\Enums\TransactionSource;
+use App\Models\Account;
+use App\Models\AnalysisSuggestion;
+use App\Models\Category;
+use App\Models\PipelineAuditEntry;
+use App\Models\PipelineRun;
+use App\Models\PlannedTransaction;
+use App\Models\Transaction;
+use App\Models\User;
+use App\Services\PipelineStages\IdentifyRecurringTransactionsStage;
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Collection;
+
+beforeEach(function () {
+    $this->user = User::factory()->create();
+    $this->account = Account::factory()->for($this->user)->create();
+    $this->pipelineRun = PipelineRun::factory()->for($this->user)->create();
+    $this->context = new PipelineContext(
+        user: $this->user,
+        pipelineRun: $this->pipelineRun,
+        isFirstSync: false,
+    );
+    $this->stage = new IdentifyRecurringTransactionsStage;
+});
+
+function createBasiqTransaction(User $user, Account $account, array $overrides = []): Transaction
+{
+    return Transaction::factory()->fromBasiq()->create(array_merge([
+        'user_id' => $user->id,
+        'account_id' => $account->id,
+    ], $overrides));
+}
+
+function createMonthlyGroup(User $user, Account $account, string $merchantName, int $amount, int $count = 3, ?string $startDate = null): Collection
+{
+    $start = CarbonImmutable::parse($startDate ?? '2026-01-15');
+    $transactions = collect();
+
+    for ($i = 0; $i < $count; $i++) {
+        $transactions->push(createBasiqTransaction($user, $account, [
+            'merchant_name' => $merchantName,
+            'amount' => $amount,
+            'post_date' => $start->addMonthsNoOverflow($i),
+            'direction' => TransactionDirection::Debit,
+        ]));
+    }
+
+    return $transactions;
+}
+
+// ─── Detection ──────────────────────────────────────────────────────────
+
+test('detects monthly recurring transactions', function () {
+    createMonthlyGroup($this->user, $this->account, 'Netflix', 1699, 3);
+
+    $result = $this->stage->execute($this->context);
+
+    expect($result->success)->toBeTrue()
+        ->and($result->suggestionIds)->toHaveCount(1);
+
+    $suggestion = AnalysisSuggestion::find($result->suggestionIds[0]);
+    expect($suggestion->payload['frequency'])->toBe(RecurrenceFrequency::EveryMonth->value)
+        ->and($suggestion->payload['description'])->toBe('NETFLIX');
+});
+
+test('detects weekly recurring transactions', function () {
+    $start = CarbonImmutable::parse('2026-01-05');
+
+    for ($i = 0; $i < 4; $i++) {
+        createBasiqTransaction($this->user, $this->account, [
+            'merchant_name' => 'Coffee Club',
+            'amount' => 550,
+            'post_date' => $start->addWeeks($i),
+        ]);
+    }
+
+    $result = $this->stage->execute($this->context);
+
+    expect($result->success)->toBeTrue()
+        ->and($result->suggestionIds)->toHaveCount(1);
+
+    $suggestion = AnalysisSuggestion::find($result->suggestionIds[0]);
+    expect($suggestion->payload['frequency'])->toBe(RecurrenceFrequency::EveryWeek->value);
+});
+
+test('detects fortnightly recurring transactions', function () {
+    $start = CarbonImmutable::parse('2026-01-03');
+
+    for ($i = 0; $i < 3; $i++) {
+        createBasiqTransaction($this->user, $this->account, [
+            'merchant_name' => 'Lawn Care',
+            'amount' => 8000,
+            'post_date' => $start->addWeeks($i * 2),
+        ]);
+    }
+
+    $result = $this->stage->execute($this->context);
+
+    expect($result->success)->toBeTrue()
+        ->and($result->suggestionIds)->toHaveCount(1);
+
+    $suggestion = AnalysisSuggestion::find($result->suggestionIds[0]);
+    expect($suggestion->payload['frequency'])->toBe(RecurrenceFrequency::Every2Weeks->value);
+});
+
+test('detects quarterly recurring transactions', function () {
+    $start = CarbonImmutable::parse('2025-04-01');
+
+    for ($i = 0; $i < 3; $i++) {
+        createBasiqTransaction($this->user, $this->account, [
+            'merchant_name' => 'Insurance Corp',
+            'amount' => 45000,
+            'post_date' => $start->addMonthsNoOverflow($i * 3),
+        ]);
+    }
+
+    $result = $this->stage->execute($this->context);
+
+    expect($result->success)->toBeTrue()
+        ->and($result->suggestionIds)->toHaveCount(1);
+
+    $suggestion = AnalysisSuggestion::find($result->suggestionIds[0]);
+    expect($suggestion->payload['frequency'])->toBe(RecurrenceFrequency::Every3Months->value);
+});
+
+test('requires minimum 2 transactions to detect pattern', function () {
+    createBasiqTransaction($this->user, $this->account, [
+        'merchant_name' => 'Solo Purchase',
+        'amount' => 2000,
+        'post_date' => '2026-01-15',
+    ]);
+
+    $result = $this->stage->execute($this->context);
+
+    expect($result->success)->toBeTrue()
+        ->and($result->suggestionIds)->toBeEmpty();
+});
+
+test('separates by account creating distinct suggestions', function () {
+    $account2 = Account::factory()->for($this->user)->create();
+
+    createMonthlyGroup($this->user, $this->account, 'Spotify', 1199, 3);
+    createMonthlyGroup($this->user, $account2, 'Spotify', 1199, 3);
+
+    $result = $this->stage->execute($this->context);
+
+    expect($result->success)->toBeTrue()
+        ->and($result->suggestionIds)->toHaveCount(2);
+});
+
+test('separates debits and credits for same merchant', function () {
+    $start = CarbonImmutable::parse('2026-01-15');
+
+    for ($i = 0; $i < 3; $i++) {
+        createBasiqTransaction($this->user, $this->account, [
+            'merchant_name' => 'Transfer Corp',
+            'amount' => 10000,
+            'post_date' => $start->addMonthsNoOverflow($i),
+            'direction' => TransactionDirection::Debit,
+        ]);
+
+        createBasiqTransaction($this->user, $this->account, [
+            'merchant_name' => 'Transfer Corp',
+            'amount' => 10000,
+            'post_date' => $start->addMonthsNoOverflow($i)->addDays(1),
+            'direction' => TransactionDirection::Credit,
+        ]);
+    }
+
+    $result = $this->stage->execute($this->context);
+
+    expect($result->success)->toBeTrue()
+        ->and($result->suggestionIds)->toHaveCount(2);
+
+    $suggestions = AnalysisSuggestion::whereIn('id', $result->suggestionIds)->get();
+    $directions = $suggestions->pluck('payload.direction')->sort()->values();
+    expect($directions->all())->toBe(['credit', 'debit']);
+});
+
+// ─── Normalization ──────────────────────────────────────────────────────
+
+test('prefers merchant_name over description for grouping', function () {
+    $start = CarbonImmutable::parse('2026-01-15');
+
+    for ($i = 0; $i < 3; $i++) {
+        createBasiqTransaction($this->user, $this->account, [
+            'merchant_name' => 'Woolworths',
+            'description' => 'WOOLWORTHS '.fake()->randomNumber(4).' SYDNEY AU',
+            'amount' => 8500,
+            'post_date' => $start->addMonthsNoOverflow($i),
+        ]);
+    }
+
+    $result = $this->stage->execute($this->context);
+
+    expect($result->suggestionIds)->toHaveCount(1);
+
+    $suggestion = AnalysisSuggestion::find($result->suggestionIds[0]);
+    expect($suggestion->payload['description'])->toBe('WOOLWORTHS');
+});
+
+test('prefers clean_description when merchant_name is null', function () {
+    $start = CarbonImmutable::parse('2026-01-15');
+
+    for ($i = 0; $i < 3; $i++) {
+        createBasiqTransaction($this->user, $this->account, [
+            'merchant_name' => null,
+            'clean_description' => 'BP Fuel Station',
+            'description' => 'BP FUEL STATION '.fake()->randomNumber(4),
+            'amount' => 6000,
+            'post_date' => $start->addMonthsNoOverflow($i),
+        ]);
+    }
+
+    $result = $this->stage->execute($this->context);
+
+    expect($result->suggestionIds)->toHaveCount(1);
+
+    $suggestion = AnalysisSuggestion::find($result->suggestionIds[0]);
+    expect($suggestion->payload['description'])->toBe('BP FUEL STATION');
+});
+
+test('strips card numbers from raw descriptions for grouping', function () {
+    $start = CarbonImmutable::parse('2026-01-15');
+
+    for ($i = 0; $i < 3; $i++) {
+        createBasiqTransaction($this->user, $this->account, [
+            'merchant_name' => null,
+            'clean_description' => null,
+            'description' => 'WOOLWORTHS 1234 SYDNEY AU',
+            'amount' => 8500,
+            'post_date' => $start->addMonthsNoOverflow($i),
+        ]);
+    }
+
+    $result = $this->stage->execute($this->context);
+
+    expect($result->suggestionIds)->toHaveCount(1);
+
+    $suggestion = AnalysisSuggestion::find($result->suggestionIds[0]);
+    expect($suggestion->payload['description'])->toBe('WOOLWORTHS');
+});
+
+test('strips date patterns from raw descriptions for grouping', function () {
+    $start = CarbonImmutable::parse('2026-01-15');
+    $dates = ['12/03', '13/04', '14/05'];
+
+    for ($i = 0; $i < 3; $i++) {
+        createBasiqTransaction($this->user, $this->account, [
+            'merchant_name' => null,
+            'clean_description' => null,
+            'description' => 'BP DANDENONG '.$dates[$i],
+            'amount' => 7500,
+            'post_date' => $start->addMonthsNoOverflow($i),
+        ]);
+    }
+
+    $result = $this->stage->execute($this->context);
+
+    expect($result->suggestionIds)->toHaveCount(1);
+
+    $suggestion = AnalysisSuggestion::find($result->suggestionIds[0]);
+    expect($suggestion->payload['description'])->toBe('BP DANDENONG');
+});
+
+test('deduplicates repeated names in descriptions', function () {
+    $start = CarbonImmutable::parse('2026-01-15');
+
+    for ($i = 0; $i < 3; $i++) {
+        createBasiqTransaction($this->user, $this->account, [
+            'merchant_name' => null,
+            'clean_description' => null,
+            'description' => 'NETFLIX.COM NETFLIX.COM',
+            'amount' => 1699,
+            'post_date' => $start->addMonthsNoOverflow($i),
+        ]);
+    }
+
+    $result = $this->stage->execute($this->context);
+
+    expect($result->suggestionIds)->toHaveCount(1);
+
+    $suggestion = AnalysisSuggestion::find($result->suggestionIds[0]);
+    expect($suggestion->payload['description'])->toBe('NETFLIX.COM');
+});
+
+// ─── Amount Consistency ─────────────────────────────────────────────────
+
+test('rejects group where amounts vary more than 5 percent from median', function () {
+    $start = CarbonImmutable::parse('2026-01-15');
+    $amounts = [10000, 10000, 15000];
+
+    for ($i = 0; $i < 3; $i++) {
+        createBasiqTransaction($this->user, $this->account, [
+            'merchant_name' => 'Variable Store',
+            'amount' => $amounts[$i],
+            'post_date' => $start->addMonthsNoOverflow($i),
+        ]);
+    }
+
+    $result = $this->stage->execute($this->context);
+
+    expect($result->suggestionIds)->toBeEmpty();
+});
+
+test('accepts group with amounts within 5 percent tolerance', function () {
+    $start = CarbonImmutable::parse('2026-01-15');
+    $amounts = [10000, 10200, 10400];
+
+    for ($i = 0; $i < 3; $i++) {
+        createBasiqTransaction($this->user, $this->account, [
+            'merchant_name' => 'Consistent Store',
+            'amount' => $amounts[$i],
+            'post_date' => $start->addMonthsNoOverflow($i),
+        ]);
+    }
+
+    $result = $this->stage->execute($this->context);
+
+    expect($result->suggestionIds)->toHaveCount(1);
+});
+
+// ─── Idempotency ────────────────────────────────────────────────────────
+
+test('skips when accepted suggestion exists with matching description and account', function () {
+    $existingRun = PipelineRun::factory()->for($this->user)->completed()->create();
+    AnalysisSuggestion::factory()->recurringTransaction()->accepted()->create([
+        'pipeline_run_id' => $existingRun->id,
+        'user_id' => $this->user->id,
+        'payload' => [
+            'description' => 'NETFLIX',
+            'account_id' => $this->account->id,
+        ],
+    ]);
+
+    createMonthlyGroup($this->user, $this->account, 'Netflix', 1699, 3);
+
+    $result = $this->stage->execute($this->context);
+
+    expect($result->suggestionIds)->toBeEmpty();
+});
+
+test('skips when matching active PlannedTransaction exists', function () {
+    PlannedTransaction::factory()->for($this->user)->create([
+        'account_id' => $this->account->id,
+        'description' => 'Netflix',
+        'frequency' => RecurrenceFrequency::EveryMonth,
+        'amount' => 1699,
+        'is_active' => true,
+    ]);
+
+    createMonthlyGroup($this->user, $this->account, 'Netflix', 1699, 3);
+
+    $result = $this->stage->execute($this->context);
+
+    expect($result->suggestionIds)->toBeEmpty();
+});
+
+test('skips when rejected suggestion within 90 days exists', function () {
+    $existingRun = PipelineRun::factory()->for($this->user)->completed()->create();
+    AnalysisSuggestion::factory()->recurringTransaction()->rejected()->create([
+        'pipeline_run_id' => $existingRun->id,
+        'user_id' => $this->user->id,
+        'resolved_at' => now()->subDays(30),
+        'payload' => [
+            'description' => 'NETFLIX',
+            'account_id' => $this->account->id,
+        ],
+    ]);
+
+    createMonthlyGroup($this->user, $this->account, 'Netflix', 1699, 3);
+
+    $result = $this->stage->execute($this->context);
+
+    expect($result->suggestionIds)->toBeEmpty();
+});
+
+test('does not skip when rejection is older than 90 days', function () {
+    $existingRun = PipelineRun::factory()->for($this->user)->completed()->create();
+    AnalysisSuggestion::factory()->recurringTransaction()->rejected()->create([
+        'pipeline_run_id' => $existingRun->id,
+        'user_id' => $this->user->id,
+        'resolved_at' => now()->subDays(91),
+        'payload' => [
+            'description' => 'NETFLIX',
+            'account_id' => $this->account->id,
+        ],
+    ]);
+
+    createMonthlyGroup($this->user, $this->account, 'Netflix', 1699, 3);
+
+    $result = $this->stage->execute($this->context);
+
+    expect($result->suggestionIds)->toHaveCount(1);
+});
+
+test('PlannedTransaction match uses 5 percent amount tolerance', function () {
+    PlannedTransaction::factory()->for($this->user)->create([
+        'account_id' => $this->account->id,
+        'description' => 'Netflix',
+        'frequency' => RecurrenceFrequency::EveryMonth,
+        'amount' => 1750,
+        'is_active' => true,
+    ]);
+
+    createMonthlyGroup($this->user, $this->account, 'Netflix', 1699, 3);
+
+    $result = $this->stage->execute($this->context);
+
+    expect($result->suggestionIds)->toBeEmpty();
+});
+
+// ─── Edge Cases ─────────────────────────────────────────────────────────
+
+test('ignores non-Basiq transactions', function () {
+    $start = CarbonImmutable::parse('2026-01-15');
+
+    for ($i = 0; $i < 3; $i++) {
+        Transaction::factory()->create([
+            'user_id' => $this->user->id,
+            'account_id' => $this->account->id,
+            'source' => TransactionSource::Manual,
+            'description' => 'MANUAL ENTRY',
+            'amount' => 5000,
+            'post_date' => $start->addMonthsNoOverflow($i),
+        ]);
+    }
+
+    $result = $this->stage->execute($this->context);
+
+    expect($result->success)->toBeTrue()
+        ->and($result->suggestionIds)->toBeEmpty();
+});
+
+test('ignores transactions already linked to PlannedTransaction', function () {
+    $planned = PlannedTransaction::factory()->for($this->user)->create([
+        'account_id' => $this->account->id,
+    ]);
+
+    $start = CarbonImmutable::parse('2026-01-15');
+
+    for ($i = 0; $i < 3; $i++) {
+        createBasiqTransaction($this->user, $this->account, [
+            'merchant_name' => 'Linked Merchant',
+            'amount' => 3000,
+            'post_date' => $start->addMonthsNoOverflow($i),
+            'planned_transaction_id' => $planned->id,
+        ]);
+    }
+
+    $result = $this->stage->execute($this->context);
+
+    expect($result->success)->toBeTrue()
+        ->and($result->suggestionIds)->toBeEmpty();
+});
+
+test('returns success with empty suggestionIds when no Basiq transactions exist', function () {
+    $result = $this->stage->execute($this->context);
+
+    expect($result->success)->toBeTrue()
+        ->and($result->suggestionIds)->toBeEmpty()
+        ->and($result->stage)->toBe('identify-recurring-transactions');
+});
+
+// ─── Confidence ─────────────────────────────────────────────────────────
+
+test('higher confidence for more matches', function () {
+    $start = CarbonImmutable::parse('2025-07-15');
+
+    for ($i = 0; $i < 3; $i++) {
+        createBasiqTransaction($this->user, $this->account, [
+            'merchant_name' => 'SmallGroup',
+            'amount' => 2000,
+            'post_date' => $start->addMonthsNoOverflow($i),
+        ]);
+    }
+
+    $account2 = Account::factory()->for($this->user)->create();
+
+    for ($i = 0; $i < 8; $i++) {
+        createBasiqTransaction($this->user, $account2, [
+            'merchant_name' => 'LargeGroup',
+            'amount' => 2000,
+            'post_date' => $start->addMonthsNoOverflow($i),
+        ]);
+    }
+
+    $result = $this->stage->execute($this->context);
+
+    expect($result->suggestionIds)->toHaveCount(2);
+
+    $suggestions = AnalysisSuggestion::whereIn('id', $result->suggestionIds)
+        ->get()
+        ->keyBy(fn ($s) => $s->payload['description']);
+
+    expect($suggestions['LARGEGROUP']->payload['confidence_score'])
+        ->toBeGreaterThan($suggestions['SMALLGROUP']->payload['confidence_score']);
+});
+
+test('higher confidence for identical amounts versus varying', function () {
+    $start = CarbonImmutable::parse('2026-01-15');
+
+    for ($i = 0; $i < 4; $i++) {
+        createBasiqTransaction($this->user, $this->account, [
+            'merchant_name' => 'IdenticalCo',
+            'amount' => 5000,
+            'post_date' => $start->addMonthsNoOverflow($i),
+        ]);
+    }
+
+    $account2 = Account::factory()->for($this->user)->create();
+    $varyingAmounts = [5000, 5200, 4900, 5100];
+
+    for ($i = 0; $i < 4; $i++) {
+        createBasiqTransaction($this->user, $account2, [
+            'merchant_name' => 'VaryingCo',
+            'amount' => $varyingAmounts[$i],
+            'post_date' => $start->addMonthsNoOverflow($i),
+        ]);
+    }
+
+    $result = $this->stage->execute($this->context);
+
+    expect($result->suggestionIds)->toHaveCount(2);
+
+    $suggestions = AnalysisSuggestion::whereIn('id', $result->suggestionIds)
+        ->get()
+        ->keyBy(fn ($s) => $s->payload['description']);
+
+    expect($suggestions['IDENTICALCO']->payload['confidence_score'])
+        ->toBeGreaterThanOrEqual($suggestions['VARYINGCO']->payload['confidence_score']);
+});
+
+test('higher confidence for regular intervals', function () {
+    $account2 = Account::factory()->for($this->user)->create();
+
+    $regularDates = ['2026-01-15', '2026-02-15', '2026-03-15', '2026-04-15'];
+    foreach ($regularDates as $date) {
+        createBasiqTransaction($this->user, $this->account, [
+            'merchant_name' => 'RegularCo',
+            'amount' => 3000,
+            'post_date' => $date,
+        ]);
+    }
+
+    $irregularDates = ['2026-01-15', '2026-02-18', '2026-03-12', '2026-04-16'];
+    foreach ($irregularDates as $date) {
+        createBasiqTransaction($this->user, $account2, [
+            'merchant_name' => 'IrregularCo',
+            'amount' => 3000,
+            'post_date' => $date,
+        ]);
+    }
+
+    $result = $this->stage->execute($this->context);
+
+    expect($result->suggestionIds)->toHaveCount(2);
+
+    $suggestions = AnalysisSuggestion::whereIn('id', $result->suggestionIds)
+        ->get()
+        ->keyBy(fn ($s) => $s->payload['description']);
+
+    expect($suggestions['REGULARCO']->payload['confidence_score'])
+        ->toBeGreaterThan($suggestions['IRREGULARCO']->payload['confidence_score']);
+});
+
+// ─── Payload ────────────────────────────────────────────────────────────
+
+test('payload contains all required fields with correct types', function () {
+    $category = Category::factory()->create();
+    $start = CarbonImmutable::parse('2026-01-15');
+
+    for ($i = 0; $i < 3; $i++) {
+        createBasiqTransaction($this->user, $this->account, [
+            'merchant_name' => 'Netflix',
+            'amount' => 1699,
+            'post_date' => $start->addMonthsNoOverflow($i),
+            'category_id' => $category->id,
+        ]);
+    }
+
+    $result = $this->stage->execute($this->context);
+
+    $suggestion = AnalysisSuggestion::find($result->suggestionIds[0]);
+    $payload = $suggestion->payload;
+
+    expect($payload)
+        ->toHaveKeys([
+            'description', 'clean_description', 'amount', 'direction',
+            'frequency', 'account_id', 'category_id', 'matched_transaction_ids',
+            'start_date', 'confidence_score',
+        ])
+        ->and($payload['description'])->toBeString()
+        ->and($payload['amount'])->toBeInt()
+        ->and($payload['direction'])->toBeString()
+        ->and($payload['frequency'])->toBeString()
+        ->and($payload['account_id'])->toBeInt()
+        ->and($payload['category_id'])->toBe($category->id)
+        ->and($payload['matched_transaction_ids'])->toBeArray()
+        ->and($payload['start_date'])->toBeString()
+        ->and($payload['confidence_score'])->toBeFloat();
+});
+
+test('matched_transaction_ids contains all group transaction IDs', function () {
+    $txns = createMonthlyGroup($this->user, $this->account, 'Netflix', 1699, 3);
+
+    $result = $this->stage->execute($this->context);
+
+    $suggestion = AnalysisSuggestion::find($result->suggestionIds[0]);
+    $expectedIds = $txns->pluck('id')->sort()->values()->all();
+    $actualIds = collect($suggestion->payload['matched_transaction_ids'])->sort()->values()->all();
+
+    expect($actualIds)->toBe($expectedIds);
+});
+
+test('start_date is earliest post_date in group', function () {
+    createBasiqTransaction($this->user, $this->account, [
+        'merchant_name' => 'DateTest',
+        'amount' => 2000,
+        'post_date' => '2026-03-15',
+    ]);
+    createBasiqTransaction($this->user, $this->account, [
+        'merchant_name' => 'DateTest',
+        'amount' => 2000,
+        'post_date' => '2026-01-15',
+    ]);
+    createBasiqTransaction($this->user, $this->account, [
+        'merchant_name' => 'DateTest',
+        'amount' => 2000,
+        'post_date' => '2026-02-15',
+    ]);
+
+    $result = $this->stage->execute($this->context);
+
+    $suggestion = AnalysisSuggestion::find($result->suggestionIds[0]);
+    expect($suggestion->payload['start_date'])->toBe('2026-01-15');
+});
+
+// ─── Audit ──────────────────────────────────────────────────────────────
+
+test('creates audit entries for skipped candidates with reason in metadata', function () {
+    $existingRun = PipelineRun::factory()->for($this->user)->completed()->create();
+    AnalysisSuggestion::factory()->recurringTransaction()->accepted()->create([
+        'pipeline_run_id' => $existingRun->id,
+        'user_id' => $this->user->id,
+        'payload' => [
+            'description' => 'NETFLIX',
+            'account_id' => $this->account->id,
+        ],
+    ]);
+
+    createMonthlyGroup($this->user, $this->account, 'Netflix', 1699, 3);
+
+    $this->stage->execute($this->context);
+
+    $audit = PipelineAuditEntry::query()
+        ->where('pipeline_run_id', $this->pipelineRun->id)
+        ->where('stage', 'identify-recurring-transactions')
+        ->where('action', 'skipped')
+        ->first();
+
+    expect($audit)->not->toBeNull()
+        ->and($audit->metadata['reason'])->toBe('existing_accepted_suggestion')
+        ->and($audit->metadata['description'])->toBe('NETFLIX')
+        ->and($audit->metadata['account_id'])->toBe($this->account->id);
+});
+
+// ─── Integration ────────────────────────────────────────────────────────
+
+test('stage is registered in pipeline and full run produces suggestions', function () {
+    createMonthlyGroup($this->user, $this->account, 'Netflix', 1699, 3);
+
+    $pipeline = app(App\Services\TransactionAnalysisPipeline::class);
+    $run = $pipeline->run($this->user, App\Enums\PipelineTrigger::Sync);
+
+    expect($run->stages_completed)->toContain('identify-recurring-transactions');
+
+    $suggestions = AnalysisSuggestion::query()
+        ->where('pipeline_run_id', $run->id)
+        ->where('type', SuggestionType::RecurringTransaction)
+        ->get();
+
+    expect($suggestions)->toHaveCount(1);
+});
+
+// ─── Contract ───────────────────────────────────────────────────────────
+
+test('key returns expected string', function () {
+    expect($this->stage->key())->toBe('identify-recurring-transactions');
+});
+
+test('label returns human-readable string', function () {
+    expect($this->stage->label())->toBe('Identify Recurring Transactions');
+});
+
+test('shouldRun always returns true', function () {
+    expect($this->stage->shouldRun($this->context))->toBeTrue();
+});


### PR DESCRIPTION
## Summary

- Implements the first concrete pipeline stage: `IdentifyRecurringTransactionsStage`, which detects recurring transaction patterns from imported Basiq bank data
- Groups unmatched Basiq transactions by normalized merchant/description, direction, and account, then analyzes amount consistency, interval regularity, and calculates a confidence score to create `AnalysisSuggestion` records (type: `RecurringTransaction`)
- Includes idempotency checks — skips groups that already have an accepted suggestion, a matching active `PlannedTransaction`, or a rejection within the last 90 days
- Registers the stage in the `TransactionAnalysisPipeline` singleton in `AppServiceProvider`

## Changes

| File | Change |
|------|--------|
| `app/Services/PipelineStages/IdentifyRecurringTransactionsStage.php` | New stage class (~390 lines) implementing `PipelineStageContract` |
| `tests/Feature/Services/PipelineStages/IdentifyRecurringTransactionsStageTest.php` | 33 Pest feature tests (~700 lines) covering detection, normalization, amount consistency, idempotency, edge cases, confidence scoring, payload shape, audit trail, and integration |
| `app/Providers/AppServiceProvider.php` | Registers stage in pipeline singleton (stages: [] → stages: [new IdentifyRecurringTransactionsStage]) |

## Detection Logic

- **Normalization**: Prefers `merchant_name` > `clean_description` > cleaned raw `description` (strips card numbers, trailing dates, country codes, deduplicates repeated phrases)
- **Frequency mapping**: Median interval → `RecurrenceFrequency` enum (weekly through yearly, with real-world tolerance ranges)
- **Confidence formula**: `0.30 × matchCount + 0.35 × amountConsistency + 0.35 × intervalRegularity` (minimum threshold: 0.40)
- **Idempotency**: Checks accepted suggestions, matching PlannedTransactions (5% amount tolerance), and recent rejections (90-day cooldown)

## Test plan

- [x] `op test.filter IdentifyRecurringTransactionsStageTest` — 33 tests, 81 assertions pass
- [x] `op test.filter TransactionAnalysisPipelineTest` — 19 tests, 49 assertions pass (no regression)
- [x] `op ci` — full suite passes (1122 tests, 0 PHPStan errors, Pint clean)

Closes #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)