### PR TITLE
Fix ApexCharts querySelectorAll TypeError on chart teardown

### DIFF
--- a/resources/views/livewire/spending-by-category.blade.php
+++ b/resources/views/livewire/spending-by-category.blade.php
@@ -24,13 +24,19 @@
                         wire:ignore
                         x-data="{
                         chart: null,
+                        cleanupListener: null,
                         init() {
                             this.chart = new ApexCharts(this.$refs.chart, this.chartOptions(@js($this->categoryData, JSON_THROW_ON_ERROR)));
                             this.chart.render();
 
-                            Livewire.on('chart-updated', (event) => {
+                            this.cleanupListener = Livewire.on('chart-updated', (event) => {
+                                if (!this.$refs.chart) return;
                                 this.chart.updateOptions(this.chartOptions(event.data));
                             });
+                        },
+                        destroy() {
+                            this.cleanupListener?.();
+                            this.chart?.destroy();
                         },
                         chartOptions(data) {
                             return {

--- a/resources/views/livewire/spending-over-time.blade.php
+++ b/resources/views/livewire/spending-over-time.blade.php
@@ -26,15 +26,21 @@
                         chart: null,
                         rawData: @js($this->timeSeriesData, JSON_THROW_ON_ERROR),
                         aggregation: @js($aggregation, JSON_THROW_ON_ERROR),
+                        cleanupListener: null,
                         init() {
                             this.chart = new ApexCharts(this.$refs.chart, this.chartOptions(this.rawData, this.aggregation));
                             this.chart.render();
 
-                            Livewire.on('spending-over-time-updated', (event) => {
+                            this.cleanupListener = Livewire.on('spending-over-time-updated', (event) => {
+                                if (!this.$refs.chart) return;
                                 this.rawData = event.data;
                                 this.aggregation = event.aggregation;
                                 this.chart.updateOptions(this.chartOptions(event.data, event.aggregation));
                             });
+                        },
+                        destroy() {
+                            this.cleanupListener?.();
+                            this.chart?.destroy();
                         },
                         escapeHtml(str) {
                             var div = document.createElement('div');


### PR DESCRIPTION
## Summary

Closes #179

- Fix unhandled `TypeError: Cannot read properties of null (reading 'querySelectorAll')` in ApexCharts chart components
- Add proper Livewire event listener cleanup and Alpine `destroy()` lifecycle hooks to both `spending-over-time` and `spending-by-category` Blade views
- Prevent memory leaks from orphaned event listeners and undestroyed chart instances

## Root Cause

Both chart components register a `Livewire.on()` listener that calls `this.chart.updateOptions()`. When the `@if(empty(...))` conditional removes the chart DOM node (data becomes empty after a period change), the orphaned listener fires and ApexCharts tries to `querySelectorAll` on a null container.

## Changes

For both `spending-over-time.blade.php` and `spending-by-category.blade.php`:

1. **Capture cleanup function** from `Livewire.on()` return value
2. **Guard `$refs.chart`** before calling `updateOptions()`
3. **Add Alpine `destroy()` hook** to unsubscribe listener and destroy chart instance

## Test plan

- [ ] Open dashboard with transaction data, change period selector — chart updates without errors
- [ ] Open dashboard with no transaction data — "No spending data" placeholder renders cleanly
- [ ] Switch periods rapidly — no console errors
- [ ] Navigate away from dashboard and back — no orphaned listeners or memory leaks

🤖 Generated with [Claude Code](https://claude.com/claude-code)