### PR TITLE
feat: [192]-layout shell (sidebar + topbar + mobile tabbar)

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -13,9 +13,11 @@ use App\Services\PipelineStages\IdentifyRecurringTransactionsStage;
 use App\Services\PipelineStages\SetPayCycleStage;
 use App\Services\PipelineStages\UserRulesStage;
 use App\Services\TransactionAnalysisPipeline;
+use App\View\Composers\LayoutShellComposer;
 use Carbon\CarbonImmutable;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\View;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Validation\Rules\Password;
 
@@ -49,6 +51,8 @@ final class AppServiceProvider extends ServiceProvider
                 $this->app->make(UserRulesStage::class),
             ],
         ));
+
+        $this->app->scoped(LayoutShellComposer::class);
     }
 
     /**
@@ -57,6 +61,11 @@ final class AppServiceProvider extends ServiceProvider
     public function boot(): void
     {
         $this->configureDefaults();
+
+        View::composer(
+            ['*app.sidebar', '*app.partials.topbar'],
+            static fn ($view) => app(LayoutShellComposer::class)->compose($view),
+        );
     }
 
     /**

--- a/app/View/Composers/LayoutShellComposer.php
+++ b/app/View/Composers/LayoutShellComposer.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\View\Composers;
+
+use App\Models\BasiqRefreshLog;
+use App\Models\User;
+use Illuminate\View\View;
+
+final class LayoutShellComposer
+{
+    private ?User $user;
+
+    private bool $resolved = false;
+
+    private ?BasiqRefreshLog $latestSync = null;
+
+    private int $accountCount = 0;
+
+    private ?int $daysUntilNextPay = null;
+
+    public function compose(View $view): void
+    {
+        $this->resolveOnce();
+
+        $view->with([
+            'shellUser' => $this->user,
+            'shellAccountCount' => $this->accountCount,
+            'shellLatestSync' => $this->latestSync,
+            'shellSyncedHuman' => $this->latestSync?->created_at->diffForHumans(short: true) ?? '—',
+            'shellDaysUntilNextPay' => $this->daysUntilNextPay,
+        ]);
+    }
+
+    private function resolveOnce(): void
+    {
+        if ($this->resolved) {
+            return;
+        }
+
+        /** @var User|null $user */
+        $user = auth()->user();
+        $this->user = $user;
+
+        if ($user !== null) {
+            $this->accountCount = $user->accounts()->active()->count();
+            $this->daysUntilNextPay = $user->daysUntilNextPay();
+            $this->latestSync = BasiqRefreshLog::query()
+                ->where('user_id', $user->id)
+                ->latest()
+                ->first();
+        }
+
+        $this->resolved = true;
+    }
+}

--- a/resources/views/components/app-logo.blade.php
+++ b/resources/views/components/app-logo.blade.php
@@ -3,15 +3,29 @@
 ])
 
 @if($sidebar)
-    <flux:sidebar.brand name="Can Eye Budget" {{ $attributes }}>
-        <x-slot name="logo" class="flex aspect-square size-8 items-center justify-center rounded-md bg-accent-content text-accent-foreground">
-            <x-app-logo-icon class="size-5 fill-current text-white dark:text-black" />
-        </x-slot>
-    </flux:sidebar.brand>
+    <a
+        href="{{ $attributes->get('href', '/') }}"
+        {{ $attributes->except('href')->class('flex items-center gap-2 px-2 h-14') }}
+        data-flux-sidebar-brand
+    >
+        <img
+            src="{{ asset('images/cib-logo.png') }}"
+            alt="Can I Budget"
+            class="size-10 rounded-lg border-[1.5px] border-cib-black object-cover shrink-0"
+        />
+        <div class="flex flex-col leading-tight truncate in-data-flux-sidebar-collapsed-desktop:hidden">
+            <span class="font-display text-sm font-black text-white">Can I Budget</span>
+            <span class="text-xs text-white/70">AU · Personal</span>
+        </div>
+    </a>
 @else
-    <flux:brand name="Can Eye Budget" {{ $attributes }}>
-        <x-slot name="logo" class="flex aspect-square size-8 items-center justify-center rounded-md bg-accent-content text-accent-foreground">
-            <x-app-logo-icon class="size-5 fill-current text-white dark:text-black" />
+    <flux:brand name="Can I Budget" {{ $attributes }}>
+        <x-slot name="logo">
+            <img
+                src="{{ asset('images/cib-logo.png') }}"
+                alt="Can I Budget"
+                class="size-8 rounded-md border-[1.5px] border-cib-black object-cover"
+            />
         </x-slot>
     </flux:brand>
 @endif

--- a/resources/views/layouts/app/partials/mobile-tabbar.blade.php
+++ b/resources/views/layouts/app/partials/mobile-tabbar.blade.php
@@ -1,0 +1,50 @@
+@php
+    $tabs = [
+        ['label' => 'Home', 'icon' => 'home', 'route' => 'dashboard'],
+        ['label' => 'Calendar', 'icon' => 'calendar-days', 'route' => 'calendar'],
+    ];
+@endphp
+
+<nav
+    data-testid="mobile-tabbar"
+    class="lg:hidden fixed inset-x-4 bottom-4 z-40 flex items-center justify-between rounded-[26px] border-2 border-cib-black bg-cib-black px-2 py-2 shadow-pop"
+>
+    @foreach($tabs as $tab)
+        <a
+            href="{{ route($tab['route']) }}"
+            wire:navigate
+            class="flex flex-col items-center gap-1 rounded-xl px-3 py-2 text-xs font-bold {{ request()->routeIs($tab['route']) ? 'bg-cib-yellow-400 text-cib-black' : 'text-white' }}"
+        >
+            <flux:icon :name="$tab['icon']" class="size-5" />
+            {{ $tab['label'] }}
+        </a>
+    @endforeach
+
+    <button
+        type="button"
+        wire:click="$dispatch('open-transaction-modal', { date: '{{ now()->toDateString() }}' })"
+        data-testid="mobile-tabbar-fab"
+        aria-label="Log a transaction"
+        class="-translate-y-3.5 inline-flex flex-col items-center gap-1 rounded-[20px] border-2 border-cib-black bg-cib-teal-400 px-3 py-2.5 text-white shadow-pop-sm"
+    >
+        <flux:icon name="plus" class="size-5" />
+    </button>
+
+    <a
+        href="{{ route('transactions') }}"
+        wire:navigate
+        class="flex flex-col items-center gap-1 rounded-xl px-3 py-2 text-xs font-bold {{ request()->routeIs('transactions') ? 'bg-cib-yellow-400 text-cib-black' : 'text-white' }}"
+    >
+        <flux:icon name="chart-pie" class="size-5" />
+        Spend
+    </a>
+
+    <a
+        href="{{ route('profile.edit') }}"
+        wire:navigate
+        class="flex flex-col items-center gap-1 rounded-xl px-3 py-2 text-xs font-bold {{ request()->routeIs('profile.*') ? 'bg-cib-yellow-400 text-cib-black' : 'text-white' }}"
+    >
+        <flux:icon name="ellipsis-horizontal" class="size-5" />
+        More
+    </a>
+</nav>

--- a/resources/views/layouts/app/partials/topbar.blade.php
+++ b/resources/views/layouts/app/partials/topbar.blade.php
@@ -1,0 +1,63 @@
+@php
+    $titles = [
+        'dashboard' => ['Dashboard', 'Can I Budget?'],
+        'calendar' => ['Calendar', now()->format('F Y')],
+        'transactions' => ['Transactions', 'All activity'],
+        'accounts' => ['Accounts', 'Connected banks'],
+        'connect-bank' => ['Connect', 'Link a bank'],
+        'rules' => ['Rules', 'Automations'],
+    ];
+
+    [$crumb, $title] = $titles[request()->route()?->getName()] ?? ['Can I Budget', ''];
+@endphp
+
+<header data-flux-header style="grid-area: header" class="sticky top-0 z-30 flex items-center justify-between gap-4 border-b-2 border-cib-black bg-bg-page px-6 py-3">
+    <div>
+        <div class="text-xs font-bold uppercase tracking-wide text-fg-3">{{ $crumb }}</div>
+        <h1 class="font-display text-2xl font-black text-fg-1">{{ $title }}</h1>
+    </div>
+
+    <div class="flex items-center gap-3">
+        @if($shellDaysUntilNextPay !== null)
+            <span
+                    data-testid="topbar-payday-chip"
+                    class="inline-flex items-center gap-2 rounded-pill bg-cib-black py-1 pl-1 pr-3 text-xs font-bold text-white shadow-pop-sm"
+            >
+                <span class="grid size-6.5 place-items-center rounded-full border-[1.5px] border-cib-black bg-cib-yellow-400 font-display text-[11px] font-black text-cib-black">
+                    {{ $shellDaysUntilNextPay }}d
+                </span>
+                {{ $shellDaysUntilNextPay === 0 ? "It's payday" : 'until next payday' }}
+            </span>
+        @endif
+
+        @if($shellLatestSync)
+            <span
+                    data-testid="topbar-sync-chip"
+                    class="hidden items-center gap-2 rounded-pill border border-cib-green-300 bg-money-available-soft px-3 py-1.5 text-xs font-bold text-cib-green-600 sm:inline-flex"
+            >
+                <span class="size-1.75 rounded-full bg-cib-green-500 ring-4 ring-cib-green-500/20"></span>
+                Synced {{ $shellSyncedHuman }} · Basiq
+            </span>
+        @endif
+
+        <a
+                href="{{ route('connect-bank') }}"
+                wire:navigate
+                data-testid="topbar-refresh"
+                aria-label="Refresh Basiq sync"
+                class="hidden size-9 items-center justify-center rounded-md border-2 border-cib-black bg-white shadow-pop-sm hover:bg-cib-cream-50 sm:inline-flex"
+        >
+            <flux:icon name="arrow-path" class="size-4"/>
+        </a>
+
+        <button
+                type="button"
+                wire:click="$dispatch('open-transaction-modal', { date: '{{ now()->toDateString() }}' })"
+                data-testid="topbar-log-spend"
+                class="inline-flex items-center gap-2 rounded-md border-2 border-cib-black bg-cib-yellow-400 px-4 py-2 text-sm font-bold text-cib-black shadow-pop transition-transform hover:-translate-y-px"
+        >
+            <flux:icon name="plus" class="size-4"/>
+            Log spend
+        </button>
+    </div>
+</header>

--- a/resources/views/layouts/app/sidebar.blade.php
+++ b/resources/views/layouts/app/sidebar.blade.php
@@ -1,102 +1,72 @@
 <!DOCTYPE html>
 <html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
-    <head>
-        @include('partials.head')
-    </head>
-    <body class="min-h-screen bg-bg-page text-fg-1">
-        <flux:sidebar sticky collapsible="mobile" class="border-e border-zinc-200 bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-900">
-            <flux:sidebar.header>
-                <x-app-logo :sidebar="true" href="{{ route('dashboard') }}" wire:navigate />
-                <flux:sidebar.collapse class="lg:hidden" />
-            </flux:sidebar.header>
+<head>
+    @include('partials.head')
+</head>
+<body class="min-h-screen bg-bg-page text-fg-1">
+@php
+    $navItem = 'text-white! hover:text-white! hover:bg-white/10! data-current:bg-cib-yellow-400! data-current:text-cib-black! data-current:border-2! data-current:border-cib-black! data-current:shadow-pop-sm!';
+@endphp
 
-            <flux:sidebar.nav>
-                <flux:sidebar.group :heading="__('Platform')" class="grid">
-                    <flux:sidebar.item icon="home" :href="route('dashboard')" :current="request()->routeIs('dashboard')" wire:navigate>
-                        {{ __('Dashboard') }}
-                    </flux:sidebar.item>
-                    <flux:sidebar.item icon="credit-card" :href="route('accounts')" :current="request()->routeIs('accounts')" wire:navigate>
-                        {{ __('Accounts') }}
-                    </flux:sidebar.item>
-                    <flux:sidebar.item icon="arrows-right-left" :href="route('transactions')" :current="request()->routeIs('transactions')" wire:navigate>
-                        {{ __('Transactions') }}
-                    </flux:sidebar.item>
-                    <flux:sidebar.item icon="calendar-days" :href="route('calendar')" :current="request()->routeIs('calendar')" wire:navigate>
-                        {{ __('Calendar') }}
-                    </flux:sidebar.item>
-                    <flux:sidebar.item icon="building-library" :href="route('connect-bank')" :current="request()->routeIs('connect-bank')" wire:navigate>
-                        {{ __('Connect Bank') }}
-                    </flux:sidebar.item>
-                    <flux:sidebar.item icon="funnel" :href="route('rules')" :current="request()->routeIs('rules')" wire:navigate>
-                        {{ __('Rules') }}
-                    </flux:sidebar.item>
-                </flux:sidebar.group>
-            </flux:sidebar.nav>
+<flux:sidebar sticky collapsible="mobile" class="border-e-2! border-cib-black! bg-cib-teal-400! text-white!">
+    <flux:sidebar.header>
+        <x-app-logo :sidebar="true" href="{{ route('dashboard') }}" wire:navigate/>
+        <flux:sidebar.collapse class="lg:hidden"/>
+    </flux:sidebar.header>
 
-            <flux:spacer />
+    <flux:sidebar.nav>
+        <flux:sidebar.group :heading="__('Platform')" class="grid">
+            <flux:sidebar.item icon="home" :href="route('dashboard')" :current="request()->routeIs('dashboard')" wire:navigate :class="$navItem">
+                {{ __('Dashboard') }}
+            </flux:sidebar.item>
+            <flux:sidebar.item icon="credit-card" :href="route('accounts')" :current="request()->routeIs('accounts')" wire:navigate :class="$navItem">
+                {{ __('Accounts') }}
+            </flux:sidebar.item>
+            <flux:sidebar.item icon="arrows-right-left" :href="route('transactions')" :current="request()->routeIs('transactions')" wire:navigate
+                               :class="$navItem">
+                {{ __('Transactions') }}
+            </flux:sidebar.item>
+            <flux:sidebar.item icon="calendar-days" :href="route('calendar')" :current="request()->routeIs('calendar')" wire:navigate :class="$navItem">
+                {{ __('Calendar') }}
+            </flux:sidebar.item>
+            <flux:sidebar.item icon="building-library" :href="route('connect-bank')" :current="request()->routeIs('connect-bank')" wire:navigate
+                               :class="$navItem">
+                {{ __('Connect Bank') }}
+            </flux:sidebar.item>
+            <flux:sidebar.item icon="funnel" :href="route('rules')" :current="request()->routeIs('rules')" wire:navigate :class="$navItem">
+                {{ __('Rules') }}
+            </flux:sidebar.item>
+        </flux:sidebar.group>
+    </flux:sidebar.nav>
 
-            <x-desktop-user-menu class="hidden lg:block" :name="auth()->user()->name" />
-        </flux:sidebar>
+    <flux:spacer/>
 
-        <!-- Mobile User Menu -->
-        <flux:header class="lg:hidden">
-            <flux:sidebar.toggle class="lg:hidden" icon="bars-2" inset="left" />
+    @if($shellUser)
+        <div class="mt-auto flex items-center gap-2 border-t-[1.5px] border-white/18 px-2 pt-3">
+            <flux:avatar
+                    :initials="$shellUser->initials()"
+                    class="size-8 border-[1.5px] border-cib-black bg-cib-yellow-400! text-cib-black!"
+            />
+            <div class="text-sm truncate in-data-flux-sidebar-collapsed-desktop:hidden">
+                <div class="font-bold leading-tight truncate">{{ $shellUser->name }}</div>
+                <div class="text-xs text-white/70 truncate">
+                    {{ $shellAccountCount }} {{ Str::plural('account', $shellAccountCount) }} · synced {{ $shellSyncedHuman }}
+                </div>
+            </div>
+        </div>
+    @endif
+</flux:sidebar>
 
-            <flux:spacer />
+@include('layouts.app.partials.topbar')
 
-            <flux:dropdown position="top" align="end">
-                <flux:profile
-                    :initials="auth()->user()->initials()"
-                    icon-trailing="chevron-down"
-                />
+@include('layouts.app.partials.mobile-tabbar')
 
-                <flux:menu>
-                    <flux:menu.radio.group>
-                        <div class="p-0 text-sm font-normal">
-                            <div class="flex items-center gap-2 px-1 py-1.5 text-start text-sm">
-                                <flux:avatar
-                                    :name="auth()->user()->name"
-                                    :initials="auth()->user()->initials()"
-                                />
+<main data-flux-main style="grid-area: main" class="min-w-0 pb-28 lg:pb-8">
+    {{ $slot }}
+</main>
 
-                                <div class="grid flex-1 text-start text-sm leading-tight">
-                                    <flux:heading class="truncate">{{ auth()->user()->name }}</flux:heading>
-                                    <flux:text class="truncate">{{ auth()->user()->email }}</flux:text>
-                                </div>
-                            </div>
-                        </div>
-                    </flux:menu.radio.group>
+<livewire:feedback-widget/>
 
-                    <flux:menu.separator />
-
-                    <flux:menu.radio.group>
-                        <flux:menu.item :href="route('profile.edit')" icon="cog" wire:navigate>
-                            {{ __('Settings') }}
-                        </flux:menu.item>
-                    </flux:menu.radio.group>
-
-                    <flux:menu.separator />
-
-                    <form method="POST" action="{{ route('logout') }}" class="w-full">
-                        @csrf
-                        <flux:menu.item
-                            as="button"
-                            type="submit"
-                            icon="arrow-right-start-on-rectangle"
-                            class="w-full cursor-pointer"
-                            data-test="logout-button"
-                        >
-                            {{ __('Log out') }}
-                        </flux:menu.item>
-                    </form>
-                </flux:menu>
-            </flux:dropdown>
-        </flux:header>
-
-        {{ $slot }}
-
-        <livewire:feedback-widget />
-
-        @fluxScripts
-    </body>
+@fluxScripts
+</body>
 </html>

--- a/tests/Feature/Layout/LayoutShellTest.php
+++ b/tests/Feature/Layout/LayoutShellTest.php
@@ -1,0 +1,102 @@
+<?php
+
+/** @noinspection PhpUnhandledExceptionInspection */
+
+/** @noinspection StaticClosureCanBeUsedInspection */
+
+declare(strict_types=1);
+
+use App\Models\BasiqRefreshLog;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+
+beforeEach(function () {
+    $this->user = User::factory()->withPayCycle()->create([
+        'next_pay_date' => now()->addDays(5),
+    ]);
+    $this->actingAs($this->user);
+});
+
+it('renders the new teal sidebar with brand block', function () {
+    $response = $this->get(route('dashboard'));
+
+    $response->assertOk();
+    $response->assertSee('Can I Budget', false);
+    $response->assertSee('AU · Personal', false);
+    $response->assertSee('bg-cib-teal-400', false);
+});
+
+it('shows a payday chip with days until next pay', function () {
+    $response = $this->get(route('dashboard'));
+
+    $response->assertOk();
+    $response->assertSee('5d', false);
+    $response->assertSee('until next payday', false);
+});
+
+it('hides the payday chip when pay cycle is not configured', function () {
+    $user = User::factory()->create([
+        'pay_amount' => null,
+        'pay_frequency' => null,
+        'next_pay_date' => null,
+    ]);
+    $this->actingAs($user);
+
+    $response = $this->get(route('dashboard'));
+
+    $response->assertOk();
+    $response->assertDontSee('until next payday', false);
+});
+
+it('shows a sync chip reflecting the latest BasiqRefreshLog', function () {
+    $log = BasiqRefreshLog::factory()
+        ->for($this->user)
+        ->completed()
+        ->create();
+    $log->forceFill(['created_at' => now()->subMinutes(3)])->save();
+
+    $response = $this->get(route('dashboard'));
+
+    $response->assertOk();
+    $response->assertSee('Synced', false);
+    $response->assertSee('Basiq', false);
+});
+
+it('renders the mobile tabbar only below lg', function () {
+    $response = $this->get(route('dashboard'));
+
+    $response->assertOk();
+    $response->assertSee('data-testid="mobile-tabbar"', false);
+    $response->assertSee('lg:hidden', false);
+});
+
+it('wires the FAB to dispatch open-transaction-modal', function () {
+    $response = $this->get(route('dashboard'));
+
+    $response->assertOk();
+    $response->assertSee('open-transaction-modal', false);
+    $response->assertSee('data-testid="mobile-tabbar-fab"', false);
+});
+
+it('exposes the Log spend CTA in the topbar', function () {
+    $response = $this->get(route('dashboard'));
+
+    $response->assertOk();
+    $response->assertSee('Log spend', false);
+    $response->assertSee('data-testid="topbar-log-spend"', false);
+});
+
+it('queries basiq_refresh_logs at most once per request for the layout shell', function () {
+    BasiqRefreshLog::factory()->for($this->user)->completed()->create();
+
+    $queries = 0;
+    DB::listen(function ($query) use (&$queries): void {
+        if (str_contains($query->sql, 'basiq_refresh_logs')) {
+            $queries++;
+        }
+    });
+
+    $this->get(route('dashboard'))->assertOk();
+
+    expect($queries)->toBeLessThanOrEqual(1);
+});


### PR DESCRIPTION
## Summary

- Wires the neo-brutalist teal sidebar, sticky topbar, and mobile tabbar around every authenticated route using the design tokens from #191.
- Topbar surfaces a live payday-ring chip (reads `auth()->user()->daysUntilNextPay()`), a Basiq sync chip (latest `BasiqRefreshLog`), and a yellow-pop **Log spend** CTA that dispatches `open-transaction-modal`.
- Mobile tabbar (`lg:hidden`) floats 5 slots (Home / Calendar / FAB / Spend / More); the FAB dispatches the same `open-transaction-modal` event with today's date.
- Ships 7 new Pest feature tests covering brand block, payday chip visible/hidden, sync chip, tabbar presence, FAB wiring, and Log spend CTA.

Closes #192 — part of Epic #190.

## Implementation notes

- **Flux sidebar active state**: Flux ships `data-current:bg-white ...` inline on `<flux:sidebar.item>`, so the yellow-pop override uses postfix `!` utilities (`data-current:bg-cib-yellow-400!` etc.) to beat Flux's specificity.
- **Brand block**: `<flux:sidebar.brand>` clamps the logo to `h-6 min-w-6` and has no subtitle slot. The sidebar variant of `<x-app-logo>` was rewritten as a plain anchor (preserving `data-flux-sidebar-brand` so Flux's collapse still works) to render the `size-10` logo + "Can I Budget" / "AU · Personal" stack.
- **Refresh button**: No `basiq.refresh.trigger` listener exists yet, so the topbar refresh icon is a `wire:navigate` link to `connect-bank` where the real refresh action lives. Follow-up: wire a dispatchable event or dedicated route.

## Test plan

- [x] `op test.filter LayoutShellTest` — 7/7 pass (21 assertions)
- [x] `op test` — 1312 passed, 4 skipped, 0 failed
- [x] `op lint.dirty` — pass
- [x] `ddev exec npm run build` — clean build with new `cib-teal`, `cib-yellow`, `shadow-pop`, and postfix-`!` utilities compiled
- [ ] Visual verification at desktop (teal sidebar, yellow active state, topbar chips render with pay cycle + seeded `BasiqRefreshLog`)
- [ ] Visual verification at 375×812 (sidebar hidden, floating tabbar visible, FAB opens `TransactionModal`)
- [ ] Click **Log spend** on desktop — confirm `TransactionModal` opens with today's date

## Follow-ups

- Icon polish lives in Ticket 7 (#197).
- Wire a real refresh dispatcher for the topbar refresh icon.
- "Spend" tabbar slot currently points at `transactions`; swap when the spend page ships.