### PR TITLE
fix(#207): mount TransactionModal globally in app layout so mobile FAB works everywhere

### DIFF
--- a/resources/views/calendar.blade.php
+++ b/resources/views/calendar.blade.php
@@ -1,5 +1,4 @@
 <x-layouts::app :title="__('Calendar')">
     <livewire:calendar-view />
-    <livewire:transaction-modal />
     <livewire:reconciliation-modal />
 </x-layouts::app>

--- a/resources/views/layouts/app/sidebar.blade.php
+++ b/resources/views/layouts/app/sidebar.blade.php
@@ -66,6 +66,7 @@
 </main>
 
 <livewire:feedback-widget/>
+<livewire:transaction-modal/>
 
 @fluxScripts
 </body>

--- a/tests/Browser/Livewire/FeedbackWidgetBrowserTest.php
+++ b/tests/Browser/Livewire/FeedbackWidgetBrowserTest.php
@@ -64,8 +64,8 @@ test('description textarea accepts input', function () use ($testScreenshotBase6
     JS);
 
     $page->assertSee('Send Feedback')
-        ->type('[data-flux-textarea]', 'This is a test description')
-        ->assertValue('[data-flux-textarea]', 'This is a test description');
+        ->type('textarea[name="description"]', 'This is a test description')
+        ->assertValue('textarea[name="description"]', 'This is a test description');
 });
 
 test('screenshot preview renders when screenshot data is present', function () use ($testScreenshotBase64, $findWidget) {

--- a/tests/Feature/CalendarPageTest.php
+++ b/tests/Feature/CalendarPageTest.php
@@ -1,0 +1,48 @@
+<?php
+
+/** @noinspection PhpUnhandledExceptionInspection */
+
+/** @noinspection StaticClosureCanBeUsedInspection */
+
+declare(strict_types=1);
+
+use App\Models\User;
+
+beforeEach(function () {
+    $this->user = User::factory()->create();
+    $this->actingAs($this->user);
+});
+
+it('renders the TransactionModal exactly once on the calendar page', function () {
+    $response = $this->get(route('calendar'));
+
+    $response->assertOk();
+    $response->assertSeeLivewire('transaction-modal');
+
+    expect(countLivewireMounts($response->getContent(), 'transaction-modal'))
+        ->toBe(1);
+});
+
+/**
+ * Count how many times a Livewire component is mounted in rendered HTML by
+ * parsing each `wire:snapshot` attribute, decoding HTML entities, and inspecting
+ * the snapshot's `memo.name`. More resilient than raw substring matching, which
+ * would break if Livewire changes how it encodes snapshot JSON.
+ */
+function countLivewireMounts(string $html, string $componentName): int
+{
+    preg_match_all('/wire:snapshot="([^"]+)"/', $html, $matches);
+
+    $count = 0;
+
+    foreach ($matches[1] as $encoded) {
+        $decoded = html_entity_decode($encoded, ENT_QUOTES | ENT_HTML5);
+        $snapshot = json_decode($decoded, true, flags: JSON_THROW_ON_ERROR);
+
+        if (is_array($snapshot) && ($snapshot['memo']['name'] ?? null) === $componentName) {
+            $count++;
+        }
+    }
+
+    return $count;
+}

--- a/tests/Feature/Layout/LayoutShellTest.php
+++ b/tests/Feature/Layout/LayoutShellTest.php
@@ -78,6 +78,13 @@ it('wires the FAB to dispatch open-transaction-modal', function () {
     $response->assertSee('data-testid="mobile-tabbar-fab"', false);
 });
 
+it('mounts the TransactionModal listener inside the app layout so the mobile FAB works on every page', function () {
+    $response = $this->get(route('dashboard'));
+
+    $response->assertOk();
+    $response->assertSeeLivewire('transaction-modal');
+});
+
 it('exposes the Log spend CTA in the topbar', function () {
     $response = $this->get(route('dashboard'));
 


### PR DESCRIPTION
## Summary

- The mobile bottom tab-bar FAB (`data-testid="mobile-tabbar-fab"`) dispatches `open-transaction-modal` from the layout shell, but the `TransactionModal` Livewire component was only mounted on pages that explicitly included `<livewire:transaction-modal />` (previously just `/calendar`). So on `/dashboard` and every other top-level page, tapping the FAB silently no-opped.
- Fix mounts `<livewire:transaction-modal/>` once in `resources/views/layouts/app/sidebar.blade.php` beside the existing `<livewire:feedback-widget/>`, so every page using `<x-layouts::app>` now has a live listener.
- Removed the now-duplicate `<livewire:transaction-modal />` from `resources/views/calendar.blade.php` to prevent a double-mount (which would render two stacked modals and fire handlers twice).
- Chose an eager mount over ``<livewire:transaction-modal lazy />``. A lazy component defers hydration — and therefore event-listener registration — until its placeholder scrolls into view. A hidden modal is never visible until it opens, so ``lazy`` would silently reintroduce the exact bug we're fixing.

## Closes

- #207

## Test plan

- [x] New assertion in `tests/Feature/Layout/LayoutShellTest.php`: `assertSeeLivewire('transaction-modal')` on `/dashboard` (red → green during TDD).
- [x] New guard test `tests/Feature/CalendarPageTest.php` asserts exactly one `transaction-modal` mount on `/calendar`, preventing future double-mount regressions.
- [x] Tightened ambiguous `[data-flux-textarea]` selector in `tests/Browser/Livewire/FeedbackWidgetBrowserTest.php` to `textarea[name="description"]` — required because Flux modals render their content in the DOM even when closed, so the global TransactionModal now contributes a second textarea on every page.
- [x] `op test` — **1364 passed, 0 failed, 4 skipped** (3146 assertions).
- [x] `op lint.check` — clean across 265 files.
- [x] `op analyse` — PHPStan 131 files, no errors.
- [ ] Manual mobile smoke at 375×812: tap FAB on `/dashboard`, `/transactions`, `/accounts`, `/rules`, and `/calendar` — modal opens in "Log an expense" mode, date = today, no double-modal on `/calendar`.

## Notes

- `op ci` includes `mago.lint`, which currently reports 696 pre-existing baseline issues across unrelated files (`readable-literal` warnings on numeric literals, etc.). **Zero** of those findings are in files modified by this PR. Not addressed here to keep the fix scoped.
- Not introduced by #206 — latent since tickets 2 (#192) and 4 (#194) merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)