### PR TITLE
feat(#215): restyle /accounts with CIB sec-head + tx-row + yellow pill CTA

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -222,11 +222,16 @@ select:focus[data-flux-control] {
         cursor: pointer;
         width: 100%;
         display: grid;
-        grid-template-columns: 36px 1fr auto;
+        grid-template-columns: 36px 1fr auto auto;
         gap: 12px;
         padding: 10px 4px;
         border-bottom: 1px solid var(--color-border-1);
         align-items: center;
+    }
+    .tx-actions {
+        display: flex;
+        align-items: center;
+        gap: 4px;
     }
     .tx-row:last-child { border-bottom: 0; }
     .tx-row.passive { cursor: default; }
@@ -598,6 +603,88 @@ select:focus[data-flux-control] {
     .stat-pill-buffer-empty { background: var(--color-cib-n-100); }
     .stat-pill-buffer-empty .pill-value { color: var(--color-fg-3); font-weight: 700; font-size: 11px; }
     .stat-pill-neutral      { background: var(--color-cib-n-100); }
+
+    /* Category editor left-panel list row (ticket #215). Shares the
+       visual flavour of .tx-row but renders a plain integer count
+       instead of a MoneyCast-formatted amount. */
+    .cat-list-row {
+        display: grid;
+        grid-template-columns: 1fr auto;
+        align-items: center;
+        gap: 12px;
+        padding: 10px 14px;
+        border-bottom: 2px solid var(--color-border-strong);
+        background: var(--color-bg-surface);
+        cursor: pointer;
+        text-align: left;
+        transition: background 120ms ease;
+    }
+
+    .cat-list-row:last-child {
+        border-bottom: 0;
+    }
+
+    .cat-list-row:hover {
+        background: var(--color-cib-n-50);
+    }
+
+    .cat-list-row.is-active {
+        background: var(--color-cib-yellow-300);
+    }
+
+    .cat-list-row.is-hidden {
+        opacity: 0.5;
+    }
+
+    .cat-list-row .cat-name {
+        font: 600 14px/1.2 var(--font-sans);
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    .cat-list-row .cat-count {
+        font: 900 11px/1 var(--font-display);
+        color: var(--color-fg-3);
+        padding: 4px 8px;
+        background: var(--color-cib-n-100);
+        border-radius: 999px;
+    }
+
+    /* Yellow-on-black CTA pill (ticket #215). Used for primary actions
+       where the default Flux teal variant would break the CIB palette. */
+    .cib-yellow-pill {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        padding: 10px 16px;
+        font: 900 13px/1 var(--font-display);
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        background: var(--color-cib-yellow-400);
+        color: #111;
+        border: 2px solid var(--color-border-strong);
+        border-radius: 999px;
+        box-shadow: var(--shadow-pop-sm);
+        cursor: pointer;
+        transition: transform 120ms ease, box-shadow 120ms ease;
+    }
+
+    .cib-yellow-pill:hover {
+        transform: translate(-1px, -1px);
+        box-shadow: 3px 3px 0 0 var(--color-border-strong);
+    }
+
+    .cib-yellow-pill:active {
+        transform: translate(1px, 1px);
+        box-shadow: 1px 1px 0 0 var(--color-border-strong);
+    }
+
+    .cib-yellow-pill:focus-visible {
+        outline: 2px solid var(--color-cib-yellow-600);
+        outline-offset: 2px;
+    }
 }
 
 /* Flux modal slide-up (Ticket #196). Outside @layer components so it matches

--- a/resources/views/components/cib/sec-head.blade.php
+++ b/resources/views/components/cib/sec-head.blade.php
@@ -8,4 +8,5 @@
     @if ($href)
         <a class="link" href="{{ $href }}">See all →</a>
     @endif
+    {{ $slot }}
 </div>

--- a/resources/views/livewire/account-manager.blade.php
+++ b/resources/views/livewire/account-manager.blade.php
@@ -2,66 +2,78 @@
 <div class="space-y-6">
     <div class="flex items-center justify-between">
         <flux:heading size="xl">{{ __('Accounts') }}</flux:heading>
-        <flux:button variant="primary" icon="plus" wire:click="openAddModal">
+        <button type="button" wire:click="openAddModal" class="cib-yellow-pill">
+            <flux:icon.plus class="size-4"/>
             {{ __('Add Account') }}
-        </flux:button>
+        </button>
     </div>
 
     @forelse($grouped as $groupValue => $accounts)
         @php $groupEnum = AccountGroup::from($groupValue); @endphp
-        <div>
-            <div class="mb-3 flex items-center gap-2">
-                <flux:heading size="lg">{{ $groupEnum->label() }}</flux:heading>
-                <flux:badge size="sm" color="zinc">{{ $accounts->count() }}</flux:badge>
-            </div>
+        <section class="agenda-group">
+            <x-cib.sec-head :title="$groupEnum->label()">
+                <x-cib.stat-pill tone="neutral" :value="(string) $accounts->count()"/>
+            </x-cib.sec-head>
+            <div class="day-card">
+                @foreach($accounts as $account)
+                    @php
+                        $tone = $account->balance < 0 ? 'out' : 'inc';
+                        $metaParts = array_filter([
+                            $account->type->label(),
+                            $account->institution,
+                        ]);
+                        $metaText = implode(' · ', $metaParts);
+                        if ($account->credit_limit !== null) {
+                            $metaText = trim(($metaText ? $metaText.' · ' : '').'Limit '.$formatMoney($account->credit_limit));
+                        }
+                    @endphp
+                    <x-cib.tx-row
+                            wire:key="account-{{ $account->id }}"
+                            :name="$account->name"
+                            :amount="$account->balance"
+                            :tone="$tone"
+                            :icon="$account->type->icon()"
+                    >
+                        @if($metaText)
+                            <x-slot:meta>{{ $metaText }}</x-slot:meta>
+                        @endif
+                        <x-slot:actions>
+                            <div class="hidden items-center gap-1 md:flex">
+                                <flux:button variant="ghost" size="sm" icon="pencil" wire:click="openEditModal({{ $account->id }})"/>
+                                <flux:button variant="ghost" size="sm" icon="trash" wire:click="confirmDelete({{ $account->id }})"
+                                             class="text-red-500 hover:text-red-600"/>
+                            </div>
 
-            <div class="rounded-xl border border-neutral-200 dark:border-neutral-700">
-                <div class="divide-y divide-neutral-200 dark:divide-neutral-700">
-                    @foreach($accounts as $account)
-                        <div wire:key="account-{{ $account->id }}" class="flex items-center justify-between px-4 py-3">
-                            <div class="min-w-0 flex-1">
-                                <div class="flex items-center gap-2">
-                                    <flux:icon :name="$account->type->icon()" class="size-5 shrink-0 text-zinc-400"/>
-                                    <flux:heading size="sm" class="truncate">{{ $account->name }}</flux:heading>
-                                    <flux:badge size="sm" color="zinc">{{ $account->type->label() }}</flux:badge>
-                                </div>
-                                @if($account->institution)
-                                    <flux:text size="sm" class="mt-0.5 pl-7">{{ $account->institution }}</flux:text>
-                                @endif
-                            </div>
-                            <div class="flex items-center gap-4">
-                                <div class="text-right">
-                                    <flux:text class="tabular-nums font-medium {{ $account->balance < 0 ? 'text-red-600 dark:text-red-500' : '' }}">
-                                        {{ $formatMoney($account->balance) }}
-                                    </flux:text>
-                                    @if($account->credit_limit !== null)
-                                        <flux:text size="sm" class="tabular-nums text-zinc-500">
-                                            Limit {{ $formatMoney($account->credit_limit) }}
-                                        </flux:text>
-                                    @endif
-                                </div>
-                                <div class="flex items-center gap-1">
-                                    <flux:button variant="ghost" size="sm" icon="pencil" wire:click="openEditModal({{ $account->id }})"/>
-                                    <flux:button variant="ghost" size="sm" icon="trash" wire:click="confirmDelete({{ $account->id }})"
-                                                 class="text-red-500 hover:text-red-600"/>
-                                </div>
-                            </div>
-                        </div>
-                    @endforeach
-                </div>
+                            <flux:dropdown class="md:hidden" align="end">
+                                <flux:button variant="ghost" size="sm" icon="ellipsis-vertical" :aria-label="__('Account actions')"/>
+
+                                <flux:menu>
+                                    <flux:menu.item icon="pencil" wire:click="openEditModal({{ $account->id }})">
+                                        {{ __('Edit') }}
+                                    </flux:menu.item>
+                                    <flux:menu.item icon="trash" variant="danger" wire:click="confirmDelete({{ $account->id }})">
+                                        {{ __('Delete') }}
+                                    </flux:menu.item>
+                                </flux:menu>
+                            </flux:dropdown>
+                        </x-slot:actions>
+                    </x-cib.tx-row>
+                @endforeach
             </div>
-        </div>
+        </section>
     @empty
-        <flux:card class="p-8 text-center">
-            <flux:icon.building-library class="mx-auto size-12 text-zinc-400"/>
-            <flux:heading size="lg" class="mt-4">{{ __('No accounts yet') }}</flux:heading>
-            <flux:text class="mt-2">{{ __('Add your first account to start tracking your finances.') }}</flux:text>
-            <div class="mt-6">
-                <flux:button variant="primary" icon="plus" wire:click="openAddModal">
+        <x-cib.empty-state
+                icon="building-library"
+                :title="__('No accounts yet')"
+                :description="__('Add your first account to start tracking your finances.')"
+        >
+            <x-slot:action>
+                <button type="button" wire:click="openAddModal" class="cib-yellow-pill">
+                    <flux:icon.plus class="size-4"/>
                     {{ __('Add Account') }}
-                </flux:button>
-            </div>
-        </flux:card>
+                </button>
+            </x-slot:action>
+        </x-cib.empty-state>
     @endforelse
 
     <flux:modal wire:model="showFormModal" class="md:w-lg">
@@ -75,21 +87,27 @@
                 </flux:text>
             </div>
 
-            <flux:input
-                    wire:model="name"
-                    :label="__('Name')"
-                    placeholder="e.g. Everyday Account"
-                    required
-            />
+            <div>
+                <label class="cib-label" for="account-name">{{ __('Name') }}</label>
+                <flux:input
+                        id="account-name"
+                        wire:model="name"
+                        placeholder="e.g. Everyday Account"
+                        required
+                />
+            </div>
 
-            <flux:input
-                    wire:model="balance"
-                    :label="__('Current Balance')"
-                    type="number"
-                    step="0.01"
-                    placeholder="0.00"
-                    required
-            />
+            <div>
+                <label class="cib-label" for="account-balance">{{ __('Current Balance') }}</label>
+                <flux:input
+                        id="account-balance"
+                        wire:model="balance"
+                        type="number"
+                        step="0.01"
+                        placeholder="0.00"
+                        required
+                />
+            </div>
 
             <flux:field variant="inline">
                 <flux:checkbox wire:model.live="hasCreditLimit"/>
@@ -109,30 +127,42 @@
                 />
             @endif
 
-            <flux:textarea
-                    wire:model="description"
-                    :label="__('Description')"
-                    placeholder="{{ __('Optional description') }}"
-                    rows="2"
-            />
+            <div>
+                <label class="cib-label" for="account-description">{{ __('Description') }}</label>
+                <flux:textarea
+                        id="account-description"
+                        wire:model="description"
+                        placeholder="{{ __('Optional description') }}"
+                        rows="2"
+                />
+            </div>
 
-            <flux:select wire:model="type" :label="__('Account Type')" required>
-                @foreach($accountTypes as $accountType)
-                    <flux:select.option value="{{ $accountType->value }}">{{ $accountType->label() }}</flux:select.option>
-                @endforeach
-            </flux:select>
+            <div>
+                <label class="cib-label" for="account-type">{{ __('Account Type') }}</label>
+                <flux:select id="account-type" wire:model="type" required>
+                    @foreach($accountTypes as $accountType)
+                        <flux:select.option value="{{ $accountType->value }}">{{ $accountType->label() }}</flux:select.option>
+                    @endforeach
+                </flux:select>
+            </div>
 
-            <flux:select wire:model="group" :label="__('Account Group')" required>
-                @foreach($accountGroups as $accountGroup)
-                    <flux:select.option value="{{ $accountGroup->value }}">{{ $accountGroup->label() }}</flux:select.option>
-                @endforeach
-            </flux:select>
+            <div>
+                <label class="cib-label" for="account-group">{{ __('Account Group') }}</label>
+                <flux:select id="account-group" wire:model="group" required>
+                    @foreach($accountGroups as $accountGroup)
+                        <flux:select.option value="{{ $accountGroup->value }}">{{ $accountGroup->label() }}</flux:select.option>
+                    @endforeach
+                </flux:select>
+            </div>
 
-            <flux:input
-                    wire:model="institution"
-                    :label="__('Institution')"
-                    placeholder="e.g. Commonwealth Bank"
-            />
+            <div>
+                <label class="cib-label" for="account-institution">{{ __('Institution') }}</label>
+                <flux:input
+                        id="account-institution"
+                        wire:model="institution"
+                        placeholder="e.g. Commonwealth Bank"
+                />
+            </div>
 
             <div class="flex">
                 <flux:spacer/>
@@ -171,9 +201,11 @@
         </div>
     </flux:modal>
 
-    <flux:modal.trigger name="category-editor">
-        <flux:button variant="ghost" icon="tag" class="w-full">
-            {{ __('Manage Categories') }}
-        </flux:button>
-    </flux:modal.trigger>
+    <x-cib.card>
+        <flux:modal.trigger name="category-editor">
+            <flux:button variant="ghost" icon="tag" class="w-full">
+                {{ __('Manage Categories') }}
+            </flux:button>
+        </flux:modal.trigger>
+    </x-cib.card>
 </div>

--- a/resources/views/livewire/category-editor.blade.php
+++ b/resources/views/livewire/category-editor.blade.php
@@ -14,23 +14,25 @@
                         <flux:label>{{ __('Show hidden') }}</flux:label>
                     </flux:field>
 
-                    <div class="flex-1 overflow-y-auto rounded-lg border border-neutral-200 dark:border-neutral-700">
-                        <div class="divide-y divide-neutral-200 dark:divide-neutral-700">
-                            @forelse($categories as $category)
-                                <button
-                                        wire:key="cat-{{ $category['id'] }}"
-                                        wire:click="selectCategory({{ $category['id'] }})"
-                                        class="flex w-full items-center justify-between px-3 py-2 text-left text-sm transition hover:bg-zinc-50 dark:hover:bg-zinc-800 {{ $selectedCategoryId === $category['id'] ? 'bg-amber-50 dark:bg-amber-900/20' : '' }} {{ $category['is_hidden'] ? 'opacity-50' : '' }}"
-                                >
-                                    <span class="min-w-0 truncate">{{ $category['full_path'] }}</span>
-                                    <flux:badge size="sm" color="zinc" class="ml-2 shrink-0">{{ $category['transactions_count'] }}</flux:badge>
-                                </button>
-                            @empty
-                                <div class="p-4 text-center">
-                                    <flux:text size="sm">{{ __('No categories found.') }}</flux:text>
-                                </div>
-                            @endforelse
-                        </div>
+                    <div class="flex-1 overflow-y-auto">
+                        @forelse($categories as $category)
+                            <button
+                                    wire:key="cat-{{ $category['id'] }}"
+                                    wire:click="selectCategory({{ $category['id'] }})"
+                                    @class([
+                                        'cat-list-row w-full',
+                                        'is-active' => $selectedCategoryId === $category['id'],
+                                        'is-hidden' => $category['is_hidden'],
+                                    ])
+                            >
+                                <span class="cat-name">{{ $category['full_path'] }}</span>
+                                <span class="cat-count">{{ $category['transactions_count'] }}</span>
+                            </button>
+                        @empty
+                            <div class="p-4 text-center">
+                                <flux:text size="sm">{{ __('No categories found.') }}</flux:text>
+                            </div>
+                        @endforelse
                     </div>
 
                     @if($showCreateForm)
@@ -57,8 +59,11 @@
                 {{-- Right Panel: Category Detail & Transactions --}}
                 <div class="flex w-3/5 flex-col">
                     @if($selectedCategoryId)
-                        <div class="mb-4 flex items-center gap-2">
-                            <flux:input wire:model="editingName" size="sm" class="flex-1"/>
+                        <div class="mb-4 flex items-end gap-2">
+                            <div class="flex-1">
+                                <label class="cib-label" for="category-name-input">{{ __('Category name') }}</label>
+                                <flux:input id="category-name-input" wire:model="editingName" size="sm"/>
+                            </div>
                             <flux:button wire:click="saveRename" variant="primary" size="sm">{{ __('Save') }}</flux:button>
                             <flux:button wire:click="toggleHidden({{ $selectedCategoryId }})" variant="ghost" size="sm" icon="eye-slash">
                                 {{ __('Hide') }}

--- a/tests/Feature/Livewire/AccountManagerTest.php
+++ b/tests/Feature/Livewire/AccountManagerTest.php
@@ -293,3 +293,105 @@ test('institution is optional when adding account', function () {
 
     expect(Account::query()->where('name', 'No Institution')->first()->institution)->toBeNull();
 });
+
+/* ------------------------------------------------------------------ */
+/*  CIB visual contract (ticket #215) */
+/* ------------------------------------------------------------------ */
+
+test('cib: account group headers render via x-cib.sec-head + neutral x-cib.stat-pill', function () {
+    $user = User::factory()->create();
+    Account::factory()->for($user)->count(2)->create(['group' => AccountGroup::DayToDay]);
+    Account::factory()->for($user)->longTermSavings()->create();
+
+    Livewire::actingAs($user)
+        ->test(AccountManager::class)
+        ->assertSeeHtml('class="sec-head')
+        ->assertSeeHtml('stat-pill-neutral')
+        ->assertSee('Day to Day')
+        ->assertSee('Long Term Savings');
+});
+
+test('cib: account rows render via passive x-cib.tx-row with tone icon meta and amount', function () {
+    $user = User::factory()->create();
+
+    Account::factory()->for($user)->create([
+        'name' => 'Everyday',
+        'type' => AccountClass::Transaction,
+        'balance' => 150050,
+        'institution' => null,
+        'credit_limit' => null,
+    ]);
+    Account::factory()->for($user)->create([
+        'name' => 'Overdraft',
+        'type' => AccountClass::Transaction,
+        'balance' => -4200,
+        'institution' => null,
+        'credit_limit' => null,
+    ]);
+    Account::factory()->for($user)->create([
+        'name' => 'Card',
+        'type' => AccountClass::CreditCard,
+        'balance' => -50000,
+        'credit_limit' => 500000,
+        'institution' => 'Westpac',
+    ]);
+
+    $component = Livewire::actingAs($user)->test(AccountManager::class);
+    $html = $component->html();
+
+    expect(mb_substr_count($html, 'class="tx-row passive'))->toBe(3);
+
+    $component
+        ->assertSeeHtml('class="tx-amt inc"')
+        ->assertSeeHtml('class="tx-amt out"')
+        ->assertSeeHtml('class="tx-meta"')
+        ->assertSee('Limit $5,000.00');
+
+    expect($html)->not->toContain('text-red-600 dark:text-red-500');
+});
+
+test('cib: empty state renders via x-cib.empty-state with yellow-on-black cta', function () {
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(AccountManager::class)
+        ->assertSeeHtml('class="empty-state')
+        ->assertSeeHtml('class="empty-state-action')
+        ->assertSee('No accounts yet')
+        ->assertSeeHtml('cib-yellow-pill');
+});
+
+test('cib: primary add account cta uses yellow-on-black pill not flux primary', function () {
+    $user = User::factory()->create();
+    Account::factory()->for($user)->create();
+
+    $component = Livewire::actingAs($user)->test(AccountManager::class);
+    $html = $component->html();
+
+    $component->assertSeeHtml('cib-yellow-pill');
+
+    expect($html)->not->toMatch('/variant="primary"[^>]*wire:click="openAddModal"/');
+});
+
+test('cib: manage categories trigger sits inside a cib-card', function () {
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(AccountManager::class)
+        ->assertSeeHtml('class="cib-card')
+        ->assertSee('Manage Categories');
+});
+
+test('cib: add account modal labels render as cib-label spans', function () {
+    $user = User::factory()->create();
+
+    $component = Livewire::actingAs($user)
+        ->test(AccountManager::class)
+        ->call('openAddModal');
+
+    $html = $component->html();
+
+    expect(mb_substr_count($html, 'class="cib-label'))->toBeGreaterThanOrEqual(5);
+
+    $component->assertSeeHtml('wire:model="name"');
+});

--- a/tests/Feature/Livewire/CategoryEditorTest.php
+++ b/tests/Feature/Livewire/CategoryEditorTest.php
@@ -5,6 +5,7 @@
 declare(strict_types=1);
 
 use App\Livewire\CategoryEditor;
+use App\Models\Account;
 use App\Models\Category;
 use App\Models\Transaction;
 use App\Models\User;
@@ -264,4 +265,41 @@ test('categories sorted by transaction count descending', function () {
     $categories = $component->viewData('categories');
     expect($categories->first()['name'])->toBe('Many')
         ->and($categories->last()['name'])->toBe('Few');
+});
+
+/* ------------------------------------------------------------------ */
+/*  CIB visual contract (ticket #215) */
+/* ------------------------------------------------------------------ */
+
+test('cib: category list rows use cat-list-row markup', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $groceries = Category::factory()->create(['name' => 'Groceries']);
+    $bills = Category::factory()->create(['name' => 'Bills']);
+    Transaction::factory()->for($user)->for($account)->count(3)->create(['category_id' => $groceries->id]);
+    Transaction::factory()->for($user)->for($account)->count(5)->create(['category_id' => $bills->id]);
+
+    $component = Livewire::actingAs($user)->test(CategoryEditor::class);
+    $html = $component->html();
+
+    expect(mb_substr_count($html, 'class="cat-list-row'))->toBeGreaterThanOrEqual(2);
+
+    $component
+        ->assertSee('Groceries')
+        ->assertSee('Bills')
+        ->assertSeeHtml('<span class="cat-count">3</span>')
+        ->assertSeeHtml('<span class="cat-count">5</span>');
+
+    expect($html)->not->toContain('rounded-lg border border-neutral-200 dark:border-neutral-700');
+});
+
+test('cib: rename field label renders as cib-label span', function () {
+    $user = User::factory()->create();
+    $category = Category::factory()->create(['name' => 'Utilities']);
+
+    $component = Livewire::actingAs($user)
+        ->test(CategoryEditor::class)
+        ->call('selectCategory', $category->id);
+
+    $component->assertSeeHtml('class="cib-label');
 });


### PR DESCRIPTION
## Summary
- Restyles `/accounts` to the CIB neo-brutalist language: group headers use `<x-cib.sec-head>` + neutral `<x-cib.stat-pill>`, rows render through the **passive** `<x-cib.tx-row>` primitive with a `$meta` slot for credit-limit text and a `$actions` slot housing a responsive desktop icon cluster + mobile `<flux:dropdown>` kebab, empty state uses `<x-cib.empty-state>` with the new `.cib-yellow-pill` CTA utility, "Manage Categories" is wrapped in `<x-cib.card>`, and add/edit modal form labels switch to external `.cib-label` spans.
- Polishes the Category Editor modal — left-panel rows adopt a new `.cat-list-row` class that shares the tx-row visual flavour without clashing with `MoneyCast::format()` (the primitive would have rendered a count of 5 as `$0.05`), and the rename field gets a `.cib-label` span.
- Extends `<x-cib.sec-head>` with a trailing `{{ \$slot }}` — verified all 5 existing consumers are self-closing, so the change is backward-compatible.
- TDD-first: 8 new `cib:`-prefixed assertions proven RED before implementation; 40-test baseline stayed green throughout.

## Closes
- #215

## Test plan
- [x] `op test.filter AccountManager` — 26 green (20 baseline + 6 new)
- [x] `op test.filter CategoryEditor` — 22 green (20 baseline + 2 new)
- [x] `op test.filter Cib` — 103 green (primitives regression)
- [x] `op test.filter TransactionList` — 66 green (tx-row consumer regression)
- [x] `op test.filter CalendarView` — 48 green (+1 skipped)
- [x] `op test.filter Dashboard` — 26 green
- [x] `op test.filter ConnectBank` — 25 green
- [x] `op lint.dirty` — pass
- [x] `op ci` — Laravel 271 files pass; static-analysis errors unchanged from baseline (all pre-existing)
- [ ] Playwright visual diff on desktop 1280×900 + mobile 375×812 — deferred to Ticket 6 (#217) sweep

## Notes
- **Passive tx-row choice**: the primitive throws `InvalidArgumentException` if an `\$actions` slot is passed alongside a non-null `transactionId`. Accounts aren't transactions, so omitting `:transaction-id` triggers passive mode and unlocks the actions slot.
- **`.cib-yellow-pill` as shared utility**: Ticket 5 (#216 `/rules`) should reuse rather than re-roll.
- **In-body "Accounts" `<flux:heading>` intentionally stays** — Ticket 6 (#217) deletes all duplicated body titles.
- Part of epic #211.

🤖 Generated with [Claude Code](https://claude.com/claude-code)