### PR TITLE
feat(#197): ticket 7 — icon mapping

### DIFF
--- a/app/Livewire/CalendarView.php
+++ b/app/Livewire/CalendarView.php
@@ -67,7 +67,7 @@ final class CalendarView extends Component
         unset($this->calendarData, $this->agenda, $this->weekStrip); // @phpstan-ignore property.notFound
     }
 
-    /** @return array{monthLabel: string, weeks: list<list<array{date: int, fullDate: string, isCurrentMonth: bool, isToday: bool, transactions: list<array{id: int|null, category: string, amount: int, direction: string, type: string, source: string, isTransfer: bool, planned_transaction_id: int|null, reconciliation_status: string|null, linked_transaction_id: int|null, occurrence_date: string|null}>}>>, isCurrentMonth: bool} */
+    /** @return array{monthLabel: string, weeks: list<list<array{date: int, fullDate: string, isCurrentMonth: bool, isToday: bool, transactions: list<array{id: int|null, category: string, icon: string|null, amount: int, direction: string, type: string, source: string, isTransfer: bool, planned_transaction_id: int|null, reconciliation_status: string|null, linked_transaction_id: int|null, occurrence_date: string|null}>}>>, isCurrentMonth: bool} */
     #[Computed(persist: true)]
     public function calendarData(): array
     {
@@ -82,7 +82,11 @@ final class CalendarView extends Component
             ->where('user_id', auth()->id())
             ->current()
             ->whereBetween('post_date', [$gridStart, $gridEnd])
-            ->with('category:id,name')
+            ->with([
+                'category:id,name,icon,parent_id',
+                'category.parent:id,icon,parent_id',
+                'category.parent.parent:id,icon,parent_id',
+            ])
             ->orderBy('post_date')
             ->get();
 
@@ -107,7 +111,11 @@ final class CalendarView extends Component
             ->where('is_active', true)
             ->where('start_date', '<=', $gridEnd)
             ->where(fn ($q) => $q->whereNull('until_date')->orWhere('until_date', '>=', $gridStart))
-            ->with('category:id,name')
+            ->with([
+                'category:id,name,icon,parent_id',
+                'category.parent:id,icon,parent_id',
+                'category.parent.parent:id,icon,parent_id',
+            ])
             ->get();
 
         foreach ($plannedTransactions as $planned) {
@@ -125,6 +133,7 @@ final class CalendarView extends Component
                 $existing[] = [
                     'id' => null,
                     'category' => $planned->category?->name ?? $planned->description, // @phpstan-ignore nullsafe.neverNull
+                    'icon' => $planned->category?->resolveIcon(),
                     'amount' => $planned->amount,
                     'direction' => $planned->direction->value,
                     'type' => 'planned',
@@ -151,6 +160,7 @@ final class CalendarView extends Component
                 $actualTxns = $dayTransactions->map(fn (Transaction $t) => [
                     'id' => $t->id,
                     'category' => $t->category?->name ?? $t->description, // @phpstan-ignore nullsafe.neverNull
+                    'icon' => $t->category?->resolveIcon(),
                     'amount' => $t->amount,
                     'direction' => $t->direction->value,
                     'type' => 'actual',

--- a/app/Livewire/Dashboard.php
+++ b/app/Livewire/Dashboard.php
@@ -82,7 +82,7 @@ final class Dashboard extends Component
         return auth()->user()
             ->transactions()
             ->current()
-            ->with(['account', 'category'])
+            ->with(['account', 'category.parent.parent'])
             ->latest('post_date')
             ->limit(5)
             ->get();

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -107,6 +107,11 @@ final class Category extends Model
         return implode(' / ', $segments);
     }
 
+    public function resolveIcon(): ?string
+    {
+        return $this->icon ?? $this->parent?->resolveIcon();
+    }
+
     /** @return HasMany<Budget, $this> */
     public function budgets(): HasMany
     {

--- a/database/seeders/CategorySeeder.php
+++ b/database/seeders/CategorySeeder.php
@@ -11,119 +11,168 @@ final class CategorySeeder extends Seeder
 {
     public function run(): void
     {
-        $categories = [
-            'Office' => [
-                'Online Service' => ['Apple'],
-                'Software',
-                'AI Apps',
-                'Newsletter',
-                'Training' => ['Subscription', 'Course'],
-                'Hardware' => ['Rentals'],
-                'Mobile App',
-                '3D Printing',
-                'Laptop',
-                'Tools',
-                'IoT',
-            ],
-            'Personal' => [
-                'Health',
-                'Subscription',
-                'Finance' => ['Bank Fees'],
-                'Hunter',
-                'Pet',
-                'Kitchen',
-                'Clothes',
-                'Gifts',
-                'Grooming',
-                'Beddings',
-                'Bathroom',
-                'Holiday',
-                'Plants',
-                'Fines',
-                'Charity',
-            ],
-            'Entertainment' => [
-                'Streaming',
-                'Patreon',
-                'Adult',
-                'Twitch',
-                'Gaming',
-                'Apps',
-                'Alcohol',
-                'Event',
-                'VR',
-            ],
-            'Food' => [
-                'Groceries',
-                'Restaurant',
-                'Quick Foods',
-            ],
-            'Bills' => [
-                'Rent',
-                'Cleaning',
-                'Mobile',
-                'Internet',
-                'Electricity',
-                'Hotwater',
-                'Food',
-            ],
-            'Income' => [
-                'Salary',
-                'Client',
-                'Medicare',
-            ],
-            'Transfer' => [
-                'Optimus to Spaceship',
-                'Optimus to CC',
-                'Optimus to uBank',
-                'FairGo Finance',
-                'uBank to uSavings',
-                'Optimus to Latitude',
-                'uBank to Optimus',
-                'Optimus to Cash',
-                'uSavings to uBank',
-            ],
-            'Loan' => [
-                'Motorcycle',
-                'Latitude' => ['Interest', 'Fees'],
-                'Shane',
-            ],
-            'Transport' => [
-                'Motorcycle' => ['Fuel'],
-                'Uber',
-                'Scooter',
-                'Tolls',
-                'Parking',
-                'Translink',
-            ],
-        ];
+        foreach ($this->definitions() as $spec) {
+            $parent = Category::create([
+                'name' => $spec['name'],
+                'icon' => $spec['icon'],
+            ]);
 
-        foreach ($categories as $parentName => $children) {
-            $parent = Category::create(['name' => $parentName]);
-            $this->seedChildren($parent, $children);
+            $this->seedChildren($parent, $spec['children']);
         }
     }
 
-    /** @param array<int|string, string|list<string>> $children */
+    /**
+     * @return list<array{name: string, icon: string, children: list<string|array{name: string, icon?: string, children?: list<string>}>}>
+     */
+    private function definitions(): array
+    {
+        return [
+            [
+                'name' => 'Office',
+                'icon' => 'bolt',
+                'children' => [
+                    ['name' => 'Online Service', 'children' => ['Apple']],
+                    'Software',
+                    'AI Apps',
+                    'Newsletter',
+                    ['name' => 'Training', 'children' => ['Subscription', 'Course']],
+                    ['name' => 'Hardware', 'children' => ['Rentals']],
+                    'Mobile App',
+                    '3D Printing',
+                    'Laptop',
+                    'Tools',
+                    'IoT',
+                ],
+            ],
+            [
+                'name' => 'Personal',
+                'icon' => 'sparkles',
+                'children' => [
+                    'Health',
+                    'Subscription',
+                    ['name' => 'Finance', 'children' => ['Bank Fees']],
+                    'Hunter',
+                    'Pet',
+                    ['name' => 'Kitchen', 'icon' => 'coffee'],
+                    'Clothes',
+                    'Gifts',
+                    'Grooming',
+                    'Beddings',
+                    'Bathroom',
+                    'Holiday',
+                    'Plants',
+                    'Fines',
+                    'Charity',
+                ],
+            ],
+            [
+                'name' => 'Entertainment',
+                'icon' => 'sparkles',
+                'children' => [
+                    'Streaming',
+                    'Patreon',
+                    'Adult',
+                    'Twitch',
+                    'Gaming',
+                    'Apps',
+                    'Alcohol',
+                    'Event',
+                    'VR',
+                ],
+            ],
+            [
+                'name' => 'Food',
+                'icon' => 'shopping-cart',
+                'children' => [
+                    'Groceries',
+                    'Restaurant',
+                    'Quick Foods',
+                ],
+            ],
+            [
+                'name' => 'Bills',
+                'icon' => 'activity',
+                'children' => [
+                    ['name' => 'Rent', 'icon' => 'house-heart'],
+                    'Cleaning',
+                    'Mobile',
+                    'Internet',
+                    'Electricity',
+                    'Hotwater',
+                    'Food',
+                ],
+            ],
+            [
+                'name' => 'Income',
+                'icon' => 'arrow-trending-up',
+                'children' => [
+                    'Salary',
+                    'Client',
+                    'Medicare',
+                ],
+            ],
+            [
+                'name' => 'Transfer',
+                'icon' => 'building-library',
+                'children' => [
+                    'Optimus to Spaceship',
+                    'Optimus to CC',
+                    'Optimus to uBank',
+                    'FairGo Finance',
+                    'uBank to uSavings',
+                    'Optimus to Latitude',
+                    'uBank to Optimus',
+                    'Optimus to Cash',
+                    'uSavings to uBank',
+                ],
+            ],
+            [
+                'name' => 'Loan',
+                'icon' => 'building-library',
+                'children' => [
+                    'Motorcycle',
+                    ['name' => 'Latitude', 'children' => ['Interest', 'Fees']],
+                    'Shane',
+                ],
+            ],
+            [
+                'name' => 'Transport',
+                'icon' => 'home',
+                'children' => [
+                    ['name' => 'Motorcycle', 'children' => ['Fuel']],
+                    'Uber',
+                    'Scooter',
+                    'Tolls',
+                    'Parking',
+                    'Translink',
+                ],
+            ],
+        ];
+    }
+
+    /** @param list<string|array{name: string, icon?: string, children?: list<string>}> $children */
     private function seedChildren(Category $parent, array $children): void
     {
-        foreach ($children as $key => $value) {
-            if (is_string($key)) {
-                $child = Category::create([
-                    'name' => $key,
+        foreach ($children as $child) {
+            if (is_string($child)) {
+                Category::create([
+                    'name' => $child,
                     'parent_id' => $parent->id,
                 ]);
 
-                foreach ($value as $grandchildName) {
-                    Category::create([
-                        'name' => $grandchildName,
-                        'parent_id' => $child->id,
-                    ]);
-                }
-            } else {
+                continue;
+            }
+
+            $node = Category::create([
+                'name' => $child['name'],
+                'parent_id' => $parent->id,
+                'icon' => $child['icon'] ?? null,
+            ]);
+
+            foreach ($child['children'] ?? [] as $grandchildName) {
                 Category::create([
-                    'name' => $value,
-                    'parent_id' => $parent->id,
+                    'name' => $grandchildName,
+                    'parent_id' => $node->id,
                 ]);
             }
         }

--- a/resources/views/components/cib/tx-row.blade.php
+++ b/resources/views/components/cib/tx-row.blade.php
@@ -8,6 +8,7 @@
     'name',
     'amount',
     'tone' => 'out',
+    'icon' => null,
 ])
 
 @php
@@ -22,7 +23,11 @@
             wire:click="$dispatch('edit-transaction', { id: {{ (int) $transactionId }} })"
         @endif
 >
-    <div @class(['tx-ico', $tone])>{{ $icon ?? '' }}</div>
+    <div @class(['tx-ico', $tone])>
+        @if ($icon)
+            <flux:icon :name="$icon" variant="mini"/>
+        @endif
+    </div>
     <div>
         <div class="tx-name">{{ $name }}</div>
         @isset($meta)

--- a/resources/views/flux/icon/activity.blade.php
+++ b/resources/views/flux/icon/activity.blade.php
@@ -1,0 +1,43 @@
+@blaze(fold: true)
+
+{{-- Credit: Lucide (https://lucide.dev) --}}
+
+@props([
+    'variant' => 'outline',
+])
+
+@php
+if ($variant === 'solid') {
+    throw new Exception('The "solid" variant is not supported in Lucide.');
+}
+
+$classes = Flux::classes('shrink-0')
+    ->add(match($variant) {
+        'outline' => '[:where(&)]:size-6',
+        'solid' => '[:where(&)]:size-6',
+        'mini' => '[:where(&)]:size-5',
+        'micro' => '[:where(&)]:size-4',
+    });
+
+$strokeWidth = match ($variant) {
+    'outline' => 2,
+    'mini' => 2.25,
+    'micro' => 2.5,
+};
+@endphp
+
+<svg
+    {{ $attributes->class($classes) }}
+    data-flux-icon
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="{{ $strokeWidth }}"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    aria-hidden="true"
+    data-slot="icon"
+>
+  <path d="M22 12h-2.48a2 2 0 0 0-1.93 1.46l-2.35 8.36a.25.25 0 0 1-.48 0L9.24 2.18a.25.25 0 0 0-.48 0l-2.35 8.36A2 2 0 0 1 4.49 12H2" />
+</svg>

--- a/resources/views/flux/icon/coffee.blade.php
+++ b/resources/views/flux/icon/coffee.blade.php
@@ -1,0 +1,46 @@
+@blaze(fold: true)
+
+{{-- Credit: Lucide (https://lucide.dev) --}}
+
+@props([
+    'variant' => 'outline',
+])
+
+@php
+if ($variant === 'solid') {
+    throw new Exception('The "solid" variant is not supported in Lucide.');
+}
+
+$classes = Flux::classes('shrink-0')
+    ->add(match($variant) {
+        'outline' => '[:where(&)]:size-6',
+        'solid' => '[:where(&)]:size-6',
+        'mini' => '[:where(&)]:size-5',
+        'micro' => '[:where(&)]:size-4',
+    });
+
+$strokeWidth = match ($variant) {
+    'outline' => 2,
+    'mini' => 2.25,
+    'micro' => 2.5,
+};
+@endphp
+
+<svg
+    {{ $attributes->class($classes) }}
+    data-flux-icon
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="{{ $strokeWidth }}"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    aria-hidden="true"
+    data-slot="icon"
+>
+  <path d="M10 2v2" />
+  <path d="M14 2v2" />
+  <path d="M16 8a1 1 0 0 1 1 1v8a4 4 0 0 1-4 4H7a4 4 0 0 1-4-4V9a1 1 0 0 1 1-1h14a4 4 0 1 1 0 8h-1" />
+  <path d="M6 2v2" />
+</svg>

--- a/resources/views/flux/icon/house-heart.blade.php
+++ b/resources/views/flux/icon/house-heart.blade.php
@@ -1,0 +1,44 @@
+@blaze(fold: true)
+
+{{-- Credit: Lucide (https://lucide.dev) --}}
+
+@props([
+    'variant' => 'outline',
+])
+
+@php
+if ($variant === 'solid') {
+    throw new Exception('The "solid" variant is not supported in Lucide.');
+}
+
+$classes = Flux::classes('shrink-0')
+    ->add(match($variant) {
+        'outline' => '[:where(&)]:size-6',
+        'solid' => '[:where(&)]:size-6',
+        'mini' => '[:where(&)]:size-5',
+        'micro' => '[:where(&)]:size-4',
+    });
+
+$strokeWidth = match ($variant) {
+    'outline' => 2,
+    'mini' => 2.25,
+    'micro' => 2.5,
+};
+@endphp
+
+<svg
+    {{ $attributes->class($classes) }}
+    data-flux-icon
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="{{ $strokeWidth }}"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    aria-hidden="true"
+    data-slot="icon"
+>
+  <path d="M8.62 13.8A2.25 2.25 0 1 1 12 10.836a2.25 2.25 0 1 1 3.38 2.966l-2.626 2.856a.998.998 0 0 1-1.507 0z" />
+  <path d="M3 10a2 2 0 0 1 .709-1.528l7-6a2 2 0 0 1 2.582 0l7 6A2 2 0 0 1 21 10v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
+</svg>

--- a/resources/views/livewire/calendar-view.blade.php
+++ b/resources/views/livewire/calendar-view.blade.php
@@ -109,6 +109,7 @@
                                 :name="$txn['category']"
                                 :amount="$txn['amount']"
                                 :tone="$tone"
+                                :icon="$txn['icon'] ?? null"
                             />
                         @endforeach
                     </div>

--- a/resources/views/livewire/dashboard.blade.php
+++ b/resources/views/livewire/dashboard.blade.php
@@ -44,6 +44,7 @@
                             :name="$tx->description ?? '—'"
                             :amount="$tx->amount"
                             :tone="$tx->direction === TransactionDirection::Debit ? 'out' : 'in'"
+                            :icon="$tx->category?->resolveIcon()"
                     />
                 @empty
                     <p class="text-sm text-gray-500">No recent activity.</p>

--- a/tests/Feature/Database/Seeders/CategorySeederIconsTest.php
+++ b/tests/Feature/Database/Seeders/CategorySeederIconsTest.php
@@ -1,0 +1,78 @@
+<?php
+
+/** @noinspection StaticClosureCanBeUsedInspection */
+
+declare(strict_types=1);
+
+use App\Models\Category;
+use Database\Seeders\CategorySeeder;
+
+beforeEach(function () {
+    $this->seed(CategorySeeder::class);
+});
+
+it('assigns a non-null icon to every top-level category', function () {
+    $topLevel = Category::query()->whereNull('parent_id')->get();
+
+    expect($topLevel)->not->toBeEmpty();
+
+    foreach ($topLevel as $category) {
+        expect($category->icon)
+            ->not->toBeNull()
+            ->not->toBeEmpty();
+    }
+});
+
+it('assigns the expected icon to each top-level category', function (string $name, string $icon) {
+    $category = Category::query()->where('name', $name)->whereNull('parent_id')->first();
+
+    expect($category)->not->toBeNull("Seeder missing top-level category '{$name}'")
+        ->and($category->icon)->toBe($icon);
+})->with([
+    ['Office', 'bolt'],
+    ['Personal', 'sparkles'],
+    ['Entertainment', 'sparkles'],
+    ['Food', 'shopping-cart'],
+    ['Bills', 'activity'],
+    ['Income', 'arrow-trending-up'],
+    ['Transfer', 'building-library'],
+    ['Loan', 'building-library'],
+    ['Transport', 'home'],
+]);
+
+it('overrides specific leaf categories with prototype-required icons', function (string $parentName, string $leafName, string $icon) {
+    $leaf = Category::query()
+        ->where('name', $leafName)
+        ->whereHas('parent', fn ($q) => $q->where('name', $parentName))
+        ->first();
+
+    expect($leaf)->not->toBeNull("Leaf '{$parentName} / {$leafName}' not seeded")
+        ->and($leaf->icon)->toBe($icon);
+})->with([
+    ['Bills', 'Rent', 'house-heart'],
+    ['Personal', 'Kitchen', 'coffee'],
+]);
+
+it('only uses icon names that Flux can resolve (Heroicons allow-list or installed Lucide partials)', function () {
+    $heroicons = [
+        'home', 'shopping-cart', 'bolt', 'sparkles', 'calendar',
+        'building-library', 'arrow-trending-up',
+    ];
+
+    $lucide = collect(glob(resource_path('views/flux/icon/*.blade.php')))
+        ->map(fn (string $path): string => basename($path, '.blade.php'))
+        ->all();
+
+    $allowed = array_merge($heroicons, $lucide);
+
+    $usedIcons = Category::query()
+        ->whereNotNull('icon')
+        ->pluck('icon')
+        ->unique()
+        ->values()
+        ->all();
+
+    $unresolvable = array_values(array_diff($usedIcons, $allowed));
+
+    expect($unresolvable)->toBeEmpty();
+});

--- a/tests/Feature/Models/CategoryTest.php
+++ b/tests/Feature/Models/CategoryTest.php
@@ -6,6 +6,7 @@ declare(strict_types=1);
 
 use App\Models\Category;
 use App\Models\Transaction;
+use Illuminate\Support\Facades\DB;
 
 test('factory creates a valid category', function () {
     $category = Category::factory()->create();
@@ -179,8 +180,8 @@ test('visibleSortedByFullPath sorts by full path not leaf name', function () {
     $paths = $result->map(fn (Category $c) => $c->fullPath())->all();
 
     expect($paths)->toContain('Bills / Zebra', 'Entertainment / Alpha')
-        ->and(array_search('Bills / Zebra', $paths))
-        ->toBeLessThan(array_search('Entertainment / Alpha', $paths));
+        ->and(array_search('Bills / Zebra', $paths, true))
+        ->toBeLessThan(array_search('Entertainment / Alpha', $paths, true));
 });
 
 test('visibleSortedByFullPath excludes hidden categories', function () {
@@ -200,4 +201,51 @@ test('visibleSortedByFullPath returns values-reset collection', function () {
     $result = Category::visibleSortedByFullPath();
 
     expect($result->keys()->all())->toBe(range(0, $result->count() - 1));
+});
+
+test('resolveIcon returns own icon when set', function () {
+    $category = Category::factory()->withIcon('shopping-cart')->create();
+
+    expect($category->resolveIcon())->toBe('shopping-cart');
+});
+
+test('resolveIcon falls back to parent icon when own icon is null', function () {
+    $parent = Category::factory()->withIcon('shopping-cart')->create();
+    $child = Category::factory()->withParent($parent)->create();
+
+    expect($child->resolveIcon())->toBe('shopping-cart');
+});
+
+test('resolveIcon walks ancestors until an icon is found', function () {
+    $grandparent = Category::factory()->withIcon('coffee')->create();
+    $parent = Category::factory()->withParent($grandparent)->create();
+    $child = Category::factory()->withParent($parent)->create();
+
+    expect($child->resolveIcon())->toBe('coffee');
+});
+
+test('resolveIcon returns null when neither category nor ancestors set an icon', function () {
+    $parent = Category::factory()->create();
+    $child = Category::factory()->withParent($parent)->create();
+
+    expect($child->resolveIcon())->toBeNull();
+});
+
+test('resolveIcon fires no queries when parent.parent is eager-loaded on a grandchild', function () {
+    $grandparent = Category::factory()->withIcon('bolt')->create();
+    $parent = Category::factory()->withParent($grandparent)->create();
+    Category::factory()->withParent($parent)->create();
+
+    $grandchild = Category::query()
+        ->with('parent.parent')
+        ->where('parent_id', $parent->id)
+        ->firstOrFail();
+
+    DB::enableQueryLog();
+    DB::flushQueryLog();
+
+    $icon = $grandchild->resolveIcon();
+
+    expect($icon)->toBe('bolt')
+        ->and(DB::getQueryLog())->toBeEmpty();
 });

--- a/tests/Feature/View/Components/Cib/TxRowTest.php
+++ b/tests/Feature/View/Components/Cib/TxRowTest.php
@@ -62,16 +62,22 @@ it('omits the .tx-meta element when meta slot is not provided', function () {
     expect($html)->not->toContain('class="tx-meta"');
 });
 
-it('renders icon slot content inside .tx-ico', function () {
-    $html = Blade::render(<<<'BLADE'
-        <x-cib.tx-row :transaction-id="1" name="Coffee" :amount="500" tone="out">
-            <x-slot:icon>
-                <svg data-icon="coffee"></svg>
-            </x-slot:icon>
-        </x-cib.tx-row>
-    BLADE);
+it('renders a flux icon inside .tx-ico when the icon prop is set', function () {
+    $html = Blade::render(
+        '<x-cib.tx-row :transaction-id="1" name="Coffee" :amount="500" tone="out" icon="coffee" />'
+    );
 
-    expect($html)->toContain('data-icon="coffee"');
+    expect($html)
+        ->toContain('tx-ico out')
+        ->toMatch('/<svg[^>]*data-flux-icon/i');
+});
+
+it('omits the icon svg when no icon prop is provided', function () {
+    $html = Blade::render('<x-cib.tx-row :transaction-id="1" name="Coffee" :amount="500" />');
+
+    expect($html)
+        ->toContain('tx-ico')
+        ->not->toMatch('/<svg[^>]*data-flux-icon/i');
 });
 
 it('dispatches open-reconciliation-modal when plannedTransactionId is set', function () {


### PR DESCRIPTION
## Summary
- Every top-level `Category` now carries a Flux-resolvable icon name; children inherit via a recursive `Category::resolveIcon()` parent-chain walk — no mapping layer.
- `x-cib.tx-row` refactored from implicit icon slot to a typed `:icon` prop that renders `<flux:icon :name="$icon" variant="mini"/>`; dashboard + calendar Blade wired to pass `$tx->category?->resolveIcon()`.
- `CategorySeeder` restructured into uniform `['name', 'icon', 'children']` specs and split into `run()` + `definitions()`. Seeds 9 parent icons plus 2 leaf overrides (`Bills / Rent → house-heart`, `Personal / Kitchen → coffee`).
- Installed 3 Lucide icons via `flux:icon` (`coffee`, `house-heart`, `activity`); the remaining 7 map to Heroicons bundled with Flux.
- `CalendarView` + `Dashboard` eager loads widened to `category.parent` (with `parent_id` projected) to keep the fallback walk in-memory — no N+1.

## Closes
- #197

## Test plan
- [x] `op test` — 1403 passed, 4 skipped, 0 failed (3216 assertions)
- [x] `op lint.check` — 270 files clean
- [x] `op analyse` — 0 Larastan errors
- [x] New Pest tests: `resolveIcon` (4), `TxRow` icon prop (2), `CategorySeederIconsTest` (13)
- [x] `op migrate.fresh` + DB spot-check: all 9 parents + both leaf overrides carry expected icons

## Notes
- Pre-existing Mago noise in `CalendarView`, `Dashboard`, and `Category::visibleSortedByFullPath` is unchanged by this branch (baseline issues on `develop`).
- Devlog at `DevLogs/CanEyeBudget/2026-04-19_ticket-7-icon-mapping.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)