### PR TITLE
feat(#213): restyle /connect-bank with CIB cards + stat-pills + rule-suggest

### DIFF
--- a/app/Livewire/ConnectBank.php
+++ b/app/Livewire/ConnectBank.php
@@ -104,20 +104,34 @@ final class ConnectBank extends Component
                 ->count()
             : 0;
 
+        $refreshLogs = $isConnected
+            ? BasiqRefreshLog::query()
+                ->where('user_id', $user->id)
+                ->latest()
+                ->limit(10)
+                ->get()
+            : collect();
+
         return view('livewire.connect-bank', [
             'isConnected' => $isConnected,
             'accounts' => $isConnected ? $user->accounts()->active()->visible()->get() : collect(),
             'transactionCount' => $isConnected ? $user->transactions()->count() : 0,
             'lastSyncedAt' => $user->last_synced_at,
-            'refreshLogs' => $isConnected
-                ? BasiqRefreshLog::query()
-                    ->where('user_id', $user->id)
-                    ->latest()
-                    ->limit(10)
-                    ->get()
-                : collect(),
+            'refreshLogs' => $refreshLogs,
+            'statusTones' => $refreshLogs->mapWithKeys(
+                fn (BasiqRefreshLog $log) => [$log->id => $this->statPillToneFor($log->status)]
+            )->all(),
             'todayRefreshCount' => $todayRefreshCount,
             'canRefresh' => $isConnected && $todayRefreshCount < 20,
         ]);
+    }
+
+    private function statPillToneFor(RefreshStatus $status): string
+    {
+        return match ($status) {
+            RefreshStatus::Success => 'income',
+            RefreshStatus::Pending => 'planned',
+            RefreshStatus::Failed => 'posted',
+        };
     }
 }

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -229,6 +229,7 @@ select:focus[data-flux-control] {
         align-items: center;
     }
     .tx-row:last-child { border-bottom: 0; }
+    .tx-row.passive { cursor: default; }
     .tx-ico {
         width: 36px; height: 36px; border-radius: 10px;
         display: grid; place-items: center;

--- a/resources/views/components/cib/tx-row.blade.php
+++ b/resources/views/components/cib/tx-row.blade.php
@@ -13,26 +13,53 @@
 
 @php
     $isPlanned = $plannedTransactionId !== null;
+    $isPassive = $transactionId === null && $plannedTransactionId === null;
+
+    if (! $isPassive && isset($actions)) {
+        throw new InvalidArgumentException(
+            '<x-cib.tx-row> actions slot requires passive mode — both transactionId and plannedTransactionId must be null when an actions slot is supplied.'
+        );
+    }
 @endphp
 
-<button type="button"
-        {{ $attributes->class(['tx-row', 'planned' => $isPlanned]) }}
-        @if ($isPlanned)
-            wire:click="$dispatch('open-reconciliation-modal', { plannedId: {{ (int) $plannedTransactionId }}, occurrenceDate: {{ Js::from((string) $occurrenceDate) }} })"
-        @else
-            wire:click="$dispatch('edit-transaction', { id: {{ (int) $transactionId }} })"
-        @endif
->
-    <div @class(['tx-ico', $tone])>
-        @if ($icon)
-            <flux:icon :name="$icon" variant="mini"/>
-        @endif
-    </div>
-    <div>
-        <div class="tx-name">{{ $name }}</div>
-        @isset($meta)
-            <div class="tx-meta">{{ $meta }}</div>
+@if ($isPassive)
+    <div {{ $attributes->class(['tx-row', 'passive']) }}>
+        <div @class(['tx-ico', $tone])>
+            @if ($icon)
+                <flux:icon :name="$icon" variant="mini"/>
+            @endif
+        </div>
+        <div>
+            <div class="tx-name">{{ $name }}</div>
+            @isset($meta)
+                <div class="tx-meta">{{ $meta }}</div>
+            @endisset
+        </div>
+        <div @class(['tx-amt', $tone])>{{ MoneyCast::format((int) $amount) }}</div>
+        @isset($actions)
+            <div class="tx-actions">{{ $actions }}</div>
         @endisset
     </div>
-    <div @class(['tx-amt', $tone])>{{ MoneyCast::format((int) $amount) }}</div>
-</button>
+@else
+    <button type="button"
+            {{ $attributes->class(['tx-row', 'planned' => $isPlanned]) }}
+            @if ($isPlanned)
+                wire:click="$dispatch('open-reconciliation-modal', { plannedId: {{ (int) $plannedTransactionId }}, occurrenceDate: {{ Js::from((string) $occurrenceDate) }} })"
+            @else
+                wire:click="$dispatch('edit-transaction', { id: {{ (int) $transactionId }} })"
+            @endif
+    >
+        <div @class(['tx-ico', $tone])>
+            @if ($icon)
+                <flux:icon :name="$icon" variant="mini"/>
+            @endif
+        </div>
+        <div>
+            <div class="tx-name">{{ $name }}</div>
+            @isset($meta)
+                <div class="tx-meta">{{ $meta }}</div>
+            @endisset
+        </div>
+        <div @class(['tx-amt', $tone])>{{ MoneyCast::format((int) $amount) }}</div>
+    </button>
+@endif

--- a/resources/views/livewire/analysis-suggestions.blade.php
+++ b/resources/views/livewire/analysis-suggestions.blade.php
@@ -12,27 +12,85 @@
 
             @if($suggestions->has(SuggestionType::PrimaryAccount->value))
                 @foreach($suggestions->get(SuggestionType::PrimaryAccount->value) as $suggestion)
-                    <flux:card wire:key="suggestion-{{ $suggestion->id }}">
-                        <div class="flex items-center justify-between gap-4">
-                            <div>
-                                <flux:heading>Primary Account Detected</flux:heading>
-                                <flux:text class="mt-1">
-                                    We detected <strong>{{ $suggestion->payload['account_name'] }}</strong> as your primary account.
-                                </flux:text>
-                                <flux:text size="sm" class="mt-1 text-zinc-500">
-                                    Income: {{ MoneyCast::format($suggestion->payload['income_amount']) }}
-                                    {{ PayFrequency::from($suggestion->payload['income_frequency'])->label() }}
-                                </flux:text>
+                    <div wire:key="suggestion-{{ $suggestion->id }}" class="rule-suggest items-center">
+                        <flux:icon.sparkles class="size-5 mt-0.5"/>
+                        <div class="flex-1">
+                            <div class="t">Primary Account Detected</div>
+                            <div class="s">
+                                We detected <strong>{{ $suggestion->payload['account_name'] }}</strong> as your primary account.
                             </div>
-                            <div class="flex shrink-0 items-center gap-2">
+                            <div class="s">
+                                Income: {{ MoneyCast::format($suggestion->payload['income_amount']) }}
+                                {{ PayFrequency::from($suggestion->payload['income_frequency'])->label() }}
+                            </div>
+                        </div>
+                        <div class="flex shrink-0 items-center gap-2">
+                            <flux:button
+                                variant="primary"
+                                size="sm"
+                                wire:click="acceptPrimaryAccount({{ $suggestion->id }})"
+                                wire:loading.attr="disabled"
+                                wire:target="acceptPrimaryAccount({{ $suggestion->id }})"
+                            >
+                                <flux:icon.loading wire:loading wire:target="acceptPrimaryAccount({{ $suggestion->id }})" class="size-4"/>
+                                Accept
+                            </flux:button>
+                            <flux:button
+                                variant="ghost"
+                                size="sm"
+                                wire:click="rejectSuggestion({{ $suggestion->id }})"
+                                wire:loading.attr="disabled"
+                                wire:target="rejectSuggestion({{ $suggestion->id }})"
+                            >
+                                Dismiss
+                            </flux:button>
+                        </div>
+                    </div>
+                @endforeach
+            @endif
+
+            @if($suggestions->has(SuggestionType::PayCycle->value))
+                @foreach($suggestions->get(SuggestionType::PayCycle->value) as $suggestion)
+                    <div wire:key="suggestion-{{ $suggestion->id }}" class="rule-suggest">
+                        <flux:icon.sparkles class="size-5 mt-0.5"/>
+                        <div class="flex-1">
+                            <div class="t">Pay Cycle Detected</div>
+                            <div class="s">You appear to be paid regularly. Confirm or adjust the details below.</div>
+
+                            <div class="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-3">
+                                <flux:field>
+                                    <flux:label>Pay Amount</flux:label>
+                                    <flux:input type="number" wire:model="payAmount" step="0.01" min="0" placeholder="0.00"/>
+                                    <flux:error name="payAmount"/>
+                                </flux:field>
+
+                                <flux:field>
+                                    <flux:label>Frequency</flux:label>
+                                    <flux:select wire:model="payFrequency">
+                                        <flux:select.option value="">Select...</flux:select.option>
+                                        @foreach(PayFrequency::cases() as $freq)
+                                            <flux:select.option value="{{ $freq->value }}">{{ $freq->label() }}</flux:select.option>
+                                        @endforeach
+                                    </flux:select>
+                                    <flux:error name="payFrequency"/>
+                                </flux:field>
+
+                                <flux:field>
+                                    <flux:label>Next Pay Date</flux:label>
+                                    <flux:input type="date" wire:model="nextPayDate"/>
+                                    <flux:error name="nextPayDate"/>
+                                </flux:field>
+                            </div>
+
+                            <div class="mt-4 flex items-center gap-2">
                                 <flux:button
                                     variant="primary"
                                     size="sm"
-                                    wire:click="acceptPrimaryAccount({{ $suggestion->id }})"
+                                    wire:click="acceptPayCycle({{ $suggestion->id }})"
                                     wire:loading.attr="disabled"
-                                    wire:target="acceptPrimaryAccount({{ $suggestion->id }})"
+                                    wire:target="acceptPayCycle({{ $suggestion->id }})"
                                 >
-                                    <flux:icon.loading wire:loading wire:target="acceptPrimaryAccount({{ $suggestion->id }})" class="size-4"/>
+                                    <flux:icon.loading wire:loading wire:target="acceptPayCycle({{ $suggestion->id }})" class="size-4"/>
                                     Accept
                                 </flux:button>
                                 <flux:button
@@ -46,177 +104,121 @@
                                 </flux:button>
                             </div>
                         </div>
-                    </flux:card>
-                @endforeach
-            @endif
-
-            @if($suggestions->has(SuggestionType::PayCycle->value))
-                @foreach($suggestions->get(SuggestionType::PayCycle->value) as $suggestion)
-                    <flux:card wire:key="suggestion-{{ $suggestion->id }}">
-                        <flux:heading>Pay Cycle Detected</flux:heading>
-                        <flux:text class="mt-1">You appear to be paid regularly. Confirm or adjust the details below.</flux:text>
-
-                        <div class="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-3">
-                            <flux:field>
-                                <flux:label>Pay Amount</flux:label>
-                                <flux:input type="number" wire:model="payAmount" step="0.01" min="0" placeholder="0.00"/>
-                                <flux:error name="payAmount"/>
-                            </flux:field>
-
-                            <flux:field>
-                                <flux:label>Frequency</flux:label>
-                                <flux:select wire:model="payFrequency">
-                                    <flux:select.option value="">Select...</flux:select.option>
-                                    @foreach(PayFrequency::cases() as $freq)
-                                        <flux:select.option value="{{ $freq->value }}">{{ $freq->label() }}</flux:select.option>
-                                    @endforeach
-                                </flux:select>
-                                <flux:error name="payFrequency"/>
-                            </flux:field>
-
-                            <flux:field>
-                                <flux:label>Next Pay Date</flux:label>
-                                <flux:input type="date" wire:model="nextPayDate"/>
-                                <flux:error name="nextPayDate"/>
-                            </flux:field>
-                        </div>
-
-                        <div class="mt-4 flex items-center gap-2">
-                            <flux:button
-                                variant="primary"
-                                size="sm"
-                                wire:click="acceptPayCycle({{ $suggestion->id }})"
-                                wire:loading.attr="disabled"
-                                wire:target="acceptPayCycle({{ $suggestion->id }})"
-                            >
-                                <flux:icon.loading wire:loading wire:target="acceptPayCycle({{ $suggestion->id }})" class="size-4"/>
-                                Accept
-                            </flux:button>
-                            <flux:button
-                                variant="ghost"
-                                size="sm"
-                                wire:click="rejectSuggestion({{ $suggestion->id }})"
-                                wire:loading.attr="disabled"
-                                wire:target="rejectSuggestion({{ $suggestion->id }})"
-                            >
-                                Dismiss
-                            </flux:button>
-                        </div>
-                    </flux:card>
+                    </div>
                 @endforeach
             @endif
 
             @if($suggestions->has(SuggestionType::RecurringTransaction->value))
-                <flux:card>
+                <x-cib.card>
                     <flux:heading>Recurring Transactions Detected</flux:heading>
                     <flux:text class="mt-1">We found patterns that look like recurring transactions.</flux:text>
 
                     <div class="mt-4 max-h-96 space-y-3 overflow-y-auto">
                         @foreach($suggestions->get(SuggestionType::RecurringTransaction->value) as $suggestion)
-                            <div wire:key="suggestion-{{ $suggestion->id }}" class="flex items-center justify-between gap-4 rounded-lg border border-neutral-200 p-3 dark:border-neutral-700">
-                                <div class="min-w-0 flex-1">
-                                    <div class="flex items-center gap-2">
-                                        <flux:text class="truncate font-medium">{{ $suggestion->payload['clean_description'] }}</flux:text>
-                                        <flux:badge size="sm" :color="$suggestion->payload['direction'] === 'debit' ? 'red' : 'green'">
-                                            {{ MoneyCast::format(abs($suggestion->payload['amount'])) }}
-                                        </flux:badge>
-                                    </div>
-                                    <div class="mt-1 flex items-center gap-3">
-                                        <flux:text size="sm" class="text-zinc-500">
-                                            {{ RecurrenceFrequency::from($suggestion->payload['frequency'])->label() }}
-                                        </flux:text>
-                                        <flux:text size="sm" class="text-zinc-500">
-                                            {{ count($suggestion->payload['matched_transaction_ids']) }} matches
-                                        </flux:text>
-                                    </div>
-                                </div>
+                            <div class="day-card" wire:key="suggestion-{{ $suggestion->id }}">
+                                <x-cib.tx-row
+                                    :transaction-id="null"
+                                    :planned-transaction-id="null"
+                                    :name="$suggestion->payload['clean_description']"
+                                    :amount="abs($suggestion->payload['amount'])"
+                                    :tone="$suggestion->payload['direction'] === 'debit' ? 'out' : 'inc'"
+                                >
+                                    <x-slot:meta>
+                                        {{ RecurrenceFrequency::from($suggestion->payload['frequency'])->label() }}
+                                        · {{ count($suggestion->payload['matched_transaction_ids']) }} matches
+                                    </x-slot:meta>
+                                    <x-slot:actions>
+                                        <x-category-combobox
+                                            wire:model="recurringCategories.{{ $suggestion->id }}"
+                                            :categories="$categories"
+                                            placeholder="No category"
+                                            size="sm"
+                                            class="w-40"
+                                        />
 
-                                <div class="flex shrink-0 items-center gap-2">
-                                    <x-category-combobox
-                                        wire:model="recurringCategories.{{ $suggestion->id }}"
-                                        :categories="$categories"
-                                        placeholder="No category"
-                                        size="sm"
-                                        class="w-40"
-                                    />
-
-                                    <flux:button
-                                        variant="primary"
-                                        size="sm"
-                                        wire:click="acceptRecurringTransaction({{ $suggestion->id }})"
-                                        wire:loading.attr="disabled"
-                                        wire:target="acceptRecurringTransaction({{ $suggestion->id }})"
-                                    >
-                                        <flux:icon.loading wire:loading wire:target="acceptRecurringTransaction({{ $suggestion->id }})" class="size-4"/>
-                                        Accept
-                                    </flux:button>
-                                    <flux:button
-                                        variant="ghost"
-                                        size="sm"
-                                        wire:click="rejectSuggestion({{ $suggestion->id }})"
-                                        wire:loading.attr="disabled"
-                                        wire:target="rejectSuggestion({{ $suggestion->id }})"
-                                    >
-                                        Dismiss
-                                    </flux:button>
-                                </div>
+                                        <flux:button
+                                            variant="primary"
+                                            size="sm"
+                                            wire:click="acceptRecurringTransaction({{ $suggestion->id }})"
+                                            wire:loading.attr="disabled"
+                                            wire:target="acceptRecurringTransaction({{ $suggestion->id }})"
+                                        >
+                                            <flux:icon.loading wire:loading wire:target="acceptRecurringTransaction({{ $suggestion->id }})" class="size-4"/>
+                                            Accept
+                                        </flux:button>
+                                        <flux:button
+                                            variant="ghost"
+                                            size="sm"
+                                            wire:click="rejectSuggestion({{ $suggestion->id }})"
+                                            wire:loading.attr="disabled"
+                                            wire:target="rejectSuggestion({{ $suggestion->id }})"
+                                        >
+                                            Dismiss
+                                        </flux:button>
+                                    </x-slot:actions>
+                                </x-cib.tx-row>
                             </div>
                         @endforeach
                     </div>
-                </flux:card>
+                </x-cib.card>
             @endif
 
             @if($suggestions->has(SuggestionType::UserRule->value))
-                <flux:card>
+                <x-cib.card>
                     <flux:heading>Rule Matches</flux:heading>
                     <flux:text class="mt-1">Your rules matched the following transactions.</flux:text>
 
                     <div class="mt-4 max-h-96 space-y-3 overflow-y-auto">
                         @foreach($suggestions->get(SuggestionType::UserRule->value) as $suggestion)
-                            <div wire:key="suggestion-{{ $suggestion->id }}" class="flex items-center justify-between gap-4 rounded-lg border border-neutral-200 p-3 dark:border-neutral-700">
-                                <div class="min-w-0 flex-1">
-                                    <div class="flex items-center gap-2">
-                                        <flux:text class="truncate font-medium">{{ $suggestion->payload['rule_name'] }}</flux:text>
-                                    </div>
-                                    <div class="mt-1 flex flex-wrap items-center gap-1">
-                                        @foreach($suggestion->payload['actions'] as $action)
-                                            <flux:badge size="sm" color="purple">
-                                                {{ RuleActionType::from($action['type'])->label() }}
-                                            </flux:badge>
-                                        @endforeach
-                                    </div>
-                                    @if(isset($ruleTransactionDescriptions[$suggestion->payload['transaction_id']]))
-                                        <flux:text size="sm" class="mt-1 text-zinc-500">
-                                            {{ $ruleTransactionDescriptions[$suggestion->payload['transaction_id']] }}
-                                        </flux:text>
-                                    @endif
-                                </div>
-
-                                <div class="flex shrink-0 items-center gap-2">
-                                    <flux:button
-                                        variant="primary"
-                                        size="sm"
-                                        wire:click="acceptUserRule({{ $suggestion->id }})"
-                                        wire:loading.attr="disabled"
-                                        wire:target="acceptUserRule({{ $suggestion->id }})"
-                                    >
-                                        <flux:icon.loading wire:loading wire:target="acceptUserRule({{ $suggestion->id }})" class="size-4"/>
-                                        Accept
-                                    </flux:button>
-                                    <flux:button
-                                        variant="ghost"
-                                        size="sm"
-                                        wire:click="rejectSuggestion({{ $suggestion->id }})"
-                                        wire:loading.attr="disabled"
-                                        wire:target="rejectSuggestion({{ $suggestion->id }})"
-                                    >
-                                        Dismiss
-                                    </flux:button>
-                                </div>
+                            <div class="day-card" wire:key="suggestion-{{ $suggestion->id }}">
+                                <x-cib.tx-row
+                                    :transaction-id="null"
+                                    :planned-transaction-id="null"
+                                    :name="$suggestion->payload['rule_name']"
+                                    :amount="0"
+                                    tone="out"
+                                    class="[&_.tx-amt]:invisible"
+                                >
+                                    <x-slot:meta>
+                                        <div class="flex flex-wrap items-center gap-1">
+                                            @foreach($suggestion->payload['actions'] as $action)
+                                                <flux:badge size="sm" color="purple">
+                                                    {{ RuleActionType::from($action['type'])->label() }}
+                                                </flux:badge>
+                                            @endforeach
+                                        </div>
+                                        @if(isset($ruleTransactionDescriptions[$suggestion->payload['transaction_id']]))
+                                            <div class="mt-1 text-zinc-500">
+                                                {{ $ruleTransactionDescriptions[$suggestion->payload['transaction_id']] }}
+                                            </div>
+                                        @endif
+                                    </x-slot:meta>
+                                    <x-slot:actions>
+                                        <flux:button
+                                            variant="primary"
+                                            size="sm"
+                                            wire:click="acceptUserRule({{ $suggestion->id }})"
+                                            wire:loading.attr="disabled"
+                                            wire:target="acceptUserRule({{ $suggestion->id }})"
+                                        >
+                                            <flux:icon.loading wire:loading wire:target="acceptUserRule({{ $suggestion->id }})" class="size-4"/>
+                                            Accept
+                                        </flux:button>
+                                        <flux:button
+                                            variant="ghost"
+                                            size="sm"
+                                            wire:click="rejectSuggestion({{ $suggestion->id }})"
+                                            wire:loading.attr="disabled"
+                                            wire:target="rejectSuggestion({{ $suggestion->id }})"
+                                        >
+                                            Dismiss
+                                        </flux:button>
+                                    </x-slot:actions>
+                                </x-cib.tx-row>
                             </div>
                         @endforeach
                     </div>
-                </flux:card>
+                </x-cib.card>
             @endif
         </div>
     @endif

--- a/resources/views/livewire/connect-bank.blade.php
+++ b/resources/views/livewire/connect-bank.blade.php
@@ -1,19 +1,20 @@
 @php use App\Enums\RefreshStatus; use Illuminate\Support\Str; @endphp
 <div class="space-y-6">
     @if(! $isConnected)
-        <div class="rounded-xl border border-neutral-200 p-8 text-center dark:border-neutral-700">
-            <flux:icon.building-library class="mx-auto size-12 text-zinc-400"/>
-            <flux:heading size="lg" class="mt-4">No bank connected</flux:heading>
-            <flux:text class="mt-2">Connect your bank to automatically sync your accounts and transactions.</flux:text>
-            <div class="mt-6">
+        <x-cib.empty-state
+            icon="building-library"
+            title="No bank connected"
+            description="Connect your bank to automatically sync your accounts and transactions."
+        >
+            <x-slot:action>
                 <flux:button variant="primary" icon="plus" wire:click="connect" wire:loading.attr="disabled">
                     <flux:icon.loading wire:loading wire:target="connect" class="size-4"/>
                     {{ __('Connect Bank') }}
                 </flux:button>
-            </div>
-        </div>
+            </x-slot:action>
+        </x-cib.empty-state>
     @else
-        <flux:card>
+        <x-cib.card>
             <div class="flex items-center justify-between">
                 <div>
                     <flux:heading size="lg">Connection Status</flux:heading>
@@ -30,17 +31,27 @@
                     {{ __('Manage Connections') }}
                 </flux:button>
             </div>
-        </flux:card>
+        </x-cib.card>
 
-        <flux:card>
+        <x-cib.card>
             <div class="flex items-center justify-between">
                 <flux:heading size="lg">Sync Summary</flux:heading>
                 <div class="flex items-center gap-3">
-                    <flux:text size="sm">{{ $todayRefreshCount }} of 20 refreshes used today</flux:text>
-                    <flux:button size="sm" variant="primary" wire:click="refresh" wire:loading.attr="disabled" :disabled="! $canRefresh">
+                    <x-cib.stat-pill tone="neutral">
+                        {{ $todayRefreshCount }} of 20 refreshes used today
+                    </x-cib.stat-pill>
+                    <button
+                        type="button"
+                        data-testid="connect-bank-refresh-now"
+                        wire:click="refresh"
+                        wire:loading.attr="disabled"
+                        @disabled(! $canRefresh)
+                        class="inline-flex items-center gap-2 rounded-md border-2 border-cib-black bg-cib-yellow-400 px-4 py-2 text-sm font-bold text-cib-black shadow-pop transition-transform hover:-translate-y-px disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:translate-y-0"
+                    >
                         <flux:icon.loading wire:loading wire:target="refresh" class="size-4"/>
+                        <flux:icon name="arrow-path" class="size-4"/>
                         {{ __('Refresh Now') }}
-                    </flux:button>
+                    </button>
                 </div>
             </div>
             <div class="mt-4 flex flex-wrap items-center gap-3">
@@ -56,20 +67,20 @@
             @if($accounts->isNotEmpty())
                 <div class="mt-3 flex flex-wrap gap-2">
                     @foreach($accounts as $account)
-                        <flux:badge size="sm" color="zinc">{{ $account->name }}</flux:badge>
+                        <x-cib.stat-pill tone="neutral">{{ $account->name }}</x-cib.stat-pill>
                     @endforeach
                 </div>
             @endif
-        </flux:card>
+        </x-cib.card>
 
-        <flux:card>
+        <x-cib.card>
             <flux:heading size="lg">Refresh History</flux:heading>
             @if($refreshLogs->isEmpty())
                 <flux:text class="mt-2">No refresh history yet.</flux:text>
             @else
-                <div class="mt-4 divide-y divide-neutral-200 dark:divide-neutral-700">
+                <div class="mt-4 space-y-2">
                     @foreach($refreshLogs as $log)
-                        <div wire:key="log-{{ $log->id }}" class="flex items-center justify-between py-3">
+                        <div wire:key="log-{{ $log->id }}" class="day-card flex items-center justify-between py-3">
                             <div class="flex items-center gap-3">
                                 <flux:text size="sm">{{ $log->created_at->diffForHumans() }}</flux:text>
                                 <flux:text size="sm" class="text-zinc-500">{{ $log->trigger->label() }}</flux:text>
@@ -85,17 +96,13 @@
                                     </flux:text>
                                 @endif
                             </div>
-                            @if($log->status === RefreshStatus::Success)
-                                <flux:badge size="sm" color="green">Success</flux:badge>
-                            @elseif($log->status === RefreshStatus::Pending)
-                                <flux:badge size="sm" color="yellow">Pending</flux:badge>
-                            @else
-                                <flux:badge size="sm" color="red">Failed</flux:badge>
-                            @endif
+                            <x-cib.stat-pill :tone="$statusTones[$log->id]">
+                                {{ $log->status->label() }}
+                            </x-cib.stat-pill>
                         </div>
                     @endforeach
                 </div>
             @endif
-        </flux:card>
+        </x-cib.card>
     @endif
 </div>

--- a/tests/Feature/Livewire/AnalysisSuggestionsTest.php
+++ b/tests/Feature/Livewire/AnalysisSuggestionsTest.php
@@ -104,6 +104,66 @@ test('renders empty when no pending suggestions', function () {
         ->assertDontSee('Analysis Suggestions');
 });
 
+// ─── CIB visual tokens (Ticket #213) ─────────────────────
+
+test('primary-account suggestion uses the rule-suggest CIB class', function () {
+    createSuggestion($this, 'primary', primaryAccountPayload($this->account->id));
+
+    Livewire::actingAs($this->user)
+        ->test(AnalysisSuggestions::class)
+        ->assertSeeHtml('class="rule-suggest')
+        ->assertSee('Primary Account Detected');
+});
+
+test('pay-cycle suggestion uses the rule-suggest CIB class', function () {
+    createSuggestion($this, 'payCycle', payCyclePayload($this->account->id));
+
+    Livewire::actingAs($this->user)
+        ->test(AnalysisSuggestions::class)
+        ->assertSeeHtml('class="rule-suggest')
+        ->assertSee('Pay Cycle Detected');
+});
+
+test('recurring-transaction list wraps in day-card with passive tx-row markup', function () {
+    createSuggestion($this, 'recurring', recurringPayload($this->account->id, [
+        'matched_transaction_ids' => [1, 2, 3],
+    ]));
+
+    $component = Livewire::actingAs($this->user)
+        ->test(AnalysisSuggestions::class);
+
+    $component
+        ->assertSeeHtml('class="day-card')
+        ->assertSeeHtml('class="tx-row')
+        ->assertDontSeeHtml("\$dispatch('edit-transaction'");
+});
+
+test('user-rule list wraps in day-card with passive tx-row markup', function () {
+    $group = UserRuleGroup::factory()->for($this->user)->create();
+    $rule = UserRule::factory()->for($this->user)->for($group, 'group')->create([
+        'name' => 'Categorise Netflix',
+    ]);
+    $transaction = Transaction::factory()->create([
+        'user_id' => $this->user->id,
+        'account_id' => $this->account->id,
+        'description' => 'NETFLIX SUBSCRIPTION',
+    ]);
+
+    createSuggestion($this, 'userRule', userRulePayload(
+        $rule->id,
+        'Categorise Netflix',
+        $transaction->id,
+    ));
+
+    $component = Livewire::actingAs($this->user)
+        ->test(AnalysisSuggestions::class);
+
+    $component
+        ->assertSeeHtml('class="day-card')
+        ->assertSeeHtml('class="tx-row')
+        ->assertDontSeeHtml("\$dispatch('edit-transaction'");
+});
+
 test('displays primary account suggestion with account name', function () {
     createSuggestion($this, 'primary', primaryAccountPayload($this->account->id));
 

--- a/tests/Feature/Livewire/ConnectBankTest.php
+++ b/tests/Feature/Livewire/ConnectBankTest.php
@@ -148,6 +148,90 @@ test('unconnected user sees only the connect button', function () {
         ->assertDontSee('Connection Status');
 });
 
+test('disconnected state renders the cib empty-state primitive', function () {
+    $user = User::factory()->create(['basiq_user_id' => null]);
+
+    fakeBasiqService();
+
+    Livewire::actingAs($user)
+        ->test(ConnectBank::class)
+        ->assertSeeHtml('class="empty-state"')
+        ->assertSee('No bank connected');
+});
+
+test('connected state renders three cib-card wrappers', function () {
+    $user = User::factory()->withBasiq()->create();
+
+    $html = Livewire::actingAs($user)
+        ->test(ConnectBank::class)
+        ->html();
+
+    expect(mb_substr_count($html, 'cib-card'))->toBeGreaterThanOrEqual(3);
+});
+
+test('refresh-counter renders as a neutral stat-pill', function () {
+    $user = User::factory()->withBasiq()->create();
+    BasiqRefreshLog::factory()->count(5)->for($user)->create();
+
+    Livewire::actingAs($user)
+        ->test(ConnectBank::class)
+        ->assertSeeHtml('stat-pill stat-pill-neutral')
+        ->assertSee('5 of 20 refreshes used today');
+});
+
+test('refresh-now CTA uses yellow-on-black pill class with testid', function () {
+    $user = User::factory()->withBasiq()->create();
+
+    $component = Livewire::actingAs($user)->test(ConnectBank::class);
+
+    $component->assertSeeHtml('data-testid="connect-bank-refresh-now"');
+
+    foreach (['bg-cib-yellow-400', 'text-cib-black', 'border-2', 'border-cib-black', 'shadow-pop'] as $class) {
+        $component->assertSeeHtml($class);
+    }
+});
+
+test('refresh history rows render inside day-card containers', function () {
+    $user = User::factory()->withBasiq()->create();
+    BasiqRefreshLog::factory()->completed()->for($user)->create();
+
+    $html = Livewire::actingAs($user)
+        ->test(ConnectBank::class)
+        ->html();
+
+    expect($html)->toContain('class="day-card');
+});
+
+test('successful refresh status renders as income-tone stat-pill', function () {
+    $user = User::factory()->withBasiq()->create();
+    BasiqRefreshLog::factory()->completed()->for($user)->create();
+
+    Livewire::actingAs($user)
+        ->test(ConnectBank::class)
+        ->assertSeeHtml('stat-pill-income')
+        ->assertDontSeeHtml('color="green"');
+});
+
+test('pending refresh status renders as planned-tone stat-pill', function () {
+    $user = User::factory()->withBasiq()->create();
+    BasiqRefreshLog::factory()->for($user)->create();
+
+    Livewire::actingAs($user)
+        ->test(ConnectBank::class)
+        ->assertSeeHtml('stat-pill-planned')
+        ->assertDontSeeHtml('color="yellow"');
+});
+
+test('failed refresh status renders as posted-tone stat-pill', function () {
+    $user = User::factory()->withBasiq()->create();
+    BasiqRefreshLog::factory()->failed()->for($user)->create();
+
+    Livewire::actingAs($user)
+        ->test(ConnectBank::class)
+        ->assertSeeHtml('stat-pill-posted')
+        ->assertDontSeeHtml('color="red"');
+});
+
 test('action defaults to manage for connected users', function () {
     $user = User::factory()->withBasiq()->create();
 

--- a/tests/Feature/View/Components/Cib/TxRowTest.php
+++ b/tests/Feature/View/Components/Cib/TxRowTest.php
@@ -100,3 +100,53 @@ it('JS-encodes occurrenceDate to neutralise apostrophe injection', function () {
         ->not->toContain("'); alert(1)")
         ->toContain('\u0027');
 });
+
+it('renders as a passive div when both transactionId and plannedTransactionId are null', function () {
+    $html = Blade::render(
+        '<x-cib.tx-row :transaction-id="null" :planned-transaction-id="null" name="Foo" :amount="100" />'
+    );
+
+    expect($html)
+        ->toContain('<div')
+        ->not->toContain('<button')
+        ->not->toContain('wire:click')
+        ->toContain('tx-row passive');
+});
+
+it('renders the actions slot inside a tx-actions container', function () {
+    $html = Blade::render(<<<'BLADE'
+        <x-cib.tx-row :transaction-id="null" :planned-transaction-id="null" name="Foo" :amount="100">
+            <x-slot:actions>
+                <span data-testid="accept">Accept</span>
+            </x-slot:actions>
+        </x-cib.tx-row>
+    BLADE);
+
+    expect($html)
+        ->toContain('class="tx-actions"')
+        ->toContain('data-testid="accept"');
+});
+
+it('omits the tx-actions container when no actions slot is supplied', function () {
+    $html = Blade::render(
+        '<x-cib.tx-row :transaction-id="null" :planned-transaction-id="null" name="Foo" :amount="100" />'
+    );
+
+    expect($html)->not->toContain('tx-actions');
+});
+
+it('throws when actions slot is used alongside a transactionId (active mode)', function () {
+    Blade::render(<<<'BLADE'
+        <x-cib.tx-row :transaction-id="1" name="Foo" :amount="100">
+            <x-slot:actions>Accept</x-slot:actions>
+        </x-cib.tx-row>
+    BLADE);
+})->throws(Illuminate\View\ViewException::class, 'actions slot requires passive mode');
+
+it('throws when actions slot is used alongside a plannedTransactionId (planned mode)', function () {
+    Blade::render(<<<'BLADE'
+        <x-cib.tx-row :planned-transaction-id="1" occurrence-date="2026-04-20" name="Foo" :amount="100" tone="plan">
+            <x-slot:actions>Accept</x-slot:actions>
+        </x-cib.tx-row>
+    BLADE);
+})->throws(Illuminate\View\ViewException::class, 'actions slot requires passive mode');


### PR DESCRIPTION
## Summary
- Restyles `/connect-bank` (disconnected empty-state + three connected cards + refresh history) and the inline `analysis-suggestions` component to the CIB neo-brutalist visual language.
- Extends `<x-cib.tx-row>` primitive with a **passive mode** (`<div>`-rendered, no `wire:click`) and an `actions` slot, enabling reuse for non-clickable suggestion-preview rows.
- Extracts a `statPillToneFor(RefreshStatus)` helper on `ConnectBank.php` so the view stays declarative; passes a per-log `statusTones` map to the blade.
- No backend, schema, or queue changes — visual-only ticket.

## Closes
- #213

## Test plan
- [x] `op test.filter TxRow` — 16 passed (+4 new: passive div, no wire:click, actions slot present, omitted by default)
- [x] `op test.filter ConnectBank` — 25 passed (+8 new: empty-state, three `cib-card` wrappers, neutral counter pill, yellow CTA testid + class set, day-card rows, income/planned/posted stat-pill tones)
- [x] `op test.filter AnalysisSuggestions` — 24 passed (+4 new: `.rule-suggest` on primary-account + pay-cycle; `.day-card` + passive `.tx-row` on recurring + user-rule lists)
- [x] Regression: `op test.filter Dashboard CalendarView TransactionList Cib` — 209 passed, no failures
- [x] Full suite `op test` — 1434 passed, 4 skipped (pre-existing)
- [x] `op lint.check` (Pint) — clean across 271 files
- [x] `op analyse` (PHPStan) — no errors
- [ ] Visual diff vs `audit-03-connect-bank-desktop.png` + `audit-07-connect-bank-mobile.png` — pending manual verification

## Notes
- `op mago.lint` shows pre-existing baseline warnings in unrelated files (AccountTest, TransactionListTest); **zero new Mago issues in the files I touched**.
- `<flux:badge color=\"purple\">` retained in user-rule action-type chips — out of scope per issue spec (only list wrapper restructure required).
- Plan: `thoughts/plans/213-restyle-connect-bank-cib.md` (TDD-first, 9 batches). Devlog: `~/ClaudeCodeVault/DevLogs/CanEyeBudget/2026-04-20_ticket-213-connect-bank-cib-restyle.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)