### PR TITLE
fix: [185] sync transactions with source=basiq + dashboard suggestions banner

### DIFF
--- a/app/Jobs/SyncTransactionsJob.php
+++ b/app/Jobs/SyncTransactionsJob.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Jobs;
 
 use App\Contracts\BasiqServiceContract;
+use App\Enums\TransactionSource;
 use App\Models\Account;
 use App\Models\Transaction;
 use App\Models\User;
@@ -190,6 +191,7 @@ final class SyncTransactionsJob implements ShouldBeUnique, ShouldQueue
                     'post_date' => $dto->postDate,
                     'transaction_date' => $dto->transactionDate,
                     'status' => $dto->status ?? 'posted',
+                    'source' => TransactionSource::Basiq,
                     'basiq_account_id' => $dto->account,
                     'merchant_name' => $dto->merchant,
                     'anzsic_code' => $dto->anzsic,

--- a/app/Livewire/AccountOverview.php
+++ b/app/Livewire/AccountOverview.php
@@ -7,6 +7,7 @@ namespace App\Livewire;
 use App\Casts\MoneyCast;
 use App\Enums\AccountClass;
 use App\Models\Account;
+use App\Models\AnalysisSuggestion;
 use Illuminate\View\View;
 use Livewire\Component;
 
@@ -56,6 +57,11 @@ final class AccountOverview extends Component
             ->filter(fn ($a) => in_array($a->type, [AccountClass::CreditCard, AccountClass::Loan], true))
             ->count();
 
+        $pendingSuggestionCount = AnalysisSuggestion::query()
+            ->where('user_id', $user->id)
+            ->pending()
+            ->count();
+
         return view('livewire.account-overview', [
             'accounts' => $accounts,
             'totalOwed' => $totalOwed,
@@ -66,6 +72,7 @@ final class AccountOverview extends Component
             'debtAccountCount' => $debtAccountCount,
             'hasPayCycle' => $user->hasPayCycleConfigured(),
             'lastSynced' => $lastSynced,
+            'pendingSuggestionCount' => $pendingSuggestionCount,
             'formatMoney' => MoneyCast::format(...),
         ]);
     }

--- a/database/migrations/2026_04_14_133735_fix_basiq_transaction_source.php
+++ b/database/migrations/2026_04_14_133735_fix_basiq_transaction_source.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        DB::table('transactions')
+            ->whereNotNull('basiq_id')
+            ->where('source', 'manual')
+            ->update(['source' => 'basiq']);
+    }
+
+    public function down(): void
+    {
+        // No-op: cannot reliably distinguish original manual rows from fixed ones.
+    }
+};

--- a/resources/views/livewire/account-overview.blade.php
+++ b/resources/views/livewire/account-overview.blade.php
@@ -1,5 +1,22 @@
 @php use App\Enums\AccountClass; @endphp
 <div class="space-y-6">
+    @if($pendingSuggestionCount > 0)
+        <flux:card class="flex items-center justify-between gap-4">
+            <div class="flex items-center gap-3">
+                <div class="rounded-lg bg-amber-500/10 p-2 dark:bg-amber-400/10">
+                    <flux:icon.sparkles class="size-5 text-amber-500 dark:text-amber-400"/>
+                </div>
+                <div>
+                    <flux:heading size="sm">
+                        {{ $pendingSuggestionCount }} {{ Str::plural('suggestion', $pendingSuggestionCount) }} ready to review
+                    </flux:heading>
+                    <flux:text size="sm">We've analysed your transactions and have recommendations waiting.</flux:text>
+                </div>
+            </div>
+            <flux:button variant="primary" size="sm" href="{{ route('connect-bank') }}">Review</flux:button>
+        </flux:card>
+    @endif
+
     @if($accounts->isEmpty())
         <div class="rounded-xl border border-neutral-200 p-8 text-center dark:border-neutral-700">
             <flux:icon.building-library class="mx-auto size-12 text-zinc-400"/>
@@ -40,6 +57,13 @@
                 </div>
                 <div class="mt-3">
                     @if($hasPayCycle && $buffer !== null)
+                        @php
+                            $bufferTextClass = match(true) {
+                                $buffer > 0 => 'text-green-600 dark:text-green-500',
+                                $buffer < 0 => 'text-red-600 dark:text-red-500',
+                                default => 'text-zinc-500 dark:text-zinc-400',
+                            };
+                        @endphp
                         <div class="flex items-center gap-1.5">
                             @if($buffer > 0)
                                 <flux:icon.arrow-trending-up class="size-4 text-green-600 dark:text-green-500"/>
@@ -48,7 +72,7 @@
                             @else
                                 <flux:icon.minus class="size-4 text-zinc-500 dark:text-zinc-400"/>
                             @endif
-                            <p class="text-sm font-semibold tabular-nums {{ $buffer > 0 ? 'text-green-600 dark:text-green-500' : ($buffer < 0 ? 'text-red-600 dark:text-red-500' : 'text-zinc-500 dark:text-zinc-400') }}">
+                            <p class="text-sm font-semibold tabular-nums {{ $bufferTextClass }}">
                                 @if($buffer > 0)
                                     +{{ $formatMoney($buffer) }} above what you need
                                 @elseif($buffer < 0)

--- a/tests/Feature/Jobs/SyncTransactionsJobTest.php
+++ b/tests/Feature/Jobs/SyncTransactionsJobTest.php
@@ -11,6 +11,7 @@ use App\DTOs\BasiqAccount;
 use App\DTOs\BasiqJob;
 use App\DTOs\BasiqTransaction;
 use App\Enums\AccountClass;
+use App\Enums\TransactionSource;
 use App\Jobs\RunTransactionAnalysisJob;
 use App\Jobs\SyncTransactionsJob;
 use App\Models\Account;
@@ -243,6 +244,7 @@ test('successful job syncs transactions with correct field mapping', function ()
         ->post_date->format('Y-m-d')->toBe('2026-03-10')
         ->transaction_date->format('Y-m-d')->toBe('2026-03-09')
         ->status->value->toBe('posted')
+        ->source->toBe(TransactionSource::Basiq)
         ->basiq_account_id->toBe('basiq-acc-1')
         ->merchant_name->toBe('Woolworths')
         ->anzsic_code->toBe('4111')
@@ -574,6 +576,7 @@ test('end-to-end sync through real BasiqService with Http::fake', function () {
         ->direction->value->toBe('debit')
         ->description->toBe('WOOLWORTHS 1234')
         ->post_date->format('Y-m-d')->toBe('2026-03-10')
+        ->source->toBe(TransactionSource::Basiq)
         ->merchant_name->toBe('Woolworths')
         ->anzsic_code->toBe('4111');
 
@@ -581,7 +584,8 @@ test('end-to-end sync through real BasiqService with Http::fake', function () {
     expect($txn2)
         ->amount->toBe(15000)
         ->direction->value->toBe('credit')
-        ->description->toBe('SALARY DEPOSIT');
+        ->description->toBe('SALARY DEPOSIT')
+        ->source->toBe(TransactionSource::Basiq);
 
     $user->refresh();
     expect($user->last_synced_at)->not->toBeNull()

--- a/tests/Feature/Livewire/AccountOverviewTest.php
+++ b/tests/Feature/Livewire/AccountOverviewTest.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 use App\Casts\MoneyCast;
 use App\Livewire\AccountOverview;
 use App\Models\Account;
+use App\Models\AnalysisSuggestion;
 use App\Models\Transaction;
 use App\Models\User;
 use Livewire\Livewire;
@@ -291,6 +292,61 @@ test('uses three-column grid on medium screens', function () {
     Livewire::actingAs($user)
         ->test(AccountOverview::class)
         ->assertSeeHtml('md:grid-cols-3');
+});
+
+test('shows pending suggestions banner with count when suggestions exist', function () {
+    $user = User::factory()->create();
+    Account::factory()->for($user)->create();
+    AnalysisSuggestion::factory()->for($user)->count(3)->create();
+
+    Livewire::actingAs($user)
+        ->test(AccountOverview::class)
+        ->assertSee('3 suggestions ready to review')
+        ->assertSeeHtml('href="'.route('connect-bank').'"');
+});
+
+test('pending suggestions banner uses singular label for one suggestion', function () {
+    $user = User::factory()->create();
+    Account::factory()->for($user)->create();
+    AnalysisSuggestion::factory()->for($user)->create();
+
+    Livewire::actingAs($user)
+        ->test(AccountOverview::class)
+        ->assertSee('1 suggestion ready to review');
+});
+
+test('pending suggestions banner is hidden when there are none', function () {
+    $user = User::factory()->create();
+    Account::factory()->for($user)->create();
+
+    Livewire::actingAs($user)
+        ->test(AccountOverview::class)
+        ->assertDontSee('ready to review');
+});
+
+test('pending suggestions banner ignores resolved suggestions', function () {
+    $user = User::factory()->create();
+    Account::factory()->for($user)->create();
+    AnalysisSuggestion::factory()->for($user)->accepted()->create();
+    AnalysisSuggestion::factory()->for($user)->rejected()->create();
+    AnalysisSuggestion::factory()->for($user)->superseded()->create();
+
+    Livewire::actingAs($user)
+        ->test(AccountOverview::class)
+        ->assertDontSee('ready to review');
+});
+
+test('pending suggestions banner only counts current user suggestions', function () {
+    $user = User::factory()->create();
+    $otherUser = User::factory()->create();
+    Account::factory()->for($user)->create();
+    AnalysisSuggestion::factory()->for($user)->create();
+    AnalysisSuggestion::factory()->for($otherUser)->count(5)->create();
+
+    Livewire::actingAs($user)
+        ->test(AccountOverview::class)
+        ->assertSee('1 suggestion ready to review')
+        ->assertDontSee('6 suggestions');
 });
 
 test('hidden group accounts are excluded from totals', function () {


### PR DESCRIPTION
## Summary

Closes #185.

The Transaction Analysis Pipeline (epic #160) was running and completing successfully, but every run produced **zero** suggestions because `SyncTransactionsJob::syncTransactions()` never set the `source` field on imported transactions. The DB default `'manual'` therefore applied to all 3,984 Basiq-imported rows, and both `IdentifyPrimaryAccountStage` and `IdentifyRecurringTransactionsStage` filter on `source = TransactionSource::Basiq` — so their queries always returned empty result sets.

### Changes

- **Root-cause fix** (`app/Jobs/SyncTransactionsJob.php`): set `'source' => TransactionSource::Basiq` in the `Transaction::updateOrCreate()` attributes.
- **Back-fill migration** (`2026_04_14_133735_fix_basiq_transaction_source.php`): idempotent update of any row with `basiq_id IS NOT NULL AND source = 'manual'` → `source = 'basiq'`. Pattern mirrors the original `add_source_and_transfer_columns_to_transactions_table` back-fill.
- **Dashboard suggestion indicator** (`app/Livewire/AccountOverview.php` + view): users had no signal that suggestions existed — added a `<flux:card>` banner above the account cards with a "Review" button linking to `/connect-bank` when pending suggestions exist.
- **Test coverage**:
  - `tests/Feature/Jobs/SyncTransactionsJobTest.php` — assert `source = TransactionSource::Basiq` on synced transactions (field-mapping + end-to-end).
  - `tests/Feature/Livewire/AccountOverviewTest.php` — 5 new tests (count, singular label, hidden when none, ignores resolved, scoped to current user).
- **Code-quality refactor**: replaced a nested ternary in the buffer-colour class on `account-overview.blade.php:68` with a `match(true)` expression assigned to `$bufferTextClass`.

### Verification

- `op test.filter SyncTransactionsJob` → 33 passed (100 assertions)
- `op test.filter AccountOverview` → 36 passed (56 assertions)
- `op test.filter IdentifyPrimaryAccountStage` → 23 passed
- `op test.filter IdentifyRecurringTransactionsStage` → 33 passed
- `op test.filter SetPayCycleStage` → 18 passed
- `op test.filter RunTransactionAnalysisJob` → 8 passed
- `op ci` → **1,285 passed, 0 failed**, Pint clean, PHPStan 0 errors
- DB after migration: `basiq_rows = 3984`, `manual_with_basiq_id = 0`

## Test plan

- [ ] Run `op ci` on a fresh checkout
- [ ] Verify migration runs cleanly: `op migrate`
- [ ] In dev, dispatch `RunTransactionAnalysisJob` for an affected user and confirm `analysis_suggestions` populates
- [ ] Visit `/dashboard` as that user — confirm the new "N suggestions ready to review" banner renders with a working "Review" button
- [ ] Visit `/connect-bank` — confirm primary-account, pay-cycle, and recurring-transaction suggestion cards render
- [ ] Confirm the banner disappears after all suggestions are resolved