### PR TITLE
feat(#212): CIB primitives extension (empty-state, card, filter-toggle, stat-pill)

### DIFF
--- a/app/Livewire/SmokeTest.php
+++ b/app/Livewire/SmokeTest.php
@@ -11,8 +11,6 @@ final class SmokeTest extends Component
 {
     public int $count = 0;
 
-    public ?string $filter = 'all';
-
     public function increment(): void
     {
         $this->count++;

--- a/app/Livewire/SmokeTest.php
+++ b/app/Livewire/SmokeTest.php
@@ -11,6 +11,8 @@ final class SmokeTest extends Component
 {
     public int $count = 0;
 
+    public ?string $filter = 'all';
+
     public function increment(): void
     {
         $this->count++;

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -561,6 +561,42 @@ select:focus[data-flux-control] {
         letter-spacing: 0.1em;
         color: var(--color-fg-3);
     }
+
+    /* ---------- CIB primitives extension (Ticket #212) ---------- */
+
+    .cib-card {
+        background: var(--color-bg-surface);
+        border: 2px solid var(--color-border-strong);
+        border-radius: var(--radius-md);
+        padding: 16px;
+        box-shadow: var(--shadow-pop-sm);
+    }
+    .cib-card.teal   { background: var(--color-cib-teal-400); color: var(--color-cib-white); }
+    .cib-card.yellow { background: var(--color-cib-yellow-300); }
+
+    .stat-pill {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        padding: 6px 12px;
+        border: 2px solid var(--color-border-strong);
+        border-radius: var(--radius-pill);
+        font: 700 12px/1 var(--font-sans);
+        background: var(--color-bg-surface);
+    }
+    .stat-pill-income       { background: var(--color-money-available-soft); }
+    .stat-pill-income       .pill-value { color: var(--color-cib-green-600); }
+    .stat-pill-posted       { background: var(--color-money-owed-soft); }
+    .stat-pill-posted       .pill-value { color: var(--color-money-owed); }
+    .stat-pill-planned      { background: var(--color-money-planned-soft); }
+    .stat-pill-planned      .pill-value { color: var(--color-money-planned); }
+    .stat-pill-buffer-pos   { background: var(--color-cib-teal-100); }
+    .stat-pill-buffer-pos   .pill-value { color: var(--color-cib-teal-600); }
+    .stat-pill-buffer-neg   { background: var(--color-money-owed-soft); }
+    .stat-pill-buffer-neg   .pill-value { color: var(--color-money-owed); }
+    .stat-pill-buffer-empty { background: var(--color-cib-n-100); }
+    .stat-pill-buffer-empty .pill-value { color: var(--color-fg-3); font-weight: 700; font-size: 11px; }
+    .stat-pill-neutral      { background: var(--color-cib-n-100); }
 }
 
 /* Flux modal slide-up (Ticket #196). Outside @layer components so it matches

--- a/resources/views/components/cib/card.blade.php
+++ b/resources/views/components/cib/card.blade.php
@@ -1,0 +1,17 @@
+@props([
+    'tone' => 'default',
+])
+
+<div {{ $attributes->class([
+    'cib-card',
+    'teal' => $tone === 'teal',
+    'yellow' => $tone === 'yellow',
+]) }}>
+    @isset($header)
+        <div class="cib-card-header">{{ $header }}</div>
+    @endisset
+    <div class="cib-card-body">{{ $slot }}</div>
+    @isset($footer)
+        <div class="cib-card-footer">{{ $footer }}</div>
+    @endisset
+</div>

--- a/resources/views/components/cib/empty-state.blade.php
+++ b/resources/views/components/cib/empty-state.blade.php
@@ -1,0 +1,18 @@
+@props([
+    'icon' => null,
+    'title',
+    'description' => null,
+])
+
+<div {{ $attributes->class(['empty-state']) }}>
+    @if ($icon)
+        <flux:icon :name="$icon" class="mx-auto mb-2"/>
+    @endif
+    <flux:heading size="lg">{{ $title }}</flux:heading>
+    @if ($description)
+        <flux:text>{{ $description }}</flux:text>
+    @endif
+    @isset($action)
+        <div class="empty-state-action">{{ $action }}</div>
+    @endisset
+</div>

--- a/resources/views/components/cib/filter-toggle.blade.php
+++ b/resources/views/components/cib/filter-toggle.blade.php
@@ -1,0 +1,23 @@
+@props([
+    'options' => [],
+    'selected' => null,
+    'wireModel' => null,
+])
+
+<div {{ $attributes->class(['type-toggle']) }}>
+    @foreach ($options as $option)
+        @php
+            $isActive = $option['value'] === $selected;
+            $tone = $option['tone'] ?? null;
+        @endphp
+        <button type="button"
+                @class([
+                    'active' => $isActive,
+                    $tone => $isActive && $tone,
+                ])
+                @if ($wireModel)
+                    wire:click="$set('{{ $wireModel }}', '{{ $option['value'] }}')"
+                @endif
+        >{{ $option['label'] }}</button>
+    @endforeach
+</div>

--- a/resources/views/components/cib/stat-pill.blade.php
+++ b/resources/views/components/cib/stat-pill.blade.php
@@ -1,0 +1,24 @@
+@props([
+    'tone' => 'neutral',
+    'label' => null,
+    'value' => null,
+])
+
+<span {{ $attributes->class([
+    'stat-pill',
+    'stat-pill-income' => $tone === 'income',
+    'stat-pill-posted' => $tone === 'posted',
+    'stat-pill-planned' => $tone === 'planned',
+    'stat-pill-buffer-pos' => $tone === 'buffer-pos',
+    'stat-pill-buffer-neg' => $tone === 'buffer-neg',
+    'stat-pill-buffer-empty' => $tone === 'buffer-empty',
+    'stat-pill-neutral' => $tone === 'neutral',
+]) }}>
+    @if ($label !== null)
+        <span class="pill-label">{{ $label }}</span>
+    @endif
+    @if ($value !== null)
+        <span class="pill-value">{{ $value }}</span>
+    @endif
+    {{ $slot }}
+</span>

--- a/tests/Feature/View/Components/Cib/CardTest.php
+++ b/tests/Feature/View/Components/Cib/CardTest.php
@@ -1,0 +1,87 @@
+<?php
+
+/** @noinspection StaticClosureCanBeUsedInspection */
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Blade;
+
+it('renders a root cib-card wrapper', function () {
+    $html = Blade::render('<x-cib.card>Body</x-cib.card>');
+
+    expect($html)->toContain('class="cib-card"');
+});
+
+it('renders the default slot as the card body', function () {
+    $html = Blade::render('<x-cib.card>Hello body</x-cib.card>');
+
+    expect($html)
+        ->toContain('class="cib-card-body"')
+        ->toContain('Hello body');
+});
+
+it('applies the teal tone modifier class', function () {
+    $html = Blade::render('<x-cib.card tone="teal">Body</x-cib.card>');
+
+    expect($html)->toContain('cib-card teal');
+});
+
+it('applies the yellow tone modifier class', function () {
+    $html = Blade::render('<x-cib.card tone="yellow">Body</x-cib.card>');
+
+    expect($html)->toContain('cib-card yellow');
+});
+
+it('emits no tone modifier for the default tone', function () {
+    $html = Blade::render('<x-cib.card>Body</x-cib.card>');
+
+    expect($html)
+        ->not->toContain('cib-card teal')
+        ->not->toContain('cib-card yellow');
+});
+
+it('renders the header slot inside a cib-card-header wrapper', function () {
+    $html = Blade::render(<<<'BLADE'
+        <x-cib.card>
+            <x-slot:header>My header</x-slot:header>
+            Body
+        </x-cib.card>
+    BLADE);
+
+    expect($html)
+        ->toContain('class="cib-card-header"')
+        ->toContain('My header');
+});
+
+it('omits the header wrapper when no header slot is supplied', function () {
+    $html = Blade::render('<x-cib.card>Body</x-cib.card>');
+
+    expect($html)->not->toContain('cib-card-header');
+});
+
+it('renders the footer slot inside a cib-card-footer wrapper', function () {
+    $html = Blade::render(<<<'BLADE'
+        <x-cib.card>
+            Body
+            <x-slot:footer>My footer</x-slot:footer>
+        </x-cib.card>
+    BLADE);
+
+    expect($html)
+        ->toContain('class="cib-card-footer"')
+        ->toContain('My footer');
+});
+
+it('omits the footer wrapper when no footer slot is supplied', function () {
+    $html = Blade::render('<x-cib.card>Body</x-cib.card>');
+
+    expect($html)->not->toContain('cib-card-footer');
+});
+
+it('merges caller-supplied attributes onto the root element', function () {
+    $html = Blade::render('<x-cib.card id="primary-card" data-testid="card">Body</x-cib.card>');
+
+    expect($html)
+        ->toContain('id="primary-card"')
+        ->toContain('data-testid="card"');
+});

--- a/tests/Feature/View/Components/Cib/EmptyStateTest.php
+++ b/tests/Feature/View/Components/Cib/EmptyStateTest.php
@@ -1,0 +1,65 @@
+<?php
+
+/** @noinspection StaticClosureCanBeUsedInspection */
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Blade;
+
+it('renders a root empty-state wrapper', function () {
+    $html = Blade::render('<x-cib.empty-state title="Nothing here" />');
+
+    expect($html)->toContain('class="empty-state"');
+});
+
+it('renders the title inside a heading', function () {
+    $html = Blade::render('<x-cib.empty-state title="No transactions" />');
+
+    expect($html)->toContain('No transactions');
+});
+
+it('renders the description when provided', function () {
+    $html = Blade::render(
+        '<x-cib.empty-state title="No transactions" description="Add your first transaction." />'
+    );
+
+    expect($html)->toContain('Add your first transaction.');
+});
+
+it('omits the description paragraph when description is null', function () {
+    $html = Blade::render('<x-cib.empty-state title="No transactions" />');
+
+    expect($html)->not->toContain('Add your first transaction.');
+});
+
+it('renders a flux icon when the icon prop is set', function () {
+    $html = Blade::render('<x-cib.empty-state icon="banknotes" title="No transactions" />');
+
+    expect($html)->toMatch('/<svg[^>]*data-flux-icon/i');
+});
+
+it('omits the icon svg when no icon prop is provided', function () {
+    $html = Blade::render('<x-cib.empty-state title="No transactions" />');
+
+    expect($html)->not->toMatch('/<svg[^>]*data-flux-icon/i');
+});
+
+it('renders the action slot inside an empty-state-action wrapper', function () {
+    $html = Blade::render(<<<'BLADE'
+        <x-cib.empty-state title="No transactions">
+            <x-slot:action>
+                <button type="button">Add one</button>
+            </x-slot:action>
+        </x-cib.empty-state>
+    BLADE);
+
+    expect($html)
+        ->toContain('class="empty-state-action"')
+        ->toContain('Add one');
+});
+
+it('omits the empty-state-action wrapper when the slot is not provided', function () {
+    $html = Blade::render('<x-cib.empty-state title="No transactions" />');
+
+    expect($html)->not->toContain('empty-state-action');
+});

--- a/tests/Feature/View/Components/Cib/FilterToggleTest.php
+++ b/tests/Feature/View/Components/Cib/FilterToggleTest.php
@@ -1,0 +1,88 @@
+<?php
+
+/** @noinspection StaticClosureCanBeUsedInspection */
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Blade;
+
+function filter_toggle_options(): array
+{
+    return [
+        ['value' => 'all', 'label' => 'All',      'tone' => null],
+        ['value' => 'inc', 'label' => 'Incoming', 'tone' => 'inc'],
+        ['value' => 'out', 'label' => 'Outgoing', 'tone' => 'out'],
+    ];
+}
+
+it('renders a root type-toggle wrapper', function () {
+    $html = Blade::render(
+        '<x-cib.filter-toggle :options="$options" selected="all" wire-model="filter" />',
+        ['options' => filter_toggle_options()]
+    );
+
+    expect($html)->toContain('class="type-toggle"');
+});
+
+it('renders a button for each option', function () {
+    $html = Blade::render(
+        '<x-cib.filter-toggle :options="$options" selected="all" wire-model="filter" />',
+        ['options' => filter_toggle_options()]
+    );
+
+    expect($html)
+        ->toContain('All')
+        ->toContain('Incoming')
+        ->toContain('Outgoing');
+
+    expect(mb_substr_count($html, '<button'))->toBe(3);
+});
+
+it('marks the selected option button as active', function () {
+    $html = Blade::render(
+        '<x-cib.filter-toggle :options="$options" selected="inc" wire-model="filter" />',
+        ['options' => filter_toggle_options()]
+    );
+
+    expect($html)->toContain('class="active inc"');
+});
+
+it('does not add the active class to non-selected options', function () {
+    $html = Blade::render(
+        '<x-cib.filter-toggle :options="$options" selected="all" wire-model="filter" />',
+        ['options' => filter_toggle_options()]
+    );
+
+    expect(mb_substr_count($html, 'active'))->toBe(1);
+});
+
+it('applies the tone class only to the active button', function () {
+    $html = Blade::render(
+        '<x-cib.filter-toggle :options="$options" selected="out" wire-model="filter" />',
+        ['options' => filter_toggle_options()]
+    );
+
+    expect($html)->toContain('class="active out"');
+    expect($html)->not->toContain('class="inc"');
+});
+
+it('wires click to $set on the supplied wireModel target', function () {
+    $html = Blade::render(
+        '<x-cib.filter-toggle :options="$options" selected="all" wire-model="filter" />',
+        ['options' => filter_toggle_options()]
+    );
+
+    expect($html)
+        ->toContain("wire:click=\"\$set('filter', 'all')\"")
+        ->toContain("wire:click=\"\$set('filter', 'inc')\"")
+        ->toContain("wire:click=\"\$set('filter', 'out')\"");
+});
+
+it('renders buttons as type=button for form safety', function () {
+    $html = Blade::render(
+        '<x-cib.filter-toggle :options="$options" selected="all" wire-model="filter" />',
+        ['options' => filter_toggle_options()]
+    );
+
+    expect(mb_substr_count($html, 'type="button"'))->toBe(3);
+});

--- a/tests/Feature/View/Components/Cib/StatPillTest.php
+++ b/tests/Feature/View/Components/Cib/StatPillTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/** @noinspection StaticClosureCanBeUsedInspection */
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Blade;
+
+it('renders a root stat-pill element', function () {
+    $html = Blade::render('<x-cib.stat-pill label="IN" value="$10" />');
+
+    expect($html)->toContain('stat-pill');
+});
+
+it('applies the tone modifier class', function (string $tone) {
+    $html = Blade::render('<x-cib.stat-pill tone="'.$tone.'" label="X" value="Y" />');
+
+    expect($html)->toContain('stat-pill-'.$tone);
+})->with([
+    'income',
+    'posted',
+    'planned',
+    'buffer-pos',
+    'buffer-neg',
+    'buffer-empty',
+    'neutral',
+]);
+
+it('defaults to the neutral tone when no tone is supplied', function () {
+    $html = Blade::render('<x-cib.stat-pill label="N" value="3" />');
+
+    expect($html)->toContain('stat-pill-neutral');
+});
+
+it('renders the label inside a pill-label span', function () {
+    $html = Blade::render('<x-cib.stat-pill label="IN" value="$10" />');
+
+    expect($html)
+        ->toContain('class="pill-label"')
+        ->toContain('IN');
+});
+
+it('renders the value inside a pill-value span', function () {
+    $html = Blade::render('<x-cib.stat-pill label="IN" value="$10" />');
+
+    expect($html)
+        ->toContain('class="pill-value"')
+        ->toContain('$10');
+});
+
+it('omits the pill-label span when no label is provided', function () {
+    $html = Blade::render('<x-cib.stat-pill value="$10" />');
+
+    expect($html)->not->toContain('class="pill-label"');
+});
+
+it('omits the pill-value span when no value is provided', function () {
+    $html = Blade::render('<x-cib.stat-pill label="IN" />');
+
+    expect($html)->not->toContain('class="pill-value"');
+});
+
+it('merges caller-supplied attributes onto the root element', function () {
+    $html = Blade::render('<x-cib.stat-pill data-testid="pill" label="IN" value="$10" />');
+
+    expect($html)->toContain('data-testid="pill"');
+});


### PR DESCRIPTION
## Summary
- Introduces four reusable Blade primitives under `resources/views/components/cib/`: `empty-state`, `card`, `filter-toggle`, `stat-pill`. Each is a thin wrapper around existing CIB CSS utilities (`.empty-state`, `.type-toggle`, `.quickline .pill-*`) plus two new class blocks (`.cib-card`, standalone `.stat-pill`) appended inside `@layer components` in `resources/css/app.css`.
- Unblocks Tickets #213–#216 (restyle of `/connect-bank`, `/transactions`, `/accounts`, `/rules`) by providing the shared primitives they consume.
- Visual-only — no controllers, form requests, migrations, queues, jobs, or Livewire class changes. Pure view-layer additions.

## Closes
- #212

## Test plan
- [x] `op test.filter Cib` — 77 passed, 121 assertions (39 new across the four primitives + 38 pre-existing CIB component tests, no regressions)
- [x] `op test` — 1,419 passed, 4 skipped, 0 failed (full suite regression)
- [x] `op analyse` (Larastan) — `[OK] No errors`
- [x] `op lint.dirty` (Pint) — clean
- [x] Tokens referenced by the new CSS (`--color-bg-surface`, `--color-border-strong`, `--radius-md`, `--radius-pill`, `--shadow-pop-sm`, `--color-cib-teal-{100,400,600}`, `--color-cib-yellow-300`, `--color-cib-white`, `--color-cib-green-600`, `--color-money-{available,owed,planned}-soft`, `--color-money-{owed,planned}`, `--color-cib-n-100`, `--color-fg-3`, `--font-sans`) all resolve to existing definitions in the top-of-file token block

## Notes
- The `.stat-pill-*` tone palette mirrors the existing `.quickline .pill-*` palette deliberately — tones stay in lockstep so a future DRY pass can consolidate without breaking either call site.
- New CSS is inserted inside `@layer components` (above line 564) so specificity behaves exactly like the sibling primitives; the post-layer `@keyframes cib-slideup` block is untouched.
- Tests use `Blade::render()` + `expect(\$html)->toContain(...)` — mirroring the existing `SecHeadTest`/`TxRowTest` pattern — to keep the component tests out of the Livewire test harness for pure view components.
- Target base is `develop` per `CLAUDE.local.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)