### PR TITLE
feat: IdentifyPrimaryAccountStage (#164)

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -8,6 +8,7 @@ use App\Contracts\BasiqServiceContract;
 use App\Contracts\GitHubServiceContract;
 use App\Services\BasiqService;
 use App\Services\GitHubService;
+use App\Services\PipelineStages\IdentifyPrimaryAccountStage;
 use App\Services\PipelineStages\IdentifyRecurringTransactionsStage;
 use App\Services\TransactionAnalysisPipeline;
 use Carbon\CarbonImmutable;
@@ -40,6 +41,7 @@ final class AppServiceProvider extends ServiceProvider
 
         $this->app->singleton(TransactionAnalysisPipeline::class, fn (): TransactionAnalysisPipeline => new TransactionAnalysisPipeline(
             stages: [
+                new IdentifyPrimaryAccountStage,
                 new IdentifyRecurringTransactionsStage,
             ],
         ));

--- a/app/Services/PipelineStages/IdentifyPrimaryAccountStage.php
+++ b/app/Services/PipelineStages/IdentifyPrimaryAccountStage.php
@@ -1,0 +1,336 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\PipelineStages;
+
+use App\Contracts\PipelineStageContract;
+use App\DTOs\PipelineContext;
+use App\DTOs\StageResult;
+use App\Enums\AccountClass;
+use App\Enums\PayFrequency;
+use App\Enums\SuggestionType;
+use App\Enums\TransactionDirection;
+use App\Enums\TransactionSource;
+use App\Models\Account;
+use App\Models\AnalysisSuggestion;
+use App\Models\PipelineAuditEntry;
+use App\Models\Transaction;
+use Illuminate\Support\Collection;
+
+final readonly class IdentifyPrimaryAccountStage implements PipelineStageContract
+{
+    private const string STAGE_KEY = 'identify-primary-account';
+
+    private const int MIN_OCCURRENCES = 2;
+
+    private const float MAX_INTERVAL_CV = 0.30;
+
+    private const int SALARY_THRESHOLD_HIGH = 50_000;
+
+    private const int SALARY_THRESHOLD_LOW = 25_000;
+
+    private const array FREQUENCY_RANGES = [
+        'weekly' => ['min' => 5, 'max' => 9],
+        'fortnightly' => ['min' => 12, 'max' => 16],
+        'monthly' => ['min' => 27, 'max' => 35],
+    ];
+
+    private const float WEIGHT_INTERVAL = 0.30;
+
+    private const float WEIGHT_AMOUNT = 0.25;
+
+    private const float WEIGHT_COUNT = 0.25;
+
+    private const float WEIGHT_SALARY = 0.20;
+
+    private const float TRANSFER_BONUS_MAX = 0.10;
+
+    private const float TRANSFER_BONUS_PER = 0.02;
+
+    public function key(): string
+    {
+        return self::STAGE_KEY;
+    }
+
+    public function label(): string
+    {
+        return 'Identify Primary Account';
+    }
+
+    public function shouldRun(PipelineContext $context): bool
+    {
+        return $context->isFirstSync && $context->user->primary_account_id === null;
+    }
+
+    public function execute(PipelineContext $context): StageResult
+    {
+        $accounts = $context->user->accounts()
+            ->active()
+            ->whereIn('type', [AccountClass::Transaction, AccountClass::Savings])
+            ->get();
+
+        if ($accounts->isEmpty()) {
+            return new StageResult(success: true, stage: self::STAGE_KEY);
+        }
+
+        $bestOverall = null;
+
+        foreach ($accounts as $account) {
+            $candidate = $this->analyzeAccount($account, $context);
+
+            if ($candidate === null) {
+                continue;
+            }
+
+            if ($bestOverall === null || $candidate['confidence'] > $bestOverall['confidence']) {
+                $bestOverall = $candidate;
+            }
+        }
+
+        if ($bestOverall === null) {
+            PipelineAuditEntry::create([
+                'pipeline_run_id' => $context->pipelineRun->id,
+                'stage' => self::STAGE_KEY,
+                'action' => 'no_income_pattern_detected',
+                'metadata' => ['accounts_analyzed' => $accounts->count()],
+            ]);
+
+            return new StageResult(success: true, stage: self::STAGE_KEY);
+        }
+
+        $transferCount = $this->countOutboundTransfers($bestOverall['account'], $context);
+        $transferBonus = min(self::TRANSFER_BONUS_MAX, $transferCount * self::TRANSFER_BONUS_PER);
+        $finalConfidence = min(1.0, $bestOverall['confidence'] + $transferBonus);
+
+        $suggestion = AnalysisSuggestion::create([
+            'pipeline_run_id' => $context->pipelineRun->id,
+            'user_id' => $context->user->id,
+            'type' => SuggestionType::PrimaryAccount,
+            'payload' => [
+                'account_id' => $bestOverall['account']->id,
+                'account_name' => $bestOverall['account']->name,
+                'income_amount' => $bestOverall['median_amount'],
+                'income_frequency' => $bestOverall['frequency']->value,
+                'income_description' => $bestOverall['description'],
+                'confidence_score' => round($finalConfidence, 4),
+                'matched_transaction_ids' => $bestOverall['transaction_ids'],
+                'outbound_transfer_count' => $transferCount,
+            ],
+        ]);
+
+        return new StageResult(
+            success: true,
+            stage: self::STAGE_KEY,
+            suggestionIds: [$suggestion->id],
+        );
+    }
+
+    /**
+     * @return array{account: Account, confidence: float, median_amount: int, frequency: PayFrequency, description: string, transaction_ids: list<int>}|null
+     */
+    private function analyzeAccount(Account $account, PipelineContext $context): ?array
+    {
+        $credits = Transaction::query()
+            ->where('account_id', $account->id)
+            ->where('user_id', $context->user->id)
+            ->where('direction', TransactionDirection::Credit)
+            ->where('source', TransactionSource::Basiq)
+            ->whereNull('transfer_pair_id')
+            ->current()
+            ->orderBy('post_date')
+            ->get();
+
+        if ($credits->count() < self::MIN_OCCURRENCES) {
+            return null;
+        }
+
+        $grouped = $credits->groupBy(fn (Transaction $t) => $this->normalizeDescription($t));
+
+        $bestCandidate = null;
+
+        foreach ($grouped as $description => $transactions) {
+            if ($transactions->count() < self::MIN_OCCURRENCES) {
+                continue;
+            }
+
+            $result = $this->analyzeGroup($account, (string) $description, $transactions);
+
+            if ($result === null) {
+                continue;
+            }
+
+            if ($bestCandidate === null || $result['confidence'] > $bestCandidate['confidence']) {
+                $bestCandidate = $result;
+            }
+        }
+
+        return $bestCandidate;
+    }
+
+    /**
+     * @param  Collection<int, Transaction>  $transactions
+     * @return array{account: Account, confidence: float, median_amount: int, frequency: PayFrequency, description: string, transaction_ids: list<int>}|null
+     */
+    private function analyzeGroup(Account $account, string $description, Collection $transactions): ?array
+    {
+        $sorted = $transactions->sortBy('post_date')->values();
+        $intervals = $this->calculateIntervals($sorted);
+
+        if ($intervals === []) {
+            return null;
+        }
+
+        $medianInterval = $this->median($intervals);
+        $frequency = $this->mapFrequency($medianInterval);
+
+        if ($frequency === null) {
+            return null;
+        }
+
+        $intervalCV = $this->coefficientOfVariation($intervals);
+
+        if ($intervalCV > self::MAX_INTERVAL_CV) {
+            return null;
+        }
+
+        $amounts = $sorted->pluck('amount')->map(fn ($a) => abs((int) $a))->all();
+        $medianAmount = $this->median($amounts);
+        $amountCV = $this->coefficientOfVariation($amounts);
+
+        $intervalScore = max(0.0, 1.0 - $intervalCV * 3.33);
+        $amountScore = max(0.0, 1.0 - $amountCV / 0.10);
+        $countScore = min(1.0, log($sorted->count(), 2) / log(8, 2));
+        $salaryScore = $this->salaryScore($medianAmount);
+
+        $confidence = (self::WEIGHT_INTERVAL * $intervalScore)
+            + (self::WEIGHT_AMOUNT * $amountScore)
+            + (self::WEIGHT_COUNT * $countScore)
+            + (self::WEIGHT_SALARY * $salaryScore);
+
+        return [
+            'account' => $account,
+            'confidence' => round($confidence, 4),
+            'median_amount' => (int) round($medianAmount),
+            'frequency' => $frequency,
+            'description' => $description,
+            'transaction_ids' => $sorted->pluck('id')->all(),
+        ];
+    }
+
+    /**
+     * @param  Collection<int, Transaction>  $sorted
+     * @return list<float>
+     */
+    private function calculateIntervals(Collection $sorted): array
+    {
+        $intervals = [];
+
+        for ($i = 1; $i < $sorted->count(); $i++) {
+            $intervals[] = (float) $sorted[$i - 1]->post_date->diffInDays($sorted[$i]->post_date);
+        }
+
+        return $intervals;
+    }
+
+    private function mapFrequency(float $medianInterval): ?PayFrequency
+    {
+        foreach (self::FREQUENCY_RANGES as $freq => $range) {
+            if ($medianInterval >= $range['min'] && $medianInterval <= $range['max']) {
+                return PayFrequency::from($freq);
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  list<float|int>  $values
+     */
+    private function coefficientOfVariation(array $values): float
+    {
+        $count = count($values);
+
+        if ($count < 2) {
+            return 0.0;
+        }
+
+        $mean = array_sum($values) / $count;
+
+        if ($mean === 0.0) {
+            return 0.0;
+        }
+
+        $sumSquaredDiffs = 0.0;
+
+        foreach ($values as $v) {
+            $sumSquaredDiffs += ($v - $mean) ** 2;
+        }
+
+        $stdDev = sqrt($sumSquaredDiffs / $count);
+
+        return $stdDev / abs($mean);
+    }
+
+    /**
+     * @param  list<float|int>  $values
+     */
+    private function median(array $values): float
+    {
+        $sorted = $values;
+        sort($sorted);
+
+        $count = count($sorted);
+        $mid = intdiv($count, 2);
+
+        if ($count % 2 === 0) {
+            return ($sorted[$mid - 1] + $sorted[$mid]) / 2.0;
+        }
+
+        return (float) $sorted[$mid];
+    }
+
+    private function salaryScore(float $medianAmount): float
+    {
+        if ($medianAmount >= self::SALARY_THRESHOLD_HIGH) {
+            return 1.0;
+        }
+
+        if ($medianAmount >= self::SALARY_THRESHOLD_LOW) {
+            return 0.5;
+        }
+
+        return 0.0;
+    }
+
+    private function countOutboundTransfers(Account $account, PipelineContext $context): int
+    {
+        $userAccountIds = $context->user->accounts()
+            ->where('id', '!=', $account->id)
+            ->pluck('id');
+
+        return Transaction::query()
+            ->where('account_id', $account->id)
+            ->where('user_id', $context->user->id)
+            ->where('direction', TransactionDirection::Debit)
+            ->whereNotNull('transfer_pair_id')
+            ->whereHas('transferPair', fn ($q) => $q->whereIn('account_id', $userAccountIds))
+            ->current()
+            ->count();
+    }
+
+    private function normalizeDescription(Transaction $transaction): string
+    {
+        if ($transaction->merchant_name !== null && $transaction->merchant_name !== '') {
+            return mb_strtoupper(mb_trim($transaction->merchant_name));
+        }
+
+        if ($transaction->clean_description !== null && $transaction->clean_description !== '') {
+            return mb_strtoupper(mb_trim($transaction->clean_description));
+        }
+
+        $normalized = mb_strtoupper(mb_trim($transaction->description));
+
+        return (string) preg_replace('/\s+/', ' ', $normalized);
+    }
+}

--- a/database/factories/AnalysisSuggestionFactory.php
+++ b/database/factories/AnalysisSuggestionFactory.php
@@ -68,6 +68,13 @@ final class AnalysisSuggestionFactory extends Factory
         ]);
     }
 
+    public function primaryAccount(): self
+    {
+        return $this->state(fn (array $attributes) => [
+            'type' => SuggestionType::PrimaryAccount,
+        ]);
+    }
+
     public function recurringTransaction(): self
     {
         return $this->state(fn (array $attributes) => [

--- a/tests/Feature/Services/PipelineStages/IdentifyPrimaryAccountStageTest.php
+++ b/tests/Feature/Services/PipelineStages/IdentifyPrimaryAccountStageTest.php
@@ -1,0 +1,463 @@
+<?php
+
+/** @noinspection StaticClosureCanBeUsedInspection */
+
+declare(strict_types=1);
+
+use App\DTOs\PipelineContext;
+use App\Enums\PipelineTrigger;
+use App\Enums\SuggestionType;
+use App\Models\Account;
+use App\Models\AnalysisSuggestion;
+use App\Models\PipelineAuditEntry;
+use App\Models\PipelineRun;
+use App\Models\Transaction;
+use App\Models\User;
+use App\Services\PipelineStages\IdentifyPrimaryAccountStage;
+use App\Services\TransactionAnalysisPipeline;
+use Carbon\CarbonImmutable;
+
+// ──────────────────────────────────────────────
+// Helpers
+// ──────────────────────────────────────────────
+
+function createIncomeTransaction(User $user, Account $account, array $overrides = []): Transaction
+{
+    return Transaction::factory()
+        ->for($user)
+        ->for($account)
+        ->credit()
+        ->fromBasiq()
+        ->create(array_merge([
+            'transfer_pair_id' => null,
+            'merchant_name' => null,
+            'clean_description' => null,
+        ], $overrides));
+}
+
+function createSalaryGroup(
+    User $user,
+    Account $account,
+    string $description,
+    int $amount,
+    int $count,
+    int $intervalDays,
+    ?CarbonImmutable $startDate = null,
+): array {
+    $startDate ??= CarbonImmutable::parse('2025-06-01');
+    $transactions = [];
+
+    for ($i = 0; $i < $count; $i++) {
+        $transactions[] = createIncomeTransaction($user, $account, [
+            'description' => $description,
+            'amount' => $amount,
+            'post_date' => $startDate->addDays($i * $intervalDays),
+        ]);
+    }
+
+    return $transactions;
+}
+
+function makeContext(User $user, bool $isFirstSync = true): PipelineContext
+{
+    $pipelineRun = PipelineRun::factory()->for($user)->create([
+        'is_first_sync' => $isFirstSync,
+    ]);
+
+    return new PipelineContext(
+        user: $user,
+        pipelineRun: $pipelineRun,
+        isFirstSync: $isFirstSync,
+    );
+}
+
+beforeEach(function () {
+    $this->stage = new IdentifyPrimaryAccountStage;
+    $this->user = User::factory()->create(['primary_account_id' => null]);
+    $this->account = Account::factory()->for($this->user)->create();
+});
+
+// ──────────────────────────────────────────────
+// Detection
+// ──────────────────────────────────────────────
+
+test('detects primary account with consistent salary', function () {
+    createSalaryGroup($this->user, $this->account, 'SALARY DEPOSIT', 300_000, 4, 30);
+    $context = makeContext($this->user);
+
+    $result = $this->stage->execute($context);
+
+    expect($result)
+        ->success->toBeTrue()
+        ->suggestionIds->toHaveCount(1);
+
+    $suggestion = AnalysisSuggestion::find($result->suggestionIds[0]);
+    expect($suggestion)
+        ->type->toBe(SuggestionType::PrimaryAccount)
+        ->and($suggestion->payload['account_id'])->toBe($this->account->id)
+        ->and($suggestion->payload['income_frequency'])->toBe('monthly');
+});
+
+test('picks strongest income source when multiple exist', function () {
+    createSalaryGroup($this->user, $this->account, 'SALARY DEPOSIT', 300_000, 4, 30);
+    createSalaryGroup($this->user, $this->account, 'SMALL REFUND', 5_000, 4, 30);
+
+    $context = makeContext($this->user);
+    $result = $this->stage->execute($context);
+
+    $suggestion = AnalysisSuggestion::find($result->suggestionIds[0]);
+    expect($suggestion->payload['income_description'])->toBe('SALARY DEPOSIT')
+        ->and($suggestion->payload['income_amount'])->toBe(300_000);
+});
+
+test('picks strongest across accounts', function () {
+    $transactionAccount = $this->account;
+    $savingsAccount = Account::factory()->savings()->for($this->user)->create();
+
+    createSalaryGroup($this->user, $transactionAccount, 'SALARY DEPOSIT', 300_000, 5, 14);
+    createSalaryGroup($this->user, $savingsAccount, 'INTEREST PAYMENT', 5_000, 3, 30);
+
+    $context = makeContext($this->user);
+    $result = $this->stage->execute($context);
+
+    $suggestion = AnalysisSuggestion::find($result->suggestionIds[0]);
+    expect($suggestion->payload['account_id'])->toBe($transactionAccount->id);
+});
+
+test('creates no suggestion when no clear income pattern', function () {
+    for ($i = 0; $i < 5; $i++) {
+        createIncomeTransaction($this->user, $this->account, [
+            'description' => 'RANDOM CREDIT '.$i,
+            'amount' => fake()->numberBetween(1000, 100_000),
+            'post_date' => CarbonImmutable::parse('2025-06-01')->addDays(fake()->numberBetween(1, 90)),
+        ]);
+    }
+
+    $context = makeContext($this->user);
+    $result = $this->stage->execute($context);
+
+    expect($result)
+        ->success->toBeTrue()
+        ->suggestionIds->toBeEmpty();
+});
+
+test('requires minimum 2 credit transactions', function () {
+    createIncomeTransaction($this->user, $this->account, [
+        'description' => 'SALARY DEPOSIT',
+        'amount' => 300_000,
+        'post_date' => CarbonImmutable::parse('2025-06-01'),
+    ]);
+
+    $context = makeContext($this->user);
+    $result = $this->stage->execute($context);
+
+    expect($result)
+        ->success->toBeTrue()
+        ->suggestionIds->toBeEmpty();
+});
+
+// ──────────────────────────────────────────────
+// Frequency
+// ──────────────────────────────────────────────
+
+test('detects weekly income frequency', function () {
+    createSalaryGroup($this->user, $this->account, 'WEEKLY PAY', 150_000, 4, 7);
+
+    $context = makeContext($this->user);
+    $result = $this->stage->execute($context);
+
+    $suggestion = AnalysisSuggestion::find($result->suggestionIds[0]);
+    expect($suggestion->payload['income_frequency'])->toBe('weekly');
+});
+
+test('detects fortnightly income frequency', function () {
+    createSalaryGroup($this->user, $this->account, 'SALARY DEPOSIT', 300_000, 4, 14);
+
+    $context = makeContext($this->user);
+    $result = $this->stage->execute($context);
+
+    $suggestion = AnalysisSuggestion::find($result->suggestionIds[0]);
+    expect($suggestion->payload['income_frequency'])->toBe('fortnightly');
+});
+
+test('detects monthly income frequency', function () {
+    createSalaryGroup($this->user, $this->account, 'SALARY DEPOSIT', 300_000, 4, 30);
+
+    $context = makeContext($this->user);
+    $result = $this->stage->execute($context);
+
+    $suggestion = AnalysisSuggestion::find($result->suggestionIds[0]);
+    expect($suggestion->payload['income_frequency'])->toBe('monthly');
+});
+
+test('rejects income group with interval CV above 0.3', function () {
+    $startDate = CarbonImmutable::parse('2025-06-01');
+    createIncomeTransaction($this->user, $this->account, [
+        'description' => 'IRREGULAR PAY',
+        'amount' => 300_000,
+        'post_date' => $startDate,
+    ]);
+    createIncomeTransaction($this->user, $this->account, [
+        'description' => 'IRREGULAR PAY',
+        'amount' => 300_000,
+        'post_date' => $startDate->addDays(30),
+    ]);
+    createIncomeTransaction($this->user, $this->account, [
+        'description' => 'IRREGULAR PAY',
+        'amount' => 300_000,
+        'post_date' => $startDate->addDays(45),
+    ]);
+    createIncomeTransaction($this->user, $this->account, [
+        'description' => 'IRREGULAR PAY',
+        'amount' => 300_000,
+        'post_date' => $startDate->addDays(90),
+    ]);
+
+    $context = makeContext($this->user);
+    $result = $this->stage->execute($context);
+
+    expect($result->suggestionIds)->toBeEmpty();
+});
+
+// ──────────────────────────────────────────────
+// Transfer Signal
+// ──────────────────────────────────────────────
+
+test('outbound transfers boost confidence', function () {
+    createSalaryGroup($this->user, $this->account, 'SALARY DEPOSIT', 300_000, 4, 30);
+
+    $contextNoTransfers = makeContext($this->user);
+    $resultNoTransfers = $this->stage->execute($contextNoTransfers);
+    $scoreWithout = AnalysisSuggestion::find($resultNoTransfers->suggestionIds[0])->payload['confidence_score'];
+
+    AnalysisSuggestion::query()->delete();
+
+    $savingsAccount = Account::factory()->savings()->for($this->user)->create();
+    for ($i = 0; $i < 5; $i++) {
+        $creditSide = Transaction::factory()
+            ->for($this->user)
+            ->for($savingsAccount)
+            ->credit()
+            ->fromBasiq()
+            ->create(['post_date' => CarbonImmutable::parse('2025-06-05')->addDays($i * 30)]);
+
+        Transaction::factory()
+            ->for($this->user)
+            ->for($this->account)
+            ->debit()
+            ->fromBasiq()
+            ->create([
+                'transfer_pair_id' => $creditSide->id,
+                'post_date' => CarbonImmutable::parse('2025-06-05')->addDays($i * 30),
+            ]);
+    }
+
+    $contextWithTransfers = makeContext($this->user);
+    $resultWithTransfers = $this->stage->execute($contextWithTransfers);
+
+    $suggestionWith = AnalysisSuggestion::find($resultWithTransfers->suggestionIds[0]);
+    $scoreWith = $suggestionWith->payload['confidence_score'];
+
+    expect($scoreWith)->toBeGreaterThan($scoreWithout)
+        ->and($suggestionWith->payload['outbound_transfer_count'])->toBe(5);
+});
+
+// ──────────────────────────────────────────────
+// shouldRun Guard
+// ──────────────────────────────────────────────
+
+test('skips when not first sync', function () {
+    $context = makeContext($this->user, isFirstSync: false);
+
+    expect($this->stage->shouldRun($context))->toBeFalse();
+});
+
+test('skips when primary account already set', function () {
+    $this->user->update(['primary_account_id' => $this->account->id]);
+    $this->user->refresh();
+
+    $context = makeContext($this->user);
+
+    expect($this->stage->shouldRun($context))->toBeFalse();
+});
+
+test('runs when first sync and no primary account', function () {
+    $context = makeContext($this->user);
+
+    expect($this->stage->shouldRun($context))->toBeTrue();
+});
+
+// ──────────────────────────────────────────────
+// Account Filtering
+// ──────────────────────────────────────────────
+
+test('only considers Transaction and Savings account types', function () {
+    $creditCardAccount = Account::factory()->creditCard()->for($this->user)->create();
+    createSalaryGroup($this->user, $creditCardAccount, 'SALARY DEPOSIT', 300_000, 4, 30);
+
+    $context = makeContext($this->user);
+    $result = $this->stage->execute($context);
+
+    expect($result->suggestionIds)->toBeEmpty();
+});
+
+test('only considers active accounts', function () {
+    $inactiveAccount = Account::factory()->inactive()->for($this->user)->create();
+    createSalaryGroup($this->user, $inactiveAccount, 'SALARY DEPOSIT', 300_000, 4, 30);
+
+    $context = makeContext($this->user);
+    $result = $this->stage->execute($context);
+
+    expect($result->suggestionIds)->toBeEmpty();
+});
+
+test('excludes incoming transfers from income grouping', function () {
+    $otherAccount = Account::factory()->for($this->user)->create();
+
+    $startDate = CarbonImmutable::parse('2025-06-01');
+
+    for ($i = 0; $i < 4; $i++) {
+        $debitSide = Transaction::factory()
+            ->for($this->user)
+            ->for($otherAccount)
+            ->debit()
+            ->fromBasiq()
+            ->create(['post_date' => $startDate->addDays($i * 30)]);
+
+        Transaction::factory()
+            ->for($this->user)
+            ->for($this->account)
+            ->credit()
+            ->fromBasiq()
+            ->create([
+                'description' => 'TRANSFER FROM OTHER',
+                'amount' => 300_000,
+                'transfer_pair_id' => $debitSide->id,
+                'post_date' => $startDate->addDays($i * 30),
+            ]);
+    }
+
+    $context = makeContext($this->user);
+    $result = $this->stage->execute($context);
+
+    expect($result->suggestionIds)->toBeEmpty();
+});
+
+// ──────────────────────────────────────────────
+// Payload
+// ──────────────────────────────────────────────
+
+test('payload contains all required fields with correct types', function () {
+    createSalaryGroup($this->user, $this->account, 'SALARY DEPOSIT', 300_000, 4, 30);
+
+    $context = makeContext($this->user);
+    $result = $this->stage->execute($context);
+
+    $suggestion = AnalysisSuggestion::find($result->suggestionIds[0]);
+    $payload = $suggestion->payload;
+
+    expect($payload)
+        ->toHaveKeys([
+            'account_id',
+            'account_name',
+            'income_amount',
+            'income_frequency',
+            'income_description',
+            'confidence_score',
+            'matched_transaction_ids',
+            'outbound_transfer_count',
+        ])
+        ->and($payload['account_id'])->toBeInt()
+        ->and($payload['account_name'])->toBeString()
+        ->and($payload['income_amount'])->toBeInt()
+        ->and($payload['income_frequency'])->toBeString()
+        ->and($payload['income_description'])->toBeString()
+        ->and($payload['confidence_score'])->toBeFloat()
+        ->and($payload['matched_transaction_ids'])->toBeArray()
+        ->and($payload['outbound_transfer_count'])->toBeInt();
+});
+
+test('matched_transaction_ids contains all group transaction IDs', function () {
+    $transactions = createSalaryGroup($this->user, $this->account, 'SALARY DEPOSIT', 300_000, 4, 30);
+    $expectedIds = collect($transactions)->pluck('id')->sort()->values()->all();
+
+    $context = makeContext($this->user);
+    $result = $this->stage->execute($context);
+
+    $suggestion = AnalysisSuggestion::find($result->suggestionIds[0]);
+    $actualIds = collect($suggestion->payload['matched_transaction_ids'])->sort()->values()->all();
+
+    expect($actualIds)->toBe($expectedIds);
+});
+
+// ──────────────────────────────────────────────
+// Audit
+// ──────────────────────────────────────────────
+
+test('creates audit entry when no income pattern detected', function () {
+    createIncomeTransaction($this->user, $this->account, [
+        'description' => 'RANDOM THING',
+        'amount' => 300_000,
+        'post_date' => CarbonImmutable::parse('2025-06-01'),
+    ]);
+
+    $context = makeContext($this->user);
+    $this->stage->execute($context);
+
+    $audit = PipelineAuditEntry::where('pipeline_run_id', $context->pipelineRun->id)
+        ->where('stage', 'identify-primary-account')
+        ->first();
+
+    expect($audit)
+        ->action->toBe('no_income_pattern_detected');
+});
+
+// ──────────────────────────────────────────────
+// Contract
+// ──────────────────────────────────────────────
+
+test('key returns expected string', function () {
+    expect($this->stage->key())->toBe('identify-primary-account');
+});
+
+test('label returns human-readable string', function () {
+    expect($this->stage->label())->toBe('Identify Primary Account');
+});
+
+// ──────────────────────────────────────────────
+// Integration
+// ──────────────────────────────────────────────
+
+test('stage is registered in pipeline and full run produces suggestion on first sync', function () {
+    createSalaryGroup($this->user, $this->account, 'SALARY DEPOSIT', 300_000, 4, 30);
+
+    $pipeline = app(TransactionAnalysisPipeline::class);
+    $run = $pipeline->run($this->user, PipelineTrigger::Sync);
+
+    expect($run->stages_completed)->toContain('identify-primary-account');
+
+    $suggestion = AnalysisSuggestion::where('pipeline_run_id', $run->id)
+        ->where('type', SuggestionType::PrimaryAccount)
+        ->first();
+
+    expect($suggestion)->not->toBeNull()
+        ->and($suggestion->payload['account_id'])->toBe($this->account->id);
+});
+
+test('stage is skipped in pipeline when not first sync', function () {
+    $this->user->update(['primary_account_id' => $this->account->id]);
+    $this->user->refresh();
+
+    createSalaryGroup($this->user, $this->account, 'SALARY DEPOSIT', 300_000, 4, 30);
+
+    $pipeline = app(TransactionAnalysisPipeline::class);
+    $run = $pipeline->run($this->user, PipelineTrigger::Sync);
+
+    expect($run->stages_skipped)->toContain('identify-primary-account');
+
+    $suggestion = AnalysisSuggestion::where('pipeline_run_id', $run->id)
+        ->where('type', SuggestionType::PrimaryAccount)
+        ->first();
+
+    expect($suggestion)->toBeNull();
+});


### PR DESCRIPTION
## Summary

- Implements `IdentifyPrimaryAccountStage` — the second pipeline stage that detects the user's primary bank account on first sync by finding consistent income deposits (salary patterns) across Transaction and Savings accounts
- Uses a 4-component confidence scoring system (interval regularity, amount consistency, occurrence count, salary-size threshold) with an outbound transfer bonus
- Maps income intervals to `PayFrequency` (Weekly/Fortnightly/Monthly) for downstream use by the future `IdentifyPayCycleStage` (#165)
- Only executes on first sync when no primary account is set (`shouldRun` guard), adding zero cost to subsequent pipeline runs

## Changes

- **Created** `app/Services/PipelineStages/IdentifyPrimaryAccountStage.php` — full stage implementation
- **Created** `tests/Feature/Services/PipelineStages/IdentifyPrimaryAccountStageTest.php` — 23 tests (49 assertions)
- **Modified** `app/Providers/AppServiceProvider.php` — registered stage first in pipeline
- **Modified** `database/factories/AnalysisSuggestionFactory.php` — added `primaryAccount()` state

## Test plan

- [x] `op test.filter IdentifyPrimaryAccountStage` — 23 tests pass
- [x] `op test.filter TransactionAnalysisPipelineTest` — 19 existing pipeline tests pass
- [x] `op lint.dirty` — Pint clean
- [x] `op ci` — full CI green (1112 tests, PHPStan clean)

Closes #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)