### PR TITLE
feat: [160]-Basiq pipeline recovery and observability improvements

### DIFF
--- a/app/Actions/Basiq/CreateOrReuseRefreshLog.php
+++ b/app/Actions/Basiq/CreateOrReuseRefreshLog.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Basiq;
+
+use App\Enums\RefreshStatus;
+use App\Enums\RefreshTrigger;
+use App\Jobs\SyncTransactionsJob;
+use App\Models\BasiqRefreshLog;
+use App\Models\User;
+
+final class CreateOrReuseRefreshLog
+{
+    public function __invoke(User $user, RefreshTrigger $trigger, ?string $jobId = null): BasiqRefreshLog
+    {
+        $existing = BasiqRefreshLog::query()
+            ->where('user_id', $user->id)
+            ->where('status', RefreshStatus::Pending)
+            ->where('created_at', '>', now()->subSeconds(SyncTransactionsJob::UNIQUE_FOR))
+            ->latest()
+            ->first();
+
+        return $existing ?? BasiqRefreshLog::create([
+            'user_id' => $user->id,
+            'trigger' => $trigger,
+            'status' => RefreshStatus::Pending,
+            'job_ids' => $jobId !== null ? [$jobId] : [],
+        ]);
+    }
+}

--- a/app/DTOs/BasiqJob.php
+++ b/app/DTOs/BasiqJob.php
@@ -20,6 +20,19 @@ final class BasiqJob extends Dto
         $this->status = self::resolveStatus($steps);
     }
 
+    /** @return list<array{title: string, error_type: ?string, error_url: ?string}> */
+    public function failedSteps(): array
+    {
+        return array_values(array_map(
+            static fn (array $step): array => [
+                'title' => $step['title'],
+                'error_type' => data_get($step, 'result.type'),
+                'error_url' => data_get($step, 'result.url'),
+            ],
+            array_filter($this->steps, static fn (array $step): bool => $step['status'] === 'failed'),
+        ));
+    }
+
     /** @param  array<int, array{title: string, status: string}>  $steps */
     private static function resolveStatus(array $steps): string
     {

--- a/app/Enums/RefreshTrigger.php
+++ b/app/Enums/RefreshTrigger.php
@@ -8,12 +8,14 @@ enum RefreshTrigger: string
 {
     case Manual = 'manual';
     case Scheduled = 'scheduled';
+    case Webhook = 'webhook';
 
     public function label(): string
     {
         return match ($this) {
             self::Manual => 'Manual',
             self::Scheduled => 'Scheduled',
+            self::Webhook => 'Webhook',
         };
     }
 }

--- a/app/Http/Controllers/BasiqCallbackController.php
+++ b/app/Http/Controllers/BasiqCallbackController.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers;
 
+use App\Actions\Basiq\CreateOrReuseRefreshLog;
+use App\Enums\RefreshTrigger;
 use App\Jobs\SyncTransactionsJob;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 
 final class BasiqCallbackController extends Controller
 {
-    public function __invoke(Request $request): RedirectResponse
+    public function __invoke(Request $request, CreateOrReuseRefreshLog $createOrReuseRefreshLog): RedirectResponse
     {
         $sessionState = session()->pull('basiq_consent_state');
 
@@ -28,7 +30,9 @@ final class BasiqCallbackController extends Controller
             return to_route('dashboard')->with('error', 'Bank connection failed. Please try again.');
         }
 
-        SyncTransactionsJob::dispatch($request->user(), $jobId);
+        $log = $createOrReuseRefreshLog($request->user(), RefreshTrigger::Manual, $jobId);
+
+        SyncTransactionsJob::dispatch($request->user(), $jobId, $log);
 
         return to_route('dashboard')->with('success', 'Bank connected successfully. Your transactions are syncing.');
     }

--- a/app/Http/Controllers/BasiqCallbackController.php
+++ b/app/Http/Controllers/BasiqCallbackController.php
@@ -24,7 +24,7 @@ final class BasiqCallbackController extends Controller
 
         $jobId = $request->query('jobId');
 
-        if (! is_string($jobId) || $jobId === '') {
+        if (! is_string($jobId) || in_array(mb_strtolower($jobId), ['', 'null', 'undefined'], true)) {
             return to_route('dashboard')->with('error', 'Bank connection failed. Please try again.');
         }
 

--- a/app/Http/Controllers/BasiqWebhookController.php
+++ b/app/Http/Controllers/BasiqWebhookController.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers;
 
+use App\Actions\Basiq\CreateOrReuseRefreshLog;
+use App\Enums\RefreshTrigger;
 use App\Jobs\SyncTransactionsJob;
 use App\Models\User;
 use Illuminate\Http\Request;
@@ -17,7 +19,7 @@ final class BasiqWebhookController extends Controller
         'transactions.updated',
     ];
 
-    public function __invoke(Request $request): Response
+    public function __invoke(Request $request, CreateOrReuseRefreshLog $createOrReuseRefreshLog): Response
     {
         $eventType = $request->input('eventTypeId');
         $entityUrl = $request->input('links.eventEntity', '');
@@ -44,11 +46,14 @@ final class BasiqWebhookController extends Controller
             return response()->noContent();
         }
 
-        SyncTransactionsJob::dispatch($user);
+        $log = $createOrReuseRefreshLog($user, RefreshTrigger::Webhook);
+
+        SyncTransactionsJob::dispatch($user, null, $log);
 
         Log::info('Basiq webhook dispatched sync', [
             'eventTypeId' => $eventType,
             'userId' => $user->id,
+            'refreshLogId' => $log->id,
         ]);
 
         return response()->noContent();

--- a/app/Jobs/RefreshBasiqConnectionsJob.php
+++ b/app/Jobs/RefreshBasiqConnectionsJob.php
@@ -11,6 +11,8 @@ use App\Models\User;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Http\Client\RequestException;
 use Illuminate\Queue\Middleware\WithoutOverlapping;
 use Illuminate\Support\Facades\Log;
 use Throwable;
@@ -45,7 +47,47 @@ final class RefreshBasiqConnectionsJob implements ShouldBeUnique, ShouldQueue
         ];
     }
 
+    /**
+     * @throws RequestException
+     * @throws ConnectionException
+     */
     public function handle(BasiqServiceContract $basiqService): void
+    {
+        try {
+            $this->process($basiqService);
+        } catch (RequestException $e) {
+            if ($e->response->status() === 404) {
+                Log::error('Basiq user not found (404). Clearing stale basiq_user_id.', [
+                    'userId' => $this->user->id,
+                    'basiqUserId' => $this->user->basiq_user_id,
+                ]);
+
+                $this->user->update(['basiq_user_id' => null]);
+                $this->log->update(['status' => RefreshStatus::Failed]);
+                $this->fail($e);
+
+                return;
+            }
+
+            throw $e;
+        }
+    }
+
+    public function failed(Throwable $exception): void
+    {
+        $this->log->update(['status' => RefreshStatus::Failed]);
+
+        Log::error('RefreshBasiqConnectionsJob failed', [
+            'userId' => $this->user->id,
+            'logId' => $this->log->id,
+            'exception' => $exception,
+        ]);
+    }
+
+    /**
+     * @throws RequestException|ConnectionException
+     */
+    private function process(BasiqServiceContract $basiqService): void
     {
         if ($this->log->job_ids === null) {
             $jobIds = $basiqService->refreshConnections($this->user->basiq_user_id);
@@ -73,17 +115,6 @@ final class RefreshBasiqConnectionsJob implements ShouldBeUnique, ShouldQueue
         $this->log->update([
             'status' => RefreshStatus::Success,
             'accounts_synced' => $this->user->accounts()->count(),
-        ]);
-    }
-
-    public function failed(Throwable $exception): void
-    {
-        $this->log->update(['status' => RefreshStatus::Failed]);
-
-        Log::error('RefreshBasiqConnectionsJob failed', [
-            'userId' => $this->user->id,
-            'logId' => $this->log->id,
-            'exception' => $exception,
         ]);
     }
 }

--- a/app/Jobs/SyncTransactionsJob.php
+++ b/app/Jobs/SyncTransactionsJob.php
@@ -25,13 +25,15 @@ final class SyncTransactionsJob implements ShouldBeUnique, ShouldQueue
 {
     use Queueable;
 
+    public const int UNIQUE_FOR = 300;
+
     public int $tries = 10;
 
     public int $backoff = 5;
 
     public int $timeout = 120;
 
-    public int $uniqueFor = 300;
+    public int $uniqueFor = self::UNIQUE_FOR;
 
     public function __construct(
         public readonly User $user,

--- a/app/Jobs/SyncTransactionsJob.php
+++ b/app/Jobs/SyncTransactionsJob.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace App\Jobs;
 
 use App\Contracts\BasiqServiceContract;
+use App\Enums\RefreshStatus;
 use App\Enums\TransactionSource;
 use App\Models\Account;
+use App\Models\BasiqRefreshLog;
 use App\Models\Transaction;
 use App\Models\User;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
@@ -34,6 +36,7 @@ final class SyncTransactionsJob implements ShouldBeUnique, ShouldQueue
     public function __construct(
         public readonly User $user,
         public readonly ?string $jobId = null,
+        public readonly ?BasiqRefreshLog $log = null,
     ) {}
 
     public function uniqueId(): int
@@ -64,6 +67,7 @@ final class SyncTransactionsJob implements ShouldBeUnique, ShouldQueue
                 ]);
 
                 $this->user->update(['basiq_user_id' => null]);
+                $this->log?->update(['status' => RefreshStatus::Failed]);
                 $this->fail($e);
 
                 return;
@@ -75,6 +79,8 @@ final class SyncTransactionsJob implements ShouldBeUnique, ShouldQueue
 
     public function failed(Throwable $exception): void
     {
+        $this->log?->update(['status' => RefreshStatus::Failed]);
+
         Log::error('SyncTransactionsJob failed', [
             'userId' => $this->user->id,
             'exception' => $exception,
@@ -106,7 +112,15 @@ final class SyncTransactionsJob implements ShouldBeUnique, ShouldQueue
             }
 
             if ($job->status === 'failed') {
-                Log::warning('Basiq job failed', ['jobId' => $this->jobId, 'userId' => $this->user->id]);
+                $failedSteps = $job->failedSteps();
+
+                Log::warning('Basiq job failed', [
+                    'jobId' => $this->jobId,
+                    'userId' => $this->user->id,
+                    'failed_steps' => $failedSteps,
+                ]);
+
+                $this->log?->update(['status' => RefreshStatus::Failed]);
 
                 return;
             }
@@ -114,6 +128,11 @@ final class SyncTransactionsJob implements ShouldBeUnique, ShouldQueue
 
         $accountMap = $this->syncAccounts($basiqService);
         $this->syncTransactions($basiqService, $accountMap);
+
+        $this->log?->update([
+            'status' => RefreshStatus::Success,
+            'accounts_synced' => $accountMap->count(),
+        ]);
 
         RunTransactionAnalysisJob::dispatch($this->user);
     }

--- a/app/Jobs/SyncTransactionsJob.php
+++ b/app/Jobs/SyncTransactionsJob.php
@@ -127,11 +127,12 @@ final class SyncTransactionsJob implements ShouldBeUnique, ShouldQueue
         }
 
         $accountMap = $this->syncAccounts($basiqService);
-        $this->syncTransactions($basiqService, $accountMap);
+        $transactionCounts = $this->syncTransactions($basiqService, $accountMap);
 
         $this->log?->update([
             'status' => RefreshStatus::Success,
             'accounts_synced' => $accountMap->count(),
+            'transactions_synced' => $transactionCounts['created'] + $transactionCounts['updated'],
         ]);
 
         RunTransactionAnalysisJob::dispatch($this->user);
@@ -173,11 +174,12 @@ final class SyncTransactionsJob implements ShouldBeUnique, ShouldQueue
 
     /**
      * @param  Collection<string, int>  $accountMap
+     * @return array{created: int, updated: int}
      *
      * @throws ConnectionException
      * @throws RequestException
      */
-    private function syncTransactions(BasiqServiceContract $basiqService, Collection $accountMap): void
+    private function syncTransactions(BasiqServiceContract $basiqService, Collection $accountMap): array
     {
         $filter = null;
         if ($this->user->last_synced_at) {
@@ -228,5 +230,7 @@ final class SyncTransactionsJob implements ShouldBeUnique, ShouldQueue
             'created' => $created,
             'updated' => $updated,
         ]);
+
+        return ['created' => $created, 'updated' => $updated];
     }
 }

--- a/app/Services/PipelineStages/IdentifyPrimaryAccountStage.php
+++ b/app/Services/PipelineStages/IdentifyPrimaryAccountStage.php
@@ -110,7 +110,7 @@ final readonly class IdentifyPrimaryAccountStage implements PipelineStageContrac
             'payload' => [
                 'account_id' => $bestOverall['account']->id,
                 'account_name' => $bestOverall['account']->name,
-                'income_amount' => $bestOverall['median_amount'],
+                'income_amount' => $bestOverall['latest_amount'],
                 'income_frequency' => $bestOverall['frequency']->value,
                 'income_description' => $bestOverall['description'],
                 'confidence_score' => round($finalConfidence, 4),
@@ -127,7 +127,7 @@ final readonly class IdentifyPrimaryAccountStage implements PipelineStageContrac
     }
 
     /**
-     * @return array{account: Account, confidence: float, median_amount: int, frequency: PayFrequency, description: string, transaction_ids: list<int>}|null
+     * @return array{account: Account, confidence: float, latest_amount: int, frequency: PayFrequency, description: string, transaction_ids: list<int>}|null
      */
     private function analyzeAccount(Account $account, PipelineContext $context): ?array
     {
@@ -170,7 +170,7 @@ final readonly class IdentifyPrimaryAccountStage implements PipelineStageContrac
 
     /**
      * @param  Collection<int, Transaction>  $transactions
-     * @return array{account: Account, confidence: float, median_amount: int, frequency: PayFrequency, description: string, transaction_ids: list<int>}|null
+     * @return array{account: Account, confidence: float, latest_amount: int, frequency: PayFrequency, description: string, transaction_ids: list<int>}|null
      */
     private function analyzeGroup(Account $account, string $description, Collection $transactions): ?array
     {
@@ -195,13 +195,13 @@ final readonly class IdentifyPrimaryAccountStage implements PipelineStageContrac
         }
 
         $amounts = $sorted->pluck('amount')->map(fn ($a) => abs((int) $a))->all();
-        $medianAmount = $this->median($amounts);
+        $latestAmount = abs((int) $sorted->last()->amount);
         $amountCV = $this->coefficientOfVariation($amounts);
 
         $intervalScore = max(0.0, 1.0 - $intervalCV * 3.33);
         $amountScore = max(0.0, 1.0 - $amountCV / 0.10);
         $countScore = min(1.0, log($sorted->count(), 2) / log(8, 2));
-        $salaryScore = $this->salaryScore($medianAmount);
+        $salaryScore = $this->salaryScore($latestAmount);
 
         $confidence = (self::WEIGHT_INTERVAL * $intervalScore)
             + (self::WEIGHT_AMOUNT * $amountScore)
@@ -211,7 +211,7 @@ final readonly class IdentifyPrimaryAccountStage implements PipelineStageContrac
         return [
             'account' => $account,
             'confidence' => round($confidence, 4),
-            'median_amount' => (int) round($medianAmount),
+            'latest_amount' => $latestAmount,
             'frequency' => $frequency,
             'description' => $description,
             'transaction_ids' => $sorted->pluck('id')->all(),

--- a/mago.toml
+++ b/mago.toml
@@ -1,0 +1,47 @@
+# Welcome to Mago!
+# https://mago.carthage.software/guide/configuration
+version = "1.21"
+php-version = "8.4"
+
+[source]
+paths = ["app/", "config/", "routes/", "database/factories/", "database/seeders/", "tests/"]
+includes = ["vendor"]
+excludes = ["bootstrap/cache/**", "storage/**"]
+
+[source.glob]
+literal-separator = true
+
+[formatter]
+preset = "laravel-pint"
+
+[linter]
+integrations = ["laravel", "pest"]
+
+[linter.rules]
+ambiguous-function-call = { enabled = false }
+literal-named-argument = { enabled = false }
+halstead = { effort-threshold = 7000 }
+
+[analyzer]
+find-unused-definitions = true
+find-unused-expressions = true
+find-overly-wide-return-types = true
+analyze-dead-code = true
+memoize-properties = true
+allow-possibly-undefined-array-keys = true
+check-throws = true
+unchecked-exceptions = [
+    "Illuminate\\Validation\\ValidationException",
+    "Illuminate\\Auth\\AuthenticationException",
+    "Illuminate\\Auth\\Access\\AuthorizationException",
+    "Symfony\\Component\\HttpKernel\\Exception\\HttpException",
+]
+check-missing-override = true
+find-unused-parameters = true
+strict-list-index-checks = true
+no-boolean-literal-comparison = true
+check-missing-type-hints = true
+check-closure-missing-type-hints = true
+check-arrow-function-missing-type-hints = true
+check-use-statements = true
+register-super-globals = true

--- a/resources/views/livewire/connect-bank.blade.php
+++ b/resources/views/livewire/connect-bank.blade.php
@@ -1,4 +1,4 @@
-@php use App\Enums\RefreshStatus; @endphp
+@php use App\Enums\RefreshStatus; use Illuminate\Support\Str; @endphp
 <div class="space-y-6">
     @if(! $isConnected)
         <div class="rounded-xl border border-neutral-200 p-8 text-center dark:border-neutral-700">
@@ -73,6 +73,17 @@
                             <div class="flex items-center gap-3">
                                 <flux:text size="sm">{{ $log->created_at->diffForHumans() }}</flux:text>
                                 <flux:text size="sm" class="text-zinc-500">{{ $log->trigger->label() }}</flux:text>
+                                @if($log->status === RefreshStatus::Success && ($log->accounts_synced !== null || $log->transactions_synced !== null))
+                                    <flux:text size="sm" class="text-zinc-500">
+                                        @if($log->accounts_synced !== null)
+                                            {{ $log->accounts_synced }} {{ Str::plural('account', $log->accounts_synced) }}
+                                        @endif
+                                        @if($log->accounts_synced !== null && $log->transactions_synced !== null) · @endif
+                                        @if($log->transactions_synced !== null)
+                                            {{ $log->transactions_synced }} {{ Str::plural('transaction', $log->transactions_synced) }}
+                                        @endif
+                                    </flux:text>
+                                @endif
                             </div>
                             @if($log->status === RefreshStatus::Success)
                                 <flux:badge size="sm" color="green">Success</flux:badge>

--- a/routes/console.php
+++ b/routes/console.php
@@ -2,9 +2,21 @@
 
 declare(strict_types=1);
 
+use App\Enums\RefreshStatus;
+use App\Jobs\SyncTransactionsJob;
+use App\Models\BasiqRefreshLog;
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Schedule;
 
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote');
+
+Schedule::call(static fn () => BasiqRefreshLog::query()
+    ->where('status', RefreshStatus::Pending)
+    ->where('created_at', '<', now()->subSeconds(SyncTransactionsJob::UNIQUE_FOR + 60))
+    ->update(['status' => RefreshStatus::Failed]))
+    ->everyFiveMinutes()
+    ->name('basiq:fail-stuck-refresh-logs')
+    ->withoutOverlapping();

--- a/tests/Feature/Actions/Basiq/CreateOrReuseRefreshLogTest.php
+++ b/tests/Feature/Actions/Basiq/CreateOrReuseRefreshLogTest.php
@@ -1,0 +1,82 @@
+<?php
+
+/** @noinspection StaticClosureCanBeUsedInspection */
+
+declare(strict_types=1);
+
+use App\Actions\Basiq\CreateOrReuseRefreshLog;
+use App\Enums\RefreshStatus;
+use App\Enums\RefreshTrigger;
+use App\Jobs\SyncTransactionsJob;
+use App\Models\BasiqRefreshLog;
+use App\Models\User;
+
+test('creates a new pending log when none exists', function () {
+    $user = User::factory()->create();
+
+    $log = (new CreateOrReuseRefreshLog)($user, RefreshTrigger::Webhook);
+
+    expect($log)
+        ->user_id->toBe($user->id)
+        ->trigger->toBe(RefreshTrigger::Webhook)
+        ->status->toBe(RefreshStatus::Pending)
+        ->job_ids->toBeEmpty();
+
+    expect(BasiqRefreshLog::count())->toBe(1);
+});
+
+test('stores jobId in job_ids when provided', function () {
+    $user = User::factory()->create();
+
+    $log = (new CreateOrReuseRefreshLog)($user, RefreshTrigger::Manual, 'job-abc');
+
+    expect($log->job_ids)->toBe(['job-abc']);
+});
+
+test('reuses an in-flight pending log for the same user', function () {
+    $user = User::factory()->create();
+    $existing = BasiqRefreshLog::factory()->for($user)->create([
+        'trigger' => RefreshTrigger::Manual,
+        'status' => RefreshStatus::Pending,
+    ]);
+
+    $log = (new CreateOrReuseRefreshLog)($user, RefreshTrigger::Webhook);
+
+    expect($log->id)->toBe($existing->id);
+    expect(BasiqRefreshLog::count())->toBe(1);
+});
+
+test('does not reuse a pending log older than the unique window', function () {
+    $user = User::factory()->create();
+    BasiqRefreshLog::factory()->for($user)->create([
+        'trigger' => RefreshTrigger::Manual,
+        'status' => RefreshStatus::Pending,
+        'created_at' => now()->subSeconds(SyncTransactionsJob::UNIQUE_FOR + 10),
+    ]);
+
+    $log = (new CreateOrReuseRefreshLog)($user, RefreshTrigger::Webhook);
+
+    expect(BasiqRefreshLog::count())->toBe(2);
+    expect($log->trigger)->toBe(RefreshTrigger::Webhook);
+});
+
+test('does not reuse a non-pending log', function () {
+    $user = User::factory()->create();
+    BasiqRefreshLog::factory()->for($user)->completed()->create();
+
+    $log = (new CreateOrReuseRefreshLog)($user, RefreshTrigger::Webhook);
+
+    expect(BasiqRefreshLog::count())->toBe(2);
+    expect($log->status)->toBe(RefreshStatus::Pending);
+});
+
+test('does not reuse a pending log belonging to another user', function () {
+    $userA = User::factory()->create();
+    $userB = User::factory()->create();
+    BasiqRefreshLog::factory()->for($userA)->create(['status' => RefreshStatus::Pending]);
+
+    $log = (new CreateOrReuseRefreshLog)($userB, RefreshTrigger::Webhook);
+
+    expect($log->user_id)->toBe($userB->id);
+    expect(BasiqRefreshLog::count())->toBe(2);
+});

--- a/tests/Feature/DTOs/BasiqJobTest.php
+++ b/tests/Feature/DTOs/BasiqJobTest.php
@@ -64,3 +64,40 @@ test('from preserves step result data', function () {
 
     expect($dto->steps)->toBe($steps);
 });
+
+test('failedSteps returns only failed steps with their result info', function () {
+    $dto = BasiqJob::from([
+        'id' => 'job-5',
+        'steps' => [
+            ['title' => 'verify-credentials', 'status' => 'success'],
+            [
+                'title' => 'retrieve-accounts',
+                'status' => 'failed',
+                'result' => ['type' => 'institution-unavailable', 'url' => '/errors/abc'],
+            ],
+            ['title' => 'retrieve-transactions', 'status' => 'failed'],
+        ],
+    ]);
+
+    expect($dto->failedSteps())->toBe([
+        [
+            'title' => 'retrieve-accounts',
+            'error_type' => 'institution-unavailable',
+            'error_url' => '/errors/abc',
+        ],
+        [
+            'title' => 'retrieve-transactions',
+            'error_type' => null,
+            'error_url' => null,
+        ],
+    ]);
+});
+
+test('failedSteps returns empty array when no steps fail', function () {
+    $dto = BasiqJob::from([
+        'id' => 'job-6',
+        'steps' => [['title' => 'verify-credentials', 'status' => 'success']],
+    ]);
+
+    expect($dto->failedSteps())->toBe([]);
+});

--- a/tests/Feature/DTOs/BasiqJobTest.php
+++ b/tests/Feature/DTOs/BasiqJobTest.php
@@ -101,3 +101,20 @@ test('failedSteps returns empty array when no steps fail', function () {
 
     expect($dto->failedSteps())->toBe([]);
 });
+
+test('failedSteps tolerates null result without warnings', function () {
+    $dto = BasiqJob::from([
+        'id' => 'job-7',
+        'steps' => [
+            ['title' => 'retrieve-accounts', 'status' => 'failed', 'result' => null],
+        ],
+    ]);
+
+    expect($dto->failedSteps())->toBe([
+        [
+            'title' => 'retrieve-accounts',
+            'error_type' => null,
+            'error_url' => null,
+        ],
+    ]);
+});

--- a/tests/Feature/Http/Controllers/BasiqCallbackControllerTest.php
+++ b/tests/Feature/Http/Controllers/BasiqCallbackControllerTest.php
@@ -4,11 +4,14 @@
 
 declare(strict_types=1);
 
+use App\Enums\RefreshStatus;
+use App\Enums\RefreshTrigger;
 use App\Jobs\SyncTransactionsJob;
+use App\Models\BasiqRefreshLog;
 use App\Models\User;
 use Illuminate\Support\Facades\Queue;
 
-test('valid state and jobId dispatches sync job and redirects with success', function () {
+test('valid state and jobId dispatches sync job, creates pending log, redirects with success', function () {
     Queue::fake();
 
     $user = User::factory()->withBasiq()->create();
@@ -20,8 +23,17 @@ test('valid state and jobId dispatches sync job and redirects with success', fun
         ->assertRedirect(route('dashboard'))
         ->assertSessionHas('success', 'Bank connected successfully. Your transactions are syncing.');
 
-    Queue::assertPushed(SyncTransactionsJob::class, function (SyncTransactionsJob $job) use ($user) {
-        return $job->jobId === 'job-123' && $job->user->is($user);
+    $log = BasiqRefreshLog::sole();
+    expect($log)
+        ->user_id->toBe($user->id)
+        ->trigger->toBe(RefreshTrigger::Manual)
+        ->status->toBe(RefreshStatus::Pending)
+        ->job_ids->toBe(['job-123']);
+
+    Queue::assertPushed(SyncTransactionsJob::class, function (SyncTransactionsJob $job) use ($user, $log) {
+        return $job->jobId === 'job-123'
+            && $job->user->is($user)
+            && $job->log?->is($log);
     });
 });
 

--- a/tests/Feature/Http/Controllers/BasiqCallbackControllerTest.php
+++ b/tests/Feature/Http/Controllers/BasiqCallbackControllerTest.php
@@ -111,6 +111,21 @@ test('array jobId is treated as invalid and does not dispatch job', function () 
     Queue::assertNothingPushed();
 });
 
+test('literal "null" or "undefined" jobId is rejected and does not dispatch job', function (string $jobId) {
+    Queue::fake();
+
+    $user = User::factory()->withBasiq()->create();
+    $state = 'valid-state-token-1234567890abcdefghij';
+
+    $this->actingAs($user)
+        ->withSession(['basiq_consent_state' => $state])
+        ->get(route('basiq.callback', ['state' => $state, 'jobId' => $jobId]))
+        ->assertRedirect(route('dashboard'))
+        ->assertSessionHas('error', 'Bank connection failed. Please try again.');
+
+    Queue::assertNothingPushed();
+})->with(['null', 'NULL', 'undefined', 'Undefined']);
+
 test('session state is forgotten after validation', function () {
     Queue::fake();
 

--- a/tests/Feature/Http/Controllers/BasiqWebhookControllerTest.php
+++ b/tests/Feature/Http/Controllers/BasiqWebhookControllerTest.php
@@ -69,6 +69,20 @@ test('connection.created webhook dispatches SyncTransactionsJob and creates a We
     });
 });
 
+test('concurrent webhooks reuse the in-flight pending log rather than creating duplicates', function () {
+    Queue::fake();
+
+    $user = User::factory()->withBasiq()->create();
+    $body = webhookPayload('connection.created', $user->basiq_user_id);
+
+    $this->postJson('/webhooks/basiq', json_decode($body, true), signWebhookPayload($body))
+        ->assertNoContent();
+    $this->postJson('/webhooks/basiq', json_decode($body, true), signWebhookPayload($body))
+        ->assertNoContent();
+
+    expect(BasiqRefreshLog::count())->toBe(1);
+});
+
 test('transactions.updated webhook dispatches SyncTransactionsJob', function () {
     Queue::fake();
 

--- a/tests/Feature/Http/Controllers/BasiqWebhookControllerTest.php
+++ b/tests/Feature/Http/Controllers/BasiqWebhookControllerTest.php
@@ -8,7 +8,10 @@
 
 declare(strict_types=1);
 
+use App\Enums\RefreshStatus;
+use App\Enums\RefreshTrigger;
 use App\Jobs\SyncTransactionsJob;
+use App\Models\BasiqRefreshLog;
 use App\Models\User;
 use Illuminate\Support\Facades\Queue;
 
@@ -43,7 +46,7 @@ beforeEach(function () {
     config(['services.basiq.webhook_secret' => 'whsec_'.base64_encode(random_bytes(32))]);
 });
 
-test('connection.created webhook dispatches SyncTransactionsJob', function () {
+test('connection.created webhook dispatches SyncTransactionsJob and creates a Webhook-triggered pending log', function () {
     Queue::fake();
 
     $user = User::factory()->withBasiq()->create();
@@ -53,8 +56,16 @@ test('connection.created webhook dispatches SyncTransactionsJob', function () {
     $this->postJson('/webhooks/basiq', json_decode($body, true), $headers)
         ->assertNoContent();
 
-    Queue::assertPushed(SyncTransactionsJob::class, static function (SyncTransactionsJob $job) use ($user) {
-        return $job->user->id === $user->id && $job->jobId === null;
+    $log = BasiqRefreshLog::sole();
+    expect($log)
+        ->user_id->toBe($user->id)
+        ->trigger->toBe(RefreshTrigger::Webhook)
+        ->status->toBe(RefreshStatus::Pending);
+
+    Queue::assertPushed(SyncTransactionsJob::class, static function (SyncTransactionsJob $job) use ($user, $log) {
+        return $job->user->id === $user->id
+            && $job->jobId === null
+            && $job->log?->is($log);
     });
 });
 

--- a/tests/Feature/Jobs/RefreshBasiqConnectionsJobTest.php
+++ b/tests/Feature/Jobs/RefreshBasiqConnectionsJobTest.php
@@ -13,7 +13,11 @@ use App\Jobs\RefreshBasiqConnectionsJob;
 use App\Jobs\SyncTransactionsJob;
 use App\Models\BasiqRefreshLog;
 use App\Models\User;
+use GuzzleHttp\Psr7\Response as GuzzleResponse;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Http\Client\Response;
 use Illuminate\Queue\Middleware\WithoutOverlapping;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Queue;
 use Mockery\MockInterface;
 
@@ -153,6 +157,57 @@ test('middleware returns WithoutOverlapping keyed on user id', function () {
 
     expect($middleware)->toHaveCount(1)
         ->and($middleware[0])->toBeInstanceOf(WithoutOverlapping::class);
+});
+
+test('404 from refreshConnections clears basiq_user_id and marks log Failed', function () {
+    $user = User::factory()->withBasiq()->create();
+    $originalBasiqUserId = $user->basiq_user_id;
+    $log = BasiqRefreshLog::factory()->for($user)->create([
+        'job_ids' => null,
+        'status' => RefreshStatus::Pending,
+    ]);
+
+    $response = new Response(new GuzzleResponse(404, [], json_encode([
+        'type' => 'list',
+        'data' => [['type' => 'error', 'code' => 'resource-not-found']],
+    ], JSON_THROW_ON_ERROR)));
+
+    fakeRefreshService(function (MockInterface $mock) use ($response) {
+        $mock->shouldReceive('refreshConnections')
+            ->once()
+            ->andThrow(new RequestException($response));
+    });
+
+    Log::shouldReceive('error')
+        ->once()
+        ->with('Basiq user not found (404). Clearing stale basiq_user_id.', Mockery::on(
+            fn ($ctx) => $ctx['basiqUserId'] === $originalBasiqUserId
+        ));
+
+    new RefreshBasiqConnectionsJob($user, $log)->handle(app(BasiqServiceContract::class));
+
+    $user->refresh();
+    expect($user->basiq_user_id)->toBeNull()
+        ->and($log->fresh()->status)->toBe(RefreshStatus::Failed);
+});
+
+test('non-404 RequestException from refreshConnections is re-thrown for retry', function () {
+    $user = User::factory()->withBasiq()->create();
+    $log = BasiqRefreshLog::factory()->for($user)->create(['job_ids' => null]);
+
+    $response = new Response(new GuzzleResponse(500, [], '{"error":"upstream"}'));
+
+    fakeRefreshService(function (MockInterface $mock) use ($response) {
+        $mock->shouldReceive('refreshConnections')
+            ->once()
+            ->andThrow(new RequestException($response));
+    });
+
+    expect(fn () => new RefreshBasiqConnectionsJob($user, $log)->handle(app(BasiqServiceContract::class)))
+        ->toThrow(RequestException::class);
+
+    $user->refresh();
+    expect($user->basiq_user_id)->not->toBeNull();
 });
 
 test('failed method updates log status to Failed', function () {

--- a/tests/Feature/Jobs/SyncTransactionsJobTest.php
+++ b/tests/Feature/Jobs/SyncTransactionsJobTest.php
@@ -11,10 +11,13 @@ use App\DTOs\BasiqAccount;
 use App\DTOs\BasiqJob;
 use App\DTOs\BasiqTransaction;
 use App\Enums\AccountClass;
+use App\Enums\RefreshStatus;
+use App\Enums\RefreshTrigger;
 use App\Enums\TransactionSource;
 use App\Jobs\RunTransactionAnalysisJob;
 use App\Jobs\SyncTransactionsJob;
 use App\Models\Account;
+use App\Models\BasiqRefreshLog;
 use App\Models\Transaction;
 use App\Models\User;
 use Illuminate\Support\Collection;
@@ -116,10 +119,14 @@ test('pending job releases back to queue', function () {
     expect($job->job)->toBeNull();
 });
 
-test('failed job logs warning and stops', function () {
+test('failed job logs warning with failed_steps and stops', function () {
     Log::shouldReceive('warning')
         ->once()
-        ->with('Basiq job failed', Mockery::on(fn ($ctx) => $ctx['jobId'] === 'job-1'));
+        ->with('Basiq job failed', Mockery::on(fn ($ctx) => $ctx['jobId'] === 'job-1'
+            && $ctx['failed_steps'] === [
+                ['title' => 'verify-credentials', 'error_type' => null, 'error_url' => null],
+            ]
+        ));
 
     $user = User::factory()->withBasiq()->create();
 
@@ -130,6 +137,58 @@ test('failed job logs warning and stops', function () {
     expect(Account::count())
         ->toBe(0)
         ->and(Transaction::count())->toBe(0);
+});
+
+test('failed basiq job marks attached refresh log as Failed', function () {
+    Log::shouldReceive('warning')->once();
+
+    $user = User::factory()->withBasiq()->create();
+    $log = BasiqRefreshLog::factory()->for($user)->create([
+        'status' => RefreshStatus::Pending,
+        'trigger' => RefreshTrigger::Manual,
+        'job_ids' => ['job-1'],
+    ]);
+
+    fakeBasiqJobService('failed');
+
+    new SyncTransactionsJob($user, 'job-1', $log)->handle(app(BasiqServiceContract::class));
+
+    expect($log->refresh()->status)->toBe(RefreshStatus::Failed);
+});
+
+test('successful sync marks attached refresh log as Success with accounts_synced', function () {
+    $user = User::factory()->withBasiq()->create();
+    $log = BasiqRefreshLog::factory()->for($user)->create([
+        'status' => RefreshStatus::Pending,
+        'trigger' => RefreshTrigger::Manual,
+        'job_ids' => ['job-1'],
+    ]);
+
+    fakeBasiqJobService('success', function (MockInterface $mock) {
+        $mock
+            ->shouldReceive('getAccounts')
+            ->andReturn(new Collection([
+                makeBasiqAccount('basiq-acc-1'),
+                makeBasiqAccount('basiq-acc-2', ['name' => 'Savings']),
+            ]));
+    });
+
+    new SyncTransactionsJob($user, 'job-1', $log)->handle(app(BasiqServiceContract::class));
+
+    $log->refresh();
+    expect($log->status)->toBe(RefreshStatus::Success)
+        ->and($log->accounts_synced)->toBe(2);
+});
+
+test('failed() lifecycle hook marks attached refresh log as Failed', function () {
+    $user = User::factory()->withBasiq()->create();
+    $log = BasiqRefreshLog::factory()->for($user)->create(['status' => RefreshStatus::Pending]);
+
+    Log::shouldReceive('error')->once();
+
+    new SyncTransactionsJob($user, 'job-1', $log)->failed(new RuntimeException('boom'));
+
+    expect($log->refresh()->status)->toBe(RefreshStatus::Failed);
 });
 
 test('successful job syncs accounts via updateOrCreate', function () {

--- a/tests/Feature/Jobs/SyncTransactionsJobTest.php
+++ b/tests/Feature/Jobs/SyncTransactionsJobTest.php
@@ -156,7 +156,7 @@ test('failed basiq job marks attached refresh log as Failed', function () {
     expect($log->refresh()->status)->toBe(RefreshStatus::Failed);
 });
 
-test('successful sync marks attached refresh log as Success with accounts_synced', function () {
+test('successful sync marks attached refresh log as Success with accounts_synced and transactions_synced', function () {
     $user = User::factory()->withBasiq()->create();
     $log = BasiqRefreshLog::factory()->for($user)->create([
         'status' => RefreshStatus::Pending,
@@ -171,13 +171,22 @@ test('successful sync marks attached refresh log as Success with accounts_synced
                 makeBasiqAccount('basiq-acc-1'),
                 makeBasiqAccount('basiq-acc-2', ['name' => 'Savings']),
             ]));
+
+        $mock
+            ->shouldReceive('paginateTransactions')
+            ->andReturn(LazyCollection::make([
+                makeBasiqTransaction('txn-1', 'basiq-acc-1'),
+                makeBasiqTransaction('txn-2', 'basiq-acc-1', ['amount' => '-10.00']),
+                makeBasiqTransaction('txn-3', 'basiq-acc-2', ['amount' => '100.00', 'direction' => 'credit']),
+            ]));
     });
 
     new SyncTransactionsJob($user, 'job-1', $log)->handle(app(BasiqServiceContract::class));
 
     $log->refresh();
     expect($log->status)->toBe(RefreshStatus::Success)
-        ->and($log->accounts_synced)->toBe(2);
+        ->and($log->accounts_synced)->toBe(2)
+        ->and($log->transactions_synced)->toBe(3);
 });
 
 test('failed() lifecycle hook marks attached refresh log as Failed', function () {

--- a/tests/Feature/Services/PipelineStages/IdentifyPrimaryAccountStageTest.php
+++ b/tests/Feature/Services/PipelineStages/IdentifyPrimaryAccountStageTest.php
@@ -110,6 +110,20 @@ test('picks strongest income source when multiple exist', function () {
         ->and($suggestion->payload['income_amount'])->toBe(300_000);
 });
 
+test('income_amount reflects most recent pay when salary has increased over time', function () {
+    createSalaryGroup($this->user, $this->account, 'SALARY DEPOSIT', 600_000, 6, 30, CarbonImmutable::parse('2025-03-28'));
+    createSalaryGroup($this->user, $this->account, 'SALARY DEPOSIT', 800_000, 4, 30, CarbonImmutable::parse('2025-09-27'));
+    createSalaryGroup($this->user, $this->account, 'SALARY DEPOSIT', 1_100_000, 3, 30, CarbonImmutable::parse('2026-01-27'));
+
+    $context = makeContext($this->user);
+    $result = $this->stage->execute($context);
+
+    $suggestion = AnalysisSuggestion::find($result->suggestionIds[0]);
+    expect($suggestion->payload['income_description'])->toBe('SALARY DEPOSIT')
+        ->and($suggestion->payload['income_amount'])->toBe(1_100_000)
+        ->and($suggestion->payload['income_frequency'])->toBe('monthly');
+});
+
 test('picks strongest across accounts', function () {
     $transactionAccount = $this->account;
     $savingsAccount = Account::factory()->savings()->for($this->user)->create();

--- a/tests/Unit/Enums/RefreshTriggerTest.php
+++ b/tests/Unit/Enums/RefreshTriggerTest.php
@@ -7,20 +7,23 @@ declare(strict_types=1);
 use App\Enums\RefreshTrigger;
 
 test('all refresh trigger cases exist', function () {
-    expect(RefreshTrigger::cases())->toHaveCount(2);
+    expect(RefreshTrigger::cases())->toHaveCount(3);
 });
 
 test('refresh trigger has correct backing values', function () {
     expect(RefreshTrigger::Manual->value)->toBe('manual')
-        ->and(RefreshTrigger::Scheduled->value)->toBe('scheduled');
+        ->and(RefreshTrigger::Scheduled->value)->toBe('scheduled')
+        ->and(RefreshTrigger::Webhook->value)->toBe('webhook');
 });
 
 test('refresh trigger resolves from backing value', function () {
     expect(RefreshTrigger::from('manual'))->toBe(RefreshTrigger::Manual)
-        ->and(RefreshTrigger::from('scheduled'))->toBe(RefreshTrigger::Scheduled);
+        ->and(RefreshTrigger::from('scheduled'))->toBe(RefreshTrigger::Scheduled)
+        ->and(RefreshTrigger::from('webhook'))->toBe(RefreshTrigger::Webhook);
 });
 
 test('refresh trigger has labels', function () {
     expect(RefreshTrigger::Manual->label())->toBe('Manual')
-        ->and(RefreshTrigger::Scheduled->label())->toBe('Scheduled');
+        ->and(RefreshTrigger::Scheduled->label())->toBe('Scheduled')
+        ->and(RefreshTrigger::Webhook->label())->toBe('Webhook');
 });


### PR DESCRIPTION
## Summary

Hardens the Basiq sync pipeline after two live incidents, adds user-facing observability for sync failures, and corrects the primary-account income amount to reflect current (not lifetime-median) salary.

### Data recovery
- New migration re-backfills historical basiq-sourced transactions that were stuck on ``source='manual'`` after the pre-fix sync runs (#185 regression tail).

### Error resilience
- ``BasiqCallbackController`` now rejects literal ``'null'`` / ``'undefined'`` / empty query values (case-insensitive), preventing ``SyncTransactionsJob`` from being queued with a bogus ``jobId`` that caused 10 retries of ``GET /jobs/null`` → 400.
- ``RefreshBasiqConnectionsJob`` now self-heals 404 ``resource-not-found`` responses from Basiq (e.g. sandbox reset / deleted user) by clearing the stale ``basiq_user_id``, marking the refresh log Failed, and failing the job — mirroring the existing pattern in ``SyncTransactionsJob`` and preventing 20 retries of spam in Ray.

### Observability
- ``BasiqCallbackController`` and ``BasiqWebhookController`` now persist a ``BasiqRefreshLog`` (``Pending`` → ``Success``/``Failed``) for every user-initiated connect and webhook-driven sync. Previously only manual ``Refresh Now`` was tracked.
- New ``RefreshTrigger::Webhook`` enum case.
- ``SyncTransactionsJob`` updates the attached ``BasiqRefreshLog`` to ``Success`` with ``accounts_synced`` + ``transactions_synced``, or ``Failed`` on any terminal path (Basiq job failed, 404 stale user, queued-retries-exhausted).
- ``BasiqJob::failedSteps()`` exposes per-step error info; the "Basiq job failed" warning log now carries ``failed_steps`` with each failed step's title and Basiq error type.

### UI
- ``connect-bank.blade.php`` refresh-history rows now show ``N accounts · N transactions`` inline for successful syncs, so users can self-diagnose without needing Ray access.

### Primary-account income fix
- ``IdentifyPrimaryAccountStage`` now reports ``income_amount`` as the **most recent** salary occurrence instead of the median across all history. Users who received raises previously saw their old lifetime-median salary surfaced on onboarding; now they see their current pay.

## Test plan

- [x] ``op lint.dirty`` (Pint clean)
- [x] ``op ci`` — PHPStan 0 errors, 1297 tests / 2977 assertions, all green
- [x] Manual verification:
  - User 9 (Ash) — re-dispatched pipeline after backfill: PrimaryAccount + PayCycle + 10 RecurringTransaction suggestions created correctly
  - User 6 (Jared) — Basiq job failure now surfaces with ``failed_steps`` in Ray and a ``Failed`` row in ``basiq_refresh_logs``
  - User 3 (Whistler) — 404 path cleared stale ``basiq_user_id`` and terminated retries on first attempt
  - User 5 (Gavin) — primary-account suggestion re-ran: now shows \$11,000 (current) instead of \$8,000 (lifetime median). Old row marked ``superseded``.

## Related
Closes the tail of #185 (source backfill), continues Epic #160.