### PR TITLE
feat: SetPayCycleStage (#165)

### DIFF
--- a/app/Events/PlannedTransactionCategoryUpdated.php
+++ b/app/Events/PlannedTransactionCategoryUpdated.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Events;
+
+use App\Models\PlannedTransaction;
+
+final class PlannedTransactionCategoryUpdated
+{
+    public function __construct(
+        public PlannedTransaction $plannedTransaction,
+        public ?int $previousCategoryId,
+    ) {}
+}

--- a/app/Events/TransactionCategoryUpdated.php
+++ b/app/Events/TransactionCategoryUpdated.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Events;
+
+use App\Models\Transaction;
+
+final class TransactionCategoryUpdated
+{
+    public function __construct(
+        public Transaction $transaction,
+        public ?int $previousCategoryId,
+    ) {}
+}

--- a/app/Listeners/PropagatePlannedTransactionCategory.php
+++ b/app/Listeners/PropagatePlannedTransactionCategory.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Listeners;
+
+use App\Events\PlannedTransactionCategoryUpdated;
+use App\Models\Transaction;
+
+final class PropagatePlannedTransactionCategory
+{
+    public function handle(PlannedTransactionCategoryUpdated $event): void
+    {
+        $plannedTransaction = $event->plannedTransaction;
+
+        if ($event->previousCategoryId === $plannedTransaction->category_id) {
+            return;
+        }
+
+        Transaction::query()
+            ->where('planned_transaction_id', $plannedTransaction->id)
+            ->update(['category_id' => $plannedTransaction->category_id]);
+    }
+}

--- a/app/Listeners/PropagateTransactionCategory.php
+++ b/app/Listeners/PropagateTransactionCategory.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Listeners;
+
+use App\Events\TransactionCategoryUpdated;
+use App\Models\PlannedTransaction;
+use App\Models\Transaction;
+
+final class PropagateTransactionCategory
+{
+    public function handle(TransactionCategoryUpdated $event): void
+    {
+        $transaction = $event->transaction;
+        $plannedId = $transaction->planned_transaction_id;
+
+        if ($plannedId === null) {
+            return;
+        }
+
+        if ($event->previousCategoryId === $transaction->category_id) {
+            return;
+        }
+
+        $newCategoryId = $transaction->category_id;
+
+        Transaction::query()
+            ->where('planned_transaction_id', $plannedId)
+            ->where('id', '!=', $transaction->id)
+            ->update(['category_id' => $newCategoryId]);
+
+        PlannedTransaction::query()
+            ->where('id', $plannedId)
+            ->update(['category_id' => $newCategoryId]);
+    }
+}

--- a/app/Models/PlannedTransaction.php
+++ b/app/Models/PlannedTransaction.php
@@ -7,6 +7,7 @@ namespace App\Models;
 use App\Casts\MoneyCast;
 use App\Enums\RecurrenceFrequency;
 use App\Enums\TransactionDirection;
+use App\Events\PlannedTransactionCategoryUpdated;
 use Carbon\CarbonImmutable;
 use Database\Factories\PlannedTransactionFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -128,6 +129,18 @@ final class PlannedTransaction extends Model
         }
 
         return $dates;
+    }
+
+    protected static function booted(): void
+    {
+        self::updated(static function (PlannedTransaction $plannedTransaction): void {
+            if ($plannedTransaction->wasChanged('category_id')) {
+                event(new PlannedTransactionCategoryUpdated(
+                    $plannedTransaction,
+                    $plannedTransaction->getOriginal('category_id'),
+                ));
+            }
+        });
     }
 
     /** @return array<string, string> */

--- a/app/Models/Transaction.php
+++ b/app/Models/Transaction.php
@@ -8,6 +8,7 @@ use App\Casts\MoneyCast;
 use App\Enums\TransactionDirection;
 use App\Enums\TransactionSource;
 use App\Enums\TransactionStatus;
+use App\Events\TransactionCategoryUpdated;
 use Carbon\CarbonImmutable;
 use Database\Factories\TransactionFactory;
 use Illuminate\Database\Eloquent\Builder;
@@ -175,6 +176,18 @@ final class Transaction extends Model
     public function scopeWithRelations(Builder $query): Builder
     {
         return $query->with(['account', 'category']);
+    }
+
+    protected static function booted(): void
+    {
+        self::updated(static function (Transaction $transaction): void {
+            if ($transaction->wasChanged('category_id')) {
+                event(new TransactionCategoryUpdated(
+                    $transaction,
+                    $transaction->getOriginal('category_id'),
+                ));
+            }
+        });
     }
 
     /**

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -10,6 +10,7 @@ use App\Services\BasiqService;
 use App\Services\GitHubService;
 use App\Services\PipelineStages\IdentifyPrimaryAccountStage;
 use App\Services\PipelineStages\IdentifyRecurringTransactionsStage;
+use App\Services\PipelineStages\SetPayCycleStage;
 use App\Services\TransactionAnalysisPipeline;
 use Carbon\CarbonImmutable;
 use Illuminate\Support\Facades\Date;
@@ -42,6 +43,7 @@ final class AppServiceProvider extends ServiceProvider
         $this->app->singleton(TransactionAnalysisPipeline::class, fn (): TransactionAnalysisPipeline => new TransactionAnalysisPipeline(
             stages: [
                 new IdentifyPrimaryAccountStage,
+                new SetPayCycleStage,
                 new IdentifyRecurringTransactionsStage,
             ],
         ));

--- a/app/Services/PipelineStages/SetPayCycleStage.php
+++ b/app/Services/PipelineStages/SetPayCycleStage.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\PipelineStages;
+
+use App\Contracts\PipelineStageContract;
+use App\DTOs\PipelineContext;
+use App\DTOs\StageResult;
+use App\Enums\PayFrequency;
+use App\Enums\SuggestionType;
+use App\Models\AnalysisSuggestion;
+use App\Models\PipelineAuditEntry;
+use App\Models\Transaction;
+use Carbon\CarbonImmutable;
+
+final readonly class SetPayCycleStage implements PipelineStageContract
+{
+    private const string STAGE_KEY = 'set-pay-cycle';
+
+    public function key(): string
+    {
+        return self::STAGE_KEY;
+    }
+
+    public function label(): string
+    {
+        return 'Set Pay Cycle';
+    }
+
+    public function shouldRun(PipelineContext $context): bool
+    {
+        return $context->isFirstSync && ! $context->user->hasPayCycleConfigured();
+    }
+
+    public function execute(PipelineContext $context): StageResult
+    {
+        $primarySuggestion = AnalysisSuggestion::query()
+            ->where('pipeline_run_id', $context->pipelineRun->id)
+            ->ofType(SuggestionType::PrimaryAccount)
+            ->first();
+
+        if ($primarySuggestion === null) {
+            PipelineAuditEntry::create([
+                'pipeline_run_id' => $context->pipelineRun->id,
+                'stage' => self::STAGE_KEY,
+                'action' => 'no_primary_account_suggestion',
+                'metadata' => [],
+            ]);
+
+            return new StageResult(success: true, stage: self::STAGE_KEY);
+        }
+
+        $payload = $primarySuggestion->payload;
+        $incomeAmount = (int) $payload['income_amount'];
+        $incomeFrequency = $payload['income_frequency'];
+        $incomeDescription = (string) $payload['income_description'];
+        $matchedTransactionIds = (array) $payload['matched_transaction_ids'];
+        $accountId = (int) $payload['account_id'];
+
+        $frequency = PayFrequency::from($incomeFrequency);
+
+        $matchedTransactions = Transaction::query()
+            ->where('user_id', $context->user->id)
+            ->whereIn('id', $matchedTransactionIds)
+            ->orderBy('post_date')
+            ->get();
+
+        if ($matchedTransactions->isEmpty()) {
+            PipelineAuditEntry::create([
+                'pipeline_run_id' => $context->pipelineRun->id,
+                'stage' => self::STAGE_KEY,
+                'action' => 'no_matched_transactions_found',
+                'metadata' => ['expected_ids' => $matchedTransactionIds],
+            ]);
+
+            return new StageResult(success: true, stage: self::STAGE_KEY);
+        }
+
+        $detectedDates = $matchedTransactions
+            ->pluck('post_date')
+            ->map(fn (CarbonImmutable $date): string => $date->format('Y-m-d'))
+            ->values()
+            ->all();
+
+        $mostRecentDate = $matchedTransactions->last()->post_date;
+        $nextPayDate = $this->calculateNextPayDate($mostRecentDate, $frequency);
+
+        $suggestion = AnalysisSuggestion::create([
+            'pipeline_run_id' => $context->pipelineRun->id,
+            'user_id' => $context->user->id,
+            'type' => SuggestionType::PayCycle,
+            'payload' => [
+                'pay_amount' => $incomeAmount,
+                'pay_frequency' => $frequency->value,
+                'next_pay_date' => $nextPayDate->format('Y-m-d'),
+                'source_account_id' => $accountId,
+                'source_description' => $incomeDescription,
+                'detected_dates' => $detectedDates,
+            ],
+        ]);
+
+        return new StageResult(
+            success: true,
+            stage: self::STAGE_KEY,
+            suggestionIds: [$suggestion->id],
+        );
+    }
+
+    private function calculateNextPayDate(CarbonImmutable $mostRecent, PayFrequency $frequency): CarbonImmutable
+    {
+        $next = $this->addInterval($mostRecent, $frequency);
+
+        while ($next->lte(CarbonImmutable::today())) {
+            $next = $this->addInterval($next, $frequency);
+        }
+
+        return $next;
+    }
+
+    private function addInterval(CarbonImmutable $date, PayFrequency $frequency): CarbonImmutable
+    {
+        return match ($frequency) {
+            PayFrequency::Weekly => $date->addWeek(),
+            PayFrequency::Fortnightly => $date->addWeeks(2),
+            PayFrequency::Monthly => $date->addMonth(),
+        };
+    }
+}

--- a/tests/Feature/Events/CategoryPropagationTest.php
+++ b/tests/Feature/Events/CategoryPropagationTest.php
@@ -1,0 +1,174 @@
+<?php
+
+/** @noinspection StaticClosureCanBeUsedInspection */
+
+declare(strict_types=1);
+
+use App\Events\PlannedTransactionCategoryUpdated;
+use App\Events\TransactionCategoryUpdated;
+use App\Models\Account;
+use App\Models\Category;
+use App\Models\PlannedTransaction;
+use App\Models\Transaction;
+use App\Models\User;
+use Illuminate\Support\Facades\Event;
+
+test('changing category on a linked transaction propagates to siblings', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $planned = PlannedTransaction::factory()->for($user)->for($account)->create();
+    $oldCategory = Category::factory()->create();
+    $newCategory = Category::factory()->create();
+
+    $sibling1 = Transaction::factory()->for($user)->for($account)->create([
+        'planned_transaction_id' => $planned->id,
+        'category_id' => $oldCategory->id,
+    ]);
+    $sibling2 = Transaction::factory()->for($user)->for($account)->create([
+        'planned_transaction_id' => $planned->id,
+        'category_id' => $oldCategory->id,
+    ]);
+    $target = Transaction::factory()->for($user)->for($account)->create([
+        'planned_transaction_id' => $planned->id,
+        'category_id' => $oldCategory->id,
+    ]);
+
+    $target->update(['category_id' => $newCategory->id]);
+
+    expect($sibling1->fresh()->category_id)->toBe($newCategory->id)
+        ->and($sibling2->fresh()->category_id)->toBe($newCategory->id);
+});
+
+test('changing category on a linked transaction propagates to parent PlannedTransaction', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $oldCategory = Category::factory()->create();
+    $newCategory = Category::factory()->create();
+    $planned = PlannedTransaction::factory()->for($user)->for($account)->create([
+        'category_id' => $oldCategory->id,
+    ]);
+
+    $transaction = Transaction::factory()->for($user)->for($account)->create([
+        'planned_transaction_id' => $planned->id,
+        'category_id' => $oldCategory->id,
+    ]);
+
+    $transaction->update(['category_id' => $newCategory->id]);
+
+    expect($planned->fresh()->category_id)->toBe($newCategory->id);
+});
+
+test('changing category on a PlannedTransaction propagates to all linked transactions', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $oldCategory = Category::factory()->create();
+    $newCategory = Category::factory()->create();
+    $planned = PlannedTransaction::factory()->for($user)->for($account)->create([
+        'category_id' => $oldCategory->id,
+    ]);
+
+    $transaction1 = Transaction::factory()->for($user)->for($account)->create([
+        'planned_transaction_id' => $planned->id,
+        'category_id' => $oldCategory->id,
+    ]);
+    $transaction2 = Transaction::factory()->for($user)->for($account)->create([
+        'planned_transaction_id' => $planned->id,
+        'category_id' => $oldCategory->id,
+    ]);
+
+    $planned->update(['category_id' => $newCategory->id]);
+
+    expect($transaction1->fresh()->category_id)->toBe($newCategory->id)
+        ->and($transaction2->fresh()->category_id)->toBe($newCategory->id);
+});
+
+test('non-linked transactions do not propagate category changes', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $oldCategory = Category::factory()->create();
+    $newCategory = Category::factory()->create();
+
+    $otherTransaction = Transaction::factory()->for($user)->for($account)->create([
+        'category_id' => $oldCategory->id,
+    ]);
+
+    $standalone = Transaction::factory()->for($user)->for($account)->create([
+        'category_id' => $oldCategory->id,
+    ]);
+
+    $standalone->update(['category_id' => $newCategory->id]);
+
+    expect($standalone->fresh()->category_id)->toBe($newCategory->id)
+        ->and($otherTransaction->fresh()->category_id)->toBe($oldCategory->id);
+});
+
+test('no infinite loops when propagation updates happen', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $oldCategory = Category::factory()->create();
+    $newCategory = Category::factory()->create();
+    $planned = PlannedTransaction::factory()->for($user)->for($account)->create([
+        'category_id' => $oldCategory->id,
+    ]);
+
+    Transaction::factory()->for($user)->for($account)->count(3)->create([
+        'planned_transaction_id' => $planned->id,
+        'category_id' => $oldCategory->id,
+    ]);
+
+    $eventCount = 0;
+    Event::listen(TransactionCategoryUpdated::class, function () use (&$eventCount) {
+        $eventCount++;
+    });
+    Event::listen(PlannedTransactionCategoryUpdated::class, function () use (&$eventCount) {
+        $eventCount++;
+    });
+
+    $planned->update(['category_id' => $newCategory->id]);
+
+    expect($eventCount)->toBe(1);
+});
+
+test('event only fires when category_id actually changed', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $category = Category::factory()->create();
+
+    $transaction = Transaction::factory()->for($user)->for($account)->create([
+        'category_id' => $category->id,
+    ]);
+
+    Event::fake([TransactionCategoryUpdated::class]);
+
+    $transaction->update(['description' => 'updated description']);
+
+    Event::assertNotDispatched(TransactionCategoryUpdated::class);
+});
+
+test('propagation does not affect transactions linked to a different PlannedTransaction', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $oldCategory = Category::factory()->create();
+    $newCategory = Category::factory()->create();
+
+    $planned1 = PlannedTransaction::factory()->for($user)->for($account)->create([
+        'category_id' => $oldCategory->id,
+    ]);
+    $planned2 = PlannedTransaction::factory()->for($user)->for($account)->create([
+        'category_id' => $oldCategory->id,
+    ]);
+
+    $transaction1 = Transaction::factory()->for($user)->for($account)->create([
+        'planned_transaction_id' => $planned1->id,
+        'category_id' => $oldCategory->id,
+    ]);
+    $unrelated = Transaction::factory()->for($user)->for($account)->create([
+        'planned_transaction_id' => $planned2->id,
+        'category_id' => $oldCategory->id,
+    ]);
+
+    $transaction1->update(['category_id' => $newCategory->id]);
+
+    expect($unrelated->fresh()->category_id)->toBe($oldCategory->id)
+        ->and($planned2->fresh()->category_id)->toBe($oldCategory->id);
+});

--- a/tests/Feature/Services/PipelineStages/SetPayCycleStageTest.php
+++ b/tests/Feature/Services/PipelineStages/SetPayCycleStageTest.php
@@ -1,0 +1,504 @@
+<?php
+
+/** @noinspection StaticClosureCanBeUsedInspection */
+
+declare(strict_types=1);
+
+use App\DTOs\PipelineContext;
+use App\Enums\PipelineTrigger;
+use App\Enums\SuggestionType;
+use App\Models\Account;
+use App\Models\AnalysisSuggestion;
+use App\Models\PipelineAuditEntry;
+use App\Models\PipelineRun;
+use App\Models\Transaction;
+use App\Models\User;
+use App\Services\PipelineStages\SetPayCycleStage;
+use App\Services\TransactionAnalysisPipeline;
+use Carbon\CarbonImmutable;
+
+// ──────────────────────────────────────────────
+// Helpers
+// ──────────────────────────────────────────────
+
+function createPrimaryAccountSuggestion(PipelineRun $run, User $user, array $payloadOverrides = []): AnalysisSuggestion
+{
+    return AnalysisSuggestion::factory()
+        ->primaryAccount()
+        ->create([
+            'pipeline_run_id' => $run->id,
+            'user_id' => $user->id,
+            'payload' => array_merge([
+                'account_id' => 1,
+                'account_name' => 'Everyday Account',
+                'income_amount' => 300_000,
+                'income_frequency' => 'monthly',
+                'income_description' => 'SALARY DEPOSIT',
+                'confidence_score' => 0.85,
+                'matched_transaction_ids' => [],
+                'outbound_transfer_count' => 2,
+            ], $payloadOverrides),
+        ]);
+}
+
+function makePayCycleContext(User $user, bool $isFirstSync = true): PipelineContext
+{
+    $pipelineRun = PipelineRun::factory()->for($user)->create([
+        'is_first_sync' => $isFirstSync,
+    ]);
+
+    return new PipelineContext(
+        user: $user,
+        pipelineRun: $pipelineRun,
+        isFirstSync: $isFirstSync,
+    );
+}
+
+function createIncomeTransactionForPayCycle(User $user, Account $account, array $overrides = []): Transaction
+{
+    return Transaction::factory()
+        ->for($user)
+        ->for($account)
+        ->credit()
+        ->fromBasiq()
+        ->create(array_merge([
+            'transfer_pair_id' => null,
+            'merchant_name' => null,
+            'clean_description' => null,
+        ], $overrides));
+}
+
+function createSalaryGroupForPayCycle(
+    User $user,
+    Account $account,
+    string $description,
+    int $amount,
+    int $count,
+    int $intervalDays,
+    ?CarbonImmutable $startDate = null,
+): array {
+    $startDate ??= CarbonImmutable::parse('2025-06-01');
+    $transactions = [];
+
+    for ($i = 0; $i < $count; $i++) {
+        $transactions[] = createIncomeTransactionForPayCycle($user, $account, [
+            'description' => $description,
+            'amount' => $amount,
+            'post_date' => $startDate->addDays($i * $intervalDays),
+        ]);
+    }
+
+    return $transactions;
+}
+
+beforeEach(function () {
+    $this->stage = new SetPayCycleStage;
+    $this->user = User::factory()->create([
+        'pay_amount' => null,
+        'pay_frequency' => null,
+        'next_pay_date' => null,
+    ]);
+    $this->account = Account::factory()->for($this->user)->create();
+});
+
+// ──────────────────────────────────────────────
+// shouldRun Guard
+// ──────────────────────────────────────────────
+
+test('skips when not first sync', function () {
+    $context = makePayCycleContext($this->user, isFirstSync: false);
+
+    expect($this->stage->shouldRun($context))->toBeFalse();
+});
+
+test('skips when pay cycle already configured', function () {
+    $this->user->update([
+        'pay_amount' => 300_000,
+        'pay_frequency' => 'monthly',
+        'next_pay_date' => CarbonImmutable::now()->addDays(7),
+    ]);
+    $this->user->refresh();
+
+    $context = makePayCycleContext($this->user);
+
+    expect($this->stage->shouldRun($context))->toBeFalse();
+});
+
+test('runs when first sync and no pay cycle configured', function () {
+    $context = makePayCycleContext($this->user);
+
+    expect($this->stage->shouldRun($context))->toBeTrue();
+});
+
+// ──────────────────────────────────────────────
+// Contract
+// ──────────────────────────────────────────────
+
+test('key returns expected string', function () {
+    expect($this->stage->key())->toBe('set-pay-cycle');
+});
+
+test('label returns human-readable string', function () {
+    expect($this->stage->label())->toBe('Set Pay Cycle');
+});
+
+// ──────────────────────────────────────────────
+// Next Pay Date Calculation
+// ──────────────────────────────────────────────
+
+test('calculates next pay date for weekly frequency', function () {
+    $mostRecentDate = CarbonImmutable::now()->subDays(3);
+    $transactions = [];
+    for ($i = 0; $i < 4; $i++) {
+        $transactions[] = createIncomeTransactionForPayCycle($this->user, $this->account, [
+            'description' => 'WEEKLY PAY',
+            'amount' => 150_000,
+            'post_date' => $mostRecentDate->subWeeks(3 - $i),
+        ]);
+    }
+    $transactionIds = collect($transactions)->pluck('id')->all();
+
+    $context = makePayCycleContext($this->user);
+    createPrimaryAccountSuggestion($context->pipelineRun, $this->user, [
+        'account_id' => $this->account->id,
+        'income_frequency' => 'weekly',
+        'income_amount' => 150_000,
+        'income_description' => 'WEEKLY PAY',
+        'matched_transaction_ids' => $transactionIds,
+    ]);
+
+    $result = $this->stage->execute($context);
+
+    $suggestion = AnalysisSuggestion::find($result->suggestionIds[0]);
+    $nextPayDate = CarbonImmutable::parse($suggestion->payload['next_pay_date']);
+
+    expect($nextPayDate->greaterThan(CarbonImmutable::today()))->toBeTrue()
+        ->and($nextPayDate->diffInDays($mostRecentDate))->toBeLessThanOrEqual(7);
+});
+
+test('calculates next pay date for fortnightly frequency', function () {
+    $mostRecentDate = CarbonImmutable::now()->subDays(5);
+    $transactions = [];
+    for ($i = 0; $i < 4; $i++) {
+        $transactions[] = createIncomeTransactionForPayCycle($this->user, $this->account, [
+            'description' => 'FORTNIGHTLY PAY',
+            'amount' => 200_000,
+            'post_date' => $mostRecentDate->subWeeks((3 - $i) * 2),
+        ]);
+    }
+    $transactionIds = collect($transactions)->pluck('id')->all();
+
+    $context = makePayCycleContext($this->user);
+    createPrimaryAccountSuggestion($context->pipelineRun, $this->user, [
+        'account_id' => $this->account->id,
+        'income_frequency' => 'fortnightly',
+        'income_amount' => 200_000,
+        'income_description' => 'FORTNIGHTLY PAY',
+        'matched_transaction_ids' => $transactionIds,
+    ]);
+
+    $result = $this->stage->execute($context);
+
+    $suggestion = AnalysisSuggestion::find($result->suggestionIds[0]);
+    $nextPayDate = CarbonImmutable::parse($suggestion->payload['next_pay_date']);
+
+    expect($nextPayDate->greaterThan(CarbonImmutable::today()))->toBeTrue()
+        ->and($nextPayDate->diffInDays($mostRecentDate))->toBeLessThanOrEqual(14);
+});
+
+test('calculates next pay date for monthly frequency', function () {
+    $mostRecentDate = CarbonImmutable::now()->subDays(10);
+    $transactions = [];
+    for ($i = 0; $i < 4; $i++) {
+        $transactions[] = createIncomeTransactionForPayCycle($this->user, $this->account, [
+            'description' => 'SALARY DEPOSIT',
+            'amount' => 300_000,
+            'post_date' => $mostRecentDate->subMonths(3 - $i),
+        ]);
+    }
+    $transactionIds = collect($transactions)->pluck('id')->all();
+
+    $context = makePayCycleContext($this->user);
+    createPrimaryAccountSuggestion($context->pipelineRun, $this->user, [
+        'account_id' => $this->account->id,
+        'income_frequency' => 'monthly',
+        'income_amount' => 300_000,
+        'income_description' => 'SALARY DEPOSIT',
+        'matched_transaction_ids' => $transactionIds,
+    ]);
+
+    $result = $this->stage->execute($context);
+
+    $suggestion = AnalysisSuggestion::find($result->suggestionIds[0]);
+    $nextPayDate = CarbonImmutable::parse($suggestion->payload['next_pay_date']);
+
+    expect($nextPayDate->greaterThan(CarbonImmutable::today()))->toBeTrue();
+});
+
+test('advances next pay date past today when computed date is in the past', function () {
+    $oldDate = CarbonImmutable::now()->subDays(20);
+    $transactions = [];
+    for ($i = 0; $i < 3; $i++) {
+        $transactions[] = createIncomeTransactionForPayCycle($this->user, $this->account, [
+            'description' => 'WEEKLY PAY',
+            'amount' => 150_000,
+            'post_date' => $oldDate->subWeeks(2 - $i),
+        ]);
+    }
+    $transactionIds = collect($transactions)->pluck('id')->all();
+
+    $context = makePayCycleContext($this->user);
+    createPrimaryAccountSuggestion($context->pipelineRun, $this->user, [
+        'account_id' => $this->account->id,
+        'income_frequency' => 'weekly',
+        'income_amount' => 150_000,
+        'income_description' => 'WEEKLY PAY',
+        'matched_transaction_ids' => $transactionIds,
+    ]);
+
+    $result = $this->stage->execute($context);
+
+    $suggestion = AnalysisSuggestion::find($result->suggestionIds[0]);
+    $nextPayDate = CarbonImmutable::parse($suggestion->payload['next_pay_date']);
+
+    expect($nextPayDate->greaterThan(CarbonImmutable::today()))->toBeTrue();
+});
+
+test('advances multiple intervals if needed to reach the future', function () {
+    $veryOldDate = CarbonImmutable::now()->subMonths(3);
+    $transactions = [];
+    for ($i = 0; $i < 3; $i++) {
+        $transactions[] = createIncomeTransactionForPayCycle($this->user, $this->account, [
+            'description' => 'SALARY DEPOSIT',
+            'amount' => 300_000,
+            'post_date' => $veryOldDate->subMonths(2 - $i),
+        ]);
+    }
+    $transactionIds = collect($transactions)->pluck('id')->all();
+
+    $context = makePayCycleContext($this->user);
+    createPrimaryAccountSuggestion($context->pipelineRun, $this->user, [
+        'account_id' => $this->account->id,
+        'income_frequency' => 'monthly',
+        'income_amount' => 300_000,
+        'income_description' => 'SALARY DEPOSIT',
+        'matched_transaction_ids' => $transactionIds,
+    ]);
+
+    $result = $this->stage->execute($context);
+
+    $suggestion = AnalysisSuggestion::find($result->suggestionIds[0]);
+    $nextPayDate = CarbonImmutable::parse($suggestion->payload['next_pay_date']);
+
+    expect($nextPayDate->greaterThan(CarbonImmutable::today()))->toBeTrue();
+});
+
+// ──────────────────────────────────────────────
+// Stage 1 Dependency
+// ──────────────────────────────────────────────
+
+test('returns empty result when no primary account suggestion exists for this run', function () {
+    $context = makePayCycleContext($this->user);
+
+    $result = $this->stage->execute($context);
+
+    expect($result)
+        ->success->toBeTrue()
+        ->suggestionIds->toBeEmpty();
+});
+
+test('creates audit entry when no primary account suggestion found', function () {
+    $context = makePayCycleContext($this->user);
+
+    $this->stage->execute($context);
+
+    $audit = PipelineAuditEntry::where('pipeline_run_id', $context->pipelineRun->id)
+        ->where('stage', 'set-pay-cycle')
+        ->first();
+
+    expect($audit)
+        ->action->toBe('no_primary_account_suggestion');
+});
+
+test('returns empty result with audit entry when matched transactions no longer exist', function () {
+    $context = makePayCycleContext($this->user);
+    createPrimaryAccountSuggestion($context->pipelineRun, $this->user, [
+        'account_id' => $this->account->id,
+        'matched_transaction_ids' => [99999, 99998],
+    ]);
+
+    $result = $this->stage->execute($context);
+
+    expect($result)
+        ->success->toBeTrue()
+        ->suggestionIds->toBeEmpty();
+
+    $audit = PipelineAuditEntry::where('pipeline_run_id', $context->pipelineRun->id)
+        ->where('stage', 'set-pay-cycle')
+        ->where('action', 'no_matched_transactions_found')
+        ->first();
+
+    expect($audit)->not->toBeNull()
+        ->and($audit->metadata['expected_ids'])->toBe([99999, 99998]);
+});
+
+// ──────────────────────────────────────────────
+// Payload
+// ──────────────────────────────────────────────
+
+test('payload contains all required fields with correct types', function () {
+    $transactions = [];
+    for ($i = 0; $i < 3; $i++) {
+        $transactions[] = createIncomeTransactionForPayCycle($this->user, $this->account, [
+            'description' => 'SALARY DEPOSIT',
+            'amount' => 300_000,
+            'post_date' => CarbonImmutable::now()->subMonths(3 - $i),
+        ]);
+    }
+    $transactionIds = collect($transactions)->pluck('id')->all();
+
+    $context = makePayCycleContext($this->user);
+    createPrimaryAccountSuggestion($context->pipelineRun, $this->user, [
+        'account_id' => $this->account->id,
+        'income_frequency' => 'monthly',
+        'income_amount' => 300_000,
+        'income_description' => 'SALARY DEPOSIT',
+        'matched_transaction_ids' => $transactionIds,
+    ]);
+
+    $result = $this->stage->execute($context);
+
+    $suggestion = AnalysisSuggestion::find($result->suggestionIds[0]);
+    $payload = $suggestion->payload;
+
+    expect($payload)
+        ->toHaveKeys([
+            'pay_amount',
+            'pay_frequency',
+            'next_pay_date',
+            'source_account_id',
+            'source_description',
+            'detected_dates',
+        ])
+        ->and($payload['pay_amount'])->toBeInt()
+        ->and($payload['pay_frequency'])->toBeString()
+        ->and($payload['next_pay_date'])->toBeString()
+        ->and($payload['source_account_id'])->toBeInt()
+        ->and($payload['source_description'])->toBeString()
+        ->and($payload['detected_dates'])->toBeArray();
+});
+
+test('detected dates are sorted chronologically', function () {
+    $baseDate = CarbonImmutable::now()->subMonths(3);
+    $transactions = [];
+    for ($i = 0; $i < 4; $i++) {
+        $transactions[] = createIncomeTransactionForPayCycle($this->user, $this->account, [
+            'description' => 'SALARY DEPOSIT',
+            'amount' => 300_000,
+            'post_date' => $baseDate->addMonths($i),
+        ]);
+    }
+    $transactionIds = collect($transactions)->pluck('id')->all();
+
+    $context = makePayCycleContext($this->user);
+    createPrimaryAccountSuggestion($context->pipelineRun, $this->user, [
+        'account_id' => $this->account->id,
+        'income_frequency' => 'monthly',
+        'income_amount' => 300_000,
+        'income_description' => 'SALARY DEPOSIT',
+        'matched_transaction_ids' => $transactionIds,
+    ]);
+
+    $result = $this->stage->execute($context);
+
+    $suggestion = AnalysisSuggestion::find($result->suggestionIds[0]);
+    $detectedDates = $suggestion->payload['detected_dates'];
+
+    $sorted = $detectedDates;
+    sort($sorted);
+
+    expect($detectedDates)->toBe($sorted)
+        ->and($detectedDates)->toHaveCount(4);
+});
+
+test('pay frequency maps correctly from Stage 1 string to PayFrequency enum value', function () {
+    $frequencies = ['weekly', 'fortnightly', 'monthly'];
+
+    foreach ($frequencies as $frequency) {
+        $transactions = [];
+        for ($i = 0; $i < 3; $i++) {
+            $transactions[] = createIncomeTransactionForPayCycle($this->user, $this->account, [
+                'description' => 'PAY '.$frequency,
+                'amount' => 200_000,
+                'post_date' => CarbonImmutable::now()->subDays(($i + 1) * 7),
+            ]);
+        }
+        $transactionIds = collect($transactions)->pluck('id')->all();
+
+        $context = makePayCycleContext($this->user);
+        createPrimaryAccountSuggestion($context->pipelineRun, $this->user, [
+            'account_id' => $this->account->id,
+            'income_frequency' => $frequency,
+            'income_amount' => 200_000,
+            'income_description' => 'PAY '.$frequency,
+            'matched_transaction_ids' => $transactionIds,
+        ]);
+
+        $result = $this->stage->execute($context);
+
+        $suggestion = AnalysisSuggestion::find($result->suggestionIds[0]);
+        expect($suggestion->payload['pay_frequency'])->toBe($frequency);
+    }
+});
+
+// ──────────────────────────────────────────────
+// Integration
+// ──────────────────────────────────────────────
+
+test('stage registered in pipeline and produces PayCycle suggestion on first sync', function () {
+    createSalaryGroupForPayCycle($this->user, $this->account, 'SALARY DEPOSIT', 300_000, 4, 30);
+
+    $pipeline = app(TransactionAnalysisPipeline::class);
+    $run = $pipeline->run($this->user, PipelineTrigger::Sync);
+
+    expect($run->stages_completed)->toContain('identify-primary-account')
+        ->and($run->stages_completed)->toContain('set-pay-cycle');
+
+    $payCycleSuggestion = AnalysisSuggestion::where('pipeline_run_id', $run->id)
+        ->where('type', SuggestionType::PayCycle)
+        ->first();
+
+    expect($payCycleSuggestion)->not->toBeNull()
+        ->and($payCycleSuggestion->payload['pay_amount'])->toBe(300_000)
+        ->and($payCycleSuggestion->payload['pay_frequency'])->toBe('monthly')
+        ->and($payCycleSuggestion->payload['source_account_id'])->toBe($this->account->id);
+
+    $primaryAccountSuggestion = AnalysisSuggestion::where('pipeline_run_id', $run->id)
+        ->where('type', SuggestionType::PrimaryAccount)
+        ->first();
+
+    expect($primaryAccountSuggestion)->not->toBeNull();
+});
+
+test('stage skipped when user already has pay cycle configured', function () {
+    $this->user->update([
+        'pay_amount' => 300_000,
+        'pay_frequency' => 'monthly',
+        'next_pay_date' => CarbonImmutable::now()->addDays(7),
+        'primary_account_id' => $this->account->id,
+    ]);
+    $this->user->refresh();
+
+    createSalaryGroupForPayCycle($this->user, $this->account, 'SALARY DEPOSIT', 300_000, 4, 30);
+
+    $pipeline = app(TransactionAnalysisPipeline::class);
+    $run = $pipeline->run($this->user, PipelineTrigger::Sync);
+
+    expect($run->stages_skipped)->toContain('set-pay-cycle');
+
+    $payCycleSuggestion = AnalysisSuggestion::where('pipeline_run_id', $run->id)
+        ->where('type', SuggestionType::PayCycle)
+        ->first();
+
+    expect($payCycleSuggestion)->toBeNull();
+});


### PR DESCRIPTION
## Summary

### SetPayCycleStage (#165)
- Implements Stage 2 of the Transaction Analysis Pipeline (epic #160)
- `SetPayCycleStage` reads the `PrimaryAccount` suggestion created by Stage 1, extracts income pattern data, and infers the user's pay cycle (amount, frequency, next pay date)
- Creates a `PayCycle` `AnalysisSuggestion` with the calculated data for user review
- Registered in the pipeline between `IdentifyPrimaryAccountStage` and `IdentifyRecurringTransactionsStage`
- Added user_id scope to transaction query and empty collection guard per review feedback

### Category Propagation Events & Listeners (#166)
- Bidirectional category propagation for linked transactions: when a category changes on a transaction with `planned_transaction_id`, siblings and the parent PlannedTransaction update automatically
- When a PlannedTransaction's category changes, all linked transactions update
- Uses query builder `->update()` in listeners (not Eloquent `save()`) to prevent infinite loops
- Laravel 12 auto-discovers listeners via `handle()` type-hints — no manual registration needed

Closes #165
Closes #166

## Test plan

- [x] 18 SetPayCycleStage tests (17 original + 1 empty collection guard)
- [x] 7 CategoryPropagation tests covering sibling propagation, parent propagation, PlannedTransaction propagation, non-linked isolation, loop prevention, change detection, and cross-planned-transaction isolation
- [x] TransactionModal regression: 125/125 passed
- [x] Full CI: 1170 tests passed, PHPStan clean, Pint clean

🤖 Generated with [Claude Code](https://claude.ai/claude-code)