### PR TITLE
feat: dispatch RunTransactionAnalysisJob after SyncTransactionsJob (#168)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,7 @@ yarn-error.log
 /.vscode
 /.zed
 /op.conf
-/context/todo/commit-context.md
 tests/Basiq/http-client.env.json
 **/CLAUDE.md
 !/CLAUDE.md
+/context

--- a/app/Jobs/SyncTransactionsJob.php
+++ b/app/Jobs/SyncTransactionsJob.php
@@ -113,6 +113,8 @@ final class SyncTransactionsJob implements ShouldBeUnique, ShouldQueue
 
         $accountMap = $this->syncAccounts($basiqService);
         $this->syncTransactions($basiqService, $accountMap);
+
+        RunTransactionAnalysisJob::dispatch($this->user);
     }
 
     /**

--- a/tests/Feature/Jobs/SyncTransactionsJobTest.php
+++ b/tests/Feature/Jobs/SyncTransactionsJobTest.php
@@ -11,6 +11,7 @@ use App\DTOs\BasiqAccount;
 use App\DTOs\BasiqJob;
 use App\DTOs\BasiqTransaction;
 use App\Enums\AccountClass;
+use App\Jobs\RunTransactionAnalysisJob;
 use App\Jobs\SyncTransactionsJob;
 use App\Models\Account;
 use App\Models\Transaction;
@@ -654,4 +655,51 @@ test('non-404 RequestException is re-thrown for retry', function () {
 
     $user->refresh();
     expect($user->basiq_user_id)->not->toBeNull();
+});
+
+test('dispatches RunTransactionAnalysisJob after successful sync', function () {
+    Queue::fake([RunTransactionAnalysisJob::class]);
+
+    $user = User::factory()->withBasiq()->create();
+
+    fakeBasiqJobService('success', function (MockInterface $mock) {
+        $mock
+            ->shouldReceive('getAccounts')
+            ->andReturn(new Collection([makeBasiqAccount()]));
+    });
+
+    new SyncTransactionsJob($user, 'job-1')->handle(app(BasiqServiceContract::class));
+
+    Queue::assertPushed(RunTransactionAnalysisJob::class, function ($job) use ($user) {
+        return $job->user->id === $user->id;
+    });
+});
+
+test('does not dispatch RunTransactionAnalysisJob when basiq job is pending', function () {
+    Queue::fake([RunTransactionAnalysisJob::class]);
+
+    $user = User::factory()->withBasiq()->create();
+
+    fakeBasiqJobService('pending');
+
+    $job = new SyncTransactionsJob($user, 'job-1');
+    $job->handle(app(BasiqServiceContract::class));
+
+    Queue::assertNotPushed(RunTransactionAnalysisJob::class);
+});
+
+test('does not dispatch RunTransactionAnalysisJob when basiq job fails', function () {
+    Queue::fake([RunTransactionAnalysisJob::class]);
+
+    Log::shouldReceive('warning')
+        ->once()
+        ->with('Basiq job failed', Mockery::type('array'));
+
+    $user = User::factory()->withBasiq()->create();
+
+    fakeBasiqJobService('failed');
+
+    new SyncTransactionsJob($user, 'job-1')->handle(app(BasiqServiceContract::class));
+
+    Queue::assertNotPushed(RunTransactionAnalysisJob::class);
 });


### PR DESCRIPTION
## Summary

- Dispatches `RunTransactionAnalysisJob` after a successful sync in `SyncTransactionsJob::process()`, wiring the transaction analysis pipeline to run automatically after bank data imports
- Adds 3 tests verifying the dispatch fires on success and is skipped when the Basiq job is pending or failed

Closes #168

## Context

Part of the Transaction Analysis Pipeline epic (#160). The orchestrator (#162), stages (#163–#165), job, models, and UI (#167) are all in place — this PR is the final wiring step that triggers the pipeline after `SyncTransactionsJob` finishes importing transactions.

## Test plan

- [x] `op test.filter SyncTransactionsJobTest` — all 28 tests pass (25 existing + 3 new)
- [x] `op test.filter RunTransactionAnalysisJobTest` — all 5 existing tests pass
- [x] `op ci` — Pint, PHPStan, and full test suite green (1190 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)