### PR TITLE
feat: [#229] Pay cycle calendar + 12-month projection

### DIFF
--- a/app/Livewire/Dashboard.php
+++ b/app/Livewire/Dashboard.php
@@ -75,19 +75,6 @@ final class Dashboard extends Component
         ];
     }
 
-    /** @return Collection<int, Transaction> */
-    #[Computed]
-    public function recentTransactions(): Collection
-    {
-        return auth()->user()
-            ->transactions()
-            ->current()
-            ->with(['account', 'category.parent.parent'])
-            ->latest('post_date')
-            ->limit(5)
-            ->get();
-    }
-
     /**
      * @return Collection<int, array{budget: Budget, spent: int, limit: int}>
      */

--- a/app/Livewire/Dashboard/Data/PayCycleDayData.php
+++ b/app/Livewire/Dashboard/Data/PayCycleDayData.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Dashboard\Data;
+
+final readonly class PayCycleDayData
+{
+    /**
+     * @param  list<PayCyclePip>  $pips  Full unsliced pip list for the day; the grid view slices for display, the detail panel uses the complete list.
+     */
+    public function __construct(
+        public string $iso,
+        public int $day,
+        public string $dayName,
+        public bool $isToday,
+        public bool $isCycleStart,
+        public bool $isCycleEnd,
+        public bool $isPast,
+        public array $pips,
+        public int $hiddenCount,
+        public int $netCents,
+        public int $incomeCents,
+        public int $postedCents,
+        public int $plannedCents,
+    ) {}
+}

--- a/app/Livewire/Dashboard/Data/PayCyclePip.php
+++ b/app/Livewire/Dashboard/Data/PayCyclePip.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Dashboard\Data;
+
+final readonly class PayCyclePip
+{
+    public function __construct(
+        public string $kind,
+        public string $name,
+        public int $amount,
+        public ?string $icon,
+        public ?int $transactionId,
+        public ?int $plannedTransactionId,
+        public ?string $occurrenceDate,
+    ) {}
+}

--- a/app/Livewire/Dashboard/MonthlyProjection.php
+++ b/app/Livewire/Dashboard/MonthlyProjection.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Dashboard;
+
+use App\Casts\MoneyCast;
+use App\Services\Projection\MonthlyProjectionService;
+use App\Services\Projection\ProjectedMonth;
+use Illuminate\Support\Collection;
+use Illuminate\View\View;
+use Livewire\Attributes\Computed;
+use Livewire\Component;
+
+final class MonthlyProjection extends Component
+{
+    public int $months = 12;
+
+    /**
+     * @return Collection<int, ProjectedMonth>
+     */
+    #[Computed]
+    public function projection(): Collection
+    {
+        $user = auth()->user();
+
+        if ($user === null) {
+            /** @var Collection<int, ProjectedMonth> */
+            return collect();
+        }
+
+        return app(MonthlyProjectionService::class)->forUser($user, $this->months);
+    }
+
+    #[Computed]
+    public function firstRiskyMonth(): ?ProjectedMonth
+    {
+        return $this->projection->first(static fn (ProjectedMonth $month) => $month->isRisky()); // @phpstan-ignore property.notFound
+    }
+
+    /**
+     * @return array{categories: list<string>, income: list<int>, expense: list<int>, cumulative: list<int>, riskyIndexes: list<int>, oneOffs: list<array{x: string, label: string, amountCents: int}>}
+     */
+    #[Computed]
+    public function chartPayload(): array
+    {
+        $categories = [];
+        $income = [];
+        $expense = [];
+        $cumulative = [];
+        $riskyIndexes = [];
+        $oneOffs = [];
+
+        foreach ($this->projection as $month) { // @phpstan-ignore property.notFound
+            $label = $month->isYearStart && $month->monthIndex !== 0
+                ? sprintf('%s %d', $month->label, $month->year)
+                : $month->label;
+
+            $categories[] = $label;
+            $income[] = $month->incomeCents;
+            $expense[] = $month->expenseCents;
+            $cumulative[] = $month->cumulativeNetCents;
+
+            if ($month->isRisky()) {
+                $riskyIndexes[] = $month->monthIndex;
+            }
+
+            foreach ($month->oneOffs as $oneOff) {
+                $oneOffs[] = [
+                    'x' => $label,
+                    'label' => $oneOff->description,
+                    'amountCents' => $oneOff->amountCents,
+                ];
+            }
+        }
+
+        return [
+            'categories' => $categories,
+            'income' => $income,
+            'expense' => $expense,
+            'cumulative' => $cumulative,
+            'riskyIndexes' => $riskyIndexes,
+            'oneOffs' => $oneOffs,
+        ];
+    }
+
+    public function placeholder(): string
+    {
+        return <<<'HTML'
+            <section class="monthly-projection">
+                <div class="animate-pulse h-6 w-56 rounded bg-(--color-cib-n-100)"></div>
+                <div class="animate-pulse h-64 mt-4 rounded bg-(--color-cib-n-100)"></div>
+            </section>
+            HTML;
+    }
+
+    public function render(): View
+    {
+        return view('livewire.dashboard.monthly-projection', [
+            'formatMoney' => MoneyCast::format(...),
+        ]);
+    }
+}

--- a/app/Livewire/Dashboard/PayCycleCalendar.php
+++ b/app/Livewire/Dashboard/PayCycleCalendar.php
@@ -1,0 +1,353 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Dashboard;
+
+use App\Casts\MoneyCast;
+use App\Enums\PayFrequency;
+use App\Enums\TransactionDirection;
+use App\Livewire\Dashboard\Data\PayCycleDayData;
+use App\Livewire\Dashboard\Data\PayCyclePip;
+use App\Models\PlannedTransaction;
+use App\Models\Transaction;
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Collection;
+use Illuminate\View\View;
+use Livewire\Attributes\Computed;
+use Livewire\Component;
+
+final class PayCycleCalendar extends Component
+{
+    public const int MAX_PIPS_PER_DAY = 3;
+
+    public int $cycleOffset = 0;
+
+    public ?string $selectedDate = null;
+
+    public function previousCycle(): void
+    {
+        $this->cycleOffset--;
+        $this->bustCache();
+    }
+
+    public function nextCycle(): void
+    {
+        $this->cycleOffset++;
+        $this->bustCache();
+    }
+
+    public function goToCurrentCycle(): void
+    {
+        $this->cycleOffset = 0;
+        $this->selectedDate = CarbonImmutable::today()->format('Y-m-d');
+        $this->bustCache();
+    }
+
+    public function selectDay(string $iso): void
+    {
+        $parsed = CarbonImmutable::createFromFormat('Y-m-d', $iso);
+
+        $this->selectedDate = $parsed instanceof CarbonImmutable
+            ? $parsed->format('Y-m-d')
+            : null;
+
+        unset($this->selectedDay); // @phpstan-ignore property.notFound
+    }
+
+    /**
+     * @return array{start: CarbonImmutable, end: CarbonImmutable}|null
+     */
+    #[Computed]
+    public function bounds(): ?array
+    {
+        $user = auth()->user();
+
+        if ($user === null || ! $user->hasPayCycleConfigured()) {
+            return null;
+        }
+
+        $base = $user->currentPayCycleBounds();
+
+        if ($base === null) {
+            return null;
+        }
+
+        if ($this->cycleOffset === 0) {
+            return $base;
+        }
+
+        $frequency = $user->pay_frequency;
+
+        return match ($frequency) {
+            PayFrequency::Weekly => [
+                'start' => $base['start']->addDays(7 * $this->cycleOffset),
+                'end' => $base['end']->addDays(7 * $this->cycleOffset),
+            ],
+            PayFrequency::Fortnightly => [
+                'start' => $base['start']->addDays(14 * $this->cycleOffset),
+                'end' => $base['end']->addDays(14 * $this->cycleOffset),
+            ],
+            PayFrequency::Monthly => [
+                'start' => $base['start']->addMonthsNoOverflow($this->cycleOffset),
+                'end' => $base['end']->addMonthsNoOverflow($this->cycleOffset),
+            ],
+            null => null,
+        };
+    }
+
+    /**
+     * @return list<PayCycleDayData>
+     */
+    #[Computed]
+    public function days(): array
+    {
+        $bounds = $this->bounds; // @phpstan-ignore property.notFound
+
+        if ($bounds === null) {
+            return [];
+        }
+
+        $today = CarbonImmutable::today();
+        $cycleStart = $bounds['start'];
+        $cycleEndPayday = $bounds['end'];
+        $lastRenderedDay = $cycleEndPayday->subDay();
+
+        $userId = (int) auth()->id();
+
+        $transactions = Transaction::query()
+            ->where('user_id', $userId)
+            ->current()
+            ->excludingTransfers()
+            ->whereBetween('post_date', [$cycleStart, $lastRenderedDay])
+            ->with([
+                'category:id,name,icon,parent_id',
+                'category.parent:id,icon,parent_id',
+                'category.parent.parent:id,icon,parent_id',
+            ])
+            ->orderBy('post_date')
+            ->get();
+
+        $plannedTransactions = PlannedTransaction::query()
+            ->where('user_id', $userId)
+            ->where('is_active', true)
+            ->excludingTransfers()
+            ->where('start_date', '<=', $lastRenderedDay)
+            ->where(static fn ($q) => $q->whereNull('until_date')->orWhere('until_date', '>=', $cycleStart))
+            ->with([
+                'category:id,name,icon,parent_id',
+                'category.parent:id,icon,parent_id',
+                'category.parent.parent:id,icon,parent_id',
+            ])
+            ->get();
+
+        /** @var Collection<string, Collection<int, Transaction>> $txByDate */
+        $txByDate = $transactions->groupBy(static fn (Transaction $t) => $t->post_date->format('Y-m-d'));
+
+        /** @var array<string, list<PayCyclePip>> $plannedByDate */
+        $plannedByDate = [];
+
+        foreach ($plannedTransactions as $planned) {
+            foreach ($planned->occurrencesBetween($cycleStart, $lastRenderedDay) as $occurrence) {
+                $key = $occurrence->format('Y-m-d');
+                $plannedByDate[$key] ??= [];
+                $plannedByDate[$key][] = new PayCyclePip(
+                    kind: 'plan',
+                    name: $planned->category?->name ?? $planned->description, // @phpstan-ignore nullsafe.neverNull
+                    amount: abs((int) $planned->amount),
+                    icon: $planned->category?->resolveIcon(),
+                    transactionId: null,
+                    plannedTransactionId: $planned->id,
+                    occurrenceDate: $key,
+                );
+            }
+        }
+
+        $days = [];
+        $cursor = $cycleStart;
+
+        while ($cursor->lessThanOrEqualTo($lastRenderedDay)) {
+            $key = $cursor->format('Y-m-d');
+            $dayPips = [];
+            $incomeCents = 0;
+            $postedCents = 0;
+            $plannedCents = 0;
+
+            /** @var Collection<int, Transaction> $dayTxns */
+            $dayTxns = $txByDate->get($key, collect());
+
+            foreach ($dayTxns as $tx) {
+                $absAmount = abs((int) $tx->amount);
+                $isCredit = $tx->direction === TransactionDirection::Credit;
+
+                if ($isCredit) {
+                    $incomeCents += $absAmount;
+                }
+
+                if (! $isCredit) {
+                    $postedCents += $absAmount;
+                }
+
+                $dayPips[] = new PayCyclePip(
+                    kind: $tx->direction === TransactionDirection::Credit ? 'inc' : 'out',
+                    name: $tx->category?->name ?? ($tx->description !== '' ? $tx->description : 'Transaction'), // @phpstan-ignore nullsafe.neverNull
+                    amount: $absAmount,
+                    icon: $tx->category?->resolveIcon(),
+                    transactionId: $tx->id,
+                    plannedTransactionId: null,
+                    occurrenceDate: null,
+                );
+            }
+
+            foreach ($plannedByDate[$key] ?? [] as $plannedPip) {
+                $plannedCents += $plannedPip->amount;
+                $dayPips[] = $plannedPip;
+            }
+
+            usort(
+                $dayPips,
+                static fn (PayCyclePip $a, PayCyclePip $b): int => $b->amount <=> $a->amount,
+            );
+
+            $hiddenCount = max(0, count($dayPips) - self::MAX_PIPS_PER_DAY);
+
+            $days[] = new PayCycleDayData(
+                iso: $key,
+                day: $cursor->day,
+                dayName: $cursor->format('D'),
+                isToday: $cursor->isSameDay($today),
+                isCycleStart: $cursor->isSameDay($cycleStart),
+                isCycleEnd: $cursor->isSameDay($lastRenderedDay),
+                isPast: $cursor->lessThan($today),
+                pips: $dayPips,
+                hiddenCount: $hiddenCount,
+                netCents: $incomeCents - $postedCents,
+                incomeCents: $incomeCents,
+                postedCents: $postedCents,
+                plannedCents: $plannedCents,
+            );
+
+            $cursor = $cursor->addDay();
+        }
+
+        return $days;
+    }
+
+    /**
+     * @return array{income: int, posted: int, planned: int, net: int}
+     */
+    #[Computed]
+    public function totals(): array
+    {
+        $income = 0;
+        $posted = 0;
+        $planned = 0;
+
+        foreach ($this->days as $day) { // @phpstan-ignore property.notFound
+            $income += $day->incomeCents;
+            $posted += $day->postedCents;
+            $planned += $day->plannedCents;
+        }
+
+        return [
+            'income' => $income,
+            'posted' => $posted,
+            'planned' => $planned,
+            'net' => $income - $posted,
+        ];
+    }
+
+    #[Computed]
+    public function isCurrentCycle(): bool
+    {
+        return $this->cycleOffset === 0;
+    }
+
+    /**
+     * @return array{iso: string, dayLabel: string, dateLabel: string, pips: list<PayCyclePip>, netCents: int, isToday: bool, isCycleEnd: bool}|null
+     */
+    #[Computed]
+    public function selectedDay(): ?array
+    {
+        if ($this->selectedDate === null) {
+            return null;
+        }
+
+        foreach ($this->days as $day) { // @phpstan-ignore property.notFound
+            if ($day->iso !== $this->selectedDate) {
+                continue;
+            }
+
+            $parsed = CarbonImmutable::createFromFormat('Y-m-d', $day->iso);
+
+            if (! $parsed instanceof CarbonImmutable) {
+                return null;
+            }
+
+            return [
+                'iso' => $day->iso,
+                'dayLabel' => $parsed->format('l'),
+                'dateLabel' => $parsed->format('j F'),
+                'pips' => $day->pips,
+                'netCents' => $day->netCents,
+                'isToday' => $day->isToday,
+                'isCycleEnd' => $day->isCycleEnd,
+            ];
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array{rangeLabel: string, daysUntilPay: int|null}
+     */
+    #[Computed]
+    public function header(): array
+    {
+        $bounds = $this->bounds; // @phpstan-ignore property.notFound
+
+        if ($bounds === null) {
+            return ['rangeLabel' => '', 'daysUntilPay' => null];
+        }
+
+        $today = CarbonImmutable::today();
+        $end = $bounds['end'];
+
+        return [
+            'rangeLabel' => sprintf(
+                '%s → %s',
+                $bounds['start']->format('j M'),
+                $end->format('j M'),
+            ),
+            'daysUntilPay' => $this->cycleOffset === 0
+                ? max(0, (int) $today->diffInDays($end, false))
+                : null,
+        ];
+    }
+
+    public function placeholder(): string
+    {
+        return <<<'HTML'
+            <section class="pay-cycle-cal placeholder">
+                <div class="animate-pulse h-6 w-48 rounded bg-(--color-cib-n-100)"></div>
+                <div class="mt-3 grid grid-cols-7 gap-1">
+                    @for ($i = 0; $i < 14; $i++)
+                        <div class="animate-pulse h-20 rounded bg-(--color-cib-n-100)"></div>
+                    @endfor
+                </div>
+            </section>
+            HTML;
+    }
+
+    public function render(): View
+    {
+        return view('livewire.dashboard.pay-cycle-calendar', [
+            'formatMoney' => MoneyCast::format(...),
+        ]);
+    }
+
+    private function bustCache(): void
+    {
+        unset($this->bounds, $this->days, $this->totals, $this->selectedDay, $this->isCurrentCycle, $this->header); // @phpstan-ignore property.notFound
+    }
+}

--- a/app/Services/Projection/MonthlyProjectionService.php
+++ b/app/Services/Projection/MonthlyProjectionService.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Projection;
+
+use App\Enums\PayFrequency;
+use App\Enums\RecurrenceFrequency;
+use App\Enums\TransactionDirection;
+use App\Models\PlannedTransaction;
+use App\Models\User;
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Collection;
+
+final readonly class MonthlyProjectionService
+{
+    private const int ONE_OFF_THRESHOLD_CENTS = 20000;
+
+    private const float ONE_OFF_PAY_RATIO = 0.25;
+
+    /**
+     * @return Collection<int, ProjectedMonth>
+     */
+    public function forUser(User $user, int $months = 12, bool $includeHistoricalBaseline = false): Collection
+    {
+        if (! $user->hasPayCycleConfigured()) {
+            /** @var Collection<int, ProjectedMonth> */
+            return collect();
+        }
+
+        $perMonthIncomeCents = $this->smoothedMonthlyIncomeCents($user);
+        $oneOffThresholdCents = $this->oneOffThresholdCents($user);
+
+        $plannedTransactions = PlannedTransaction::query()
+            ->where('user_id', $user->id)
+            ->where('is_active', true)
+            ->excludingTransfers()
+            ->get();
+
+        $startMonth = CarbonImmutable::today()->startOfMonth();
+        $cumulativeNetCents = 0;
+        $projectedMonths = [];
+
+        for ($i = 0; $i < $months; $i++) {
+            $monthStart = $startMonth->addMonthsNoOverflow($i);
+            $monthEnd = $monthStart->endOfMonth();
+
+            $expenseCents = 0;
+            $incomeCents = $perMonthIncomeCents;
+            $oneOffs = [];
+
+            foreach ($plannedTransactions as $planned) {
+                $occurrences = $planned->occurrencesBetween($monthStart, $monthEnd);
+
+                if ($occurrences->isEmpty()) {
+                    continue;
+                }
+
+                $absAmount = abs((int) $planned->amount);
+                $totalForMonth = $occurrences->count() * $absAmount;
+
+                if ($planned->direction === TransactionDirection::Credit) {
+                    $incomeCents += $totalForMonth;
+
+                    continue;
+                }
+
+                $expenseCents += $totalForMonth;
+
+                if ($planned->frequency === RecurrenceFrequency::DontRepeat
+                    && $absAmount >= $oneOffThresholdCents) {
+                    $first = $occurrences->first();
+                    $oneOffs[] = new ProjectedOneOff(
+                        plannedTransactionId: $planned->id,
+                        description: $planned->description,
+                        amountCents: $absAmount,
+                        occursOn: $first,
+                    );
+                }
+            }
+
+            $netCents = $incomeCents - $expenseCents;
+            $cumulativeNetCents += $netCents;
+
+            $projectedMonths[] = new ProjectedMonth(
+                monthStart: $monthStart,
+                label: $monthStart->format('M'),
+                year: $monthStart->year,
+                monthIndex: $i,
+                incomeCents: $incomeCents,
+                expenseCents: $expenseCents,
+                netCents: $netCents,
+                cumulativeNetCents: $cumulativeNetCents,
+                oneOffs: $oneOffs,
+                isCurrent: $i === 0,
+                isYearStart: $i === 0 || $monthStart->month === 1,
+            );
+        }
+
+        /** @var Collection<int, ProjectedMonth> */
+        return collect($projectedMonths);
+    }
+
+    private function smoothedMonthlyIncomeCents(User $user): int
+    {
+        $payAmount = $user->pay_amount ?? 0;
+
+        return match ($user->pay_frequency) {
+            PayFrequency::Weekly => intdiv($payAmount * 52, 12),
+            PayFrequency::Fortnightly => intdiv($payAmount * 26, 12),
+            PayFrequency::Monthly => $payAmount,
+            null => 0,
+        };
+    }
+
+    private function oneOffThresholdCents(User $user): int
+    {
+        $monthlyIncome = $this->smoothedMonthlyIncomeCents($user);
+        $ratioThreshold = (int) ($monthlyIncome * self::ONE_OFF_PAY_RATIO);
+
+        return min(self::ONE_OFF_THRESHOLD_CENTS, $ratioThreshold > 0 ? $ratioThreshold : self::ONE_OFF_THRESHOLD_CENTS);
+    }
+}

--- a/app/Services/Projection/ProjectedMonth.php
+++ b/app/Services/Projection/ProjectedMonth.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Projection;
+
+use Carbon\CarbonImmutable;
+
+final readonly class ProjectedMonth
+{
+    /**
+     * @param  list<ProjectedOneOff>  $oneOffs
+     */
+    public function __construct(
+        public CarbonImmutable $monthStart,
+        public string $label,
+        public int $year,
+        public int $monthIndex,
+        public int $incomeCents,
+        public int $expenseCents,
+        public int $netCents,
+        public int $cumulativeNetCents,
+        public array $oneOffs,
+        public bool $isCurrent,
+        public bool $isYearStart,
+    ) {}
+
+    public function isRisky(): bool
+    {
+        return $this->expenseCents > $this->incomeCents;
+    }
+}

--- a/app/Services/Projection/ProjectedOneOff.php
+++ b/app/Services/Projection/ProjectedOneOff.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Projection;
+
+use Carbon\CarbonImmutable;
+
+final readonly class ProjectedOneOff
+{
+    public function __construct(
+        public int $plannedTransactionId,
+        public string $description,
+        public int $amountCents,
+        public CarbonImmutable $occursOn,
+    ) {}
+}

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -686,7 +686,7 @@ select:focus[data-flux-control] {
         outline-offset: 2px;
     }
 
-    /* ---------- Pay-cycle calendar widget (Ticket #228) ---------- */
+    /* ---------- Pay-cycle calendar widget (Ticket #230) ---------- */
 
     .pay-cycle-cal { display: flex; flex-direction: column; gap: 14px; }
     .pay-cycle-cal .cyc-empty-link {
@@ -910,7 +910,7 @@ select:focus[data-flux-control] {
         font: 700 13px/1.5 var(--font-sans);
     }
 
-    /* ---------- 12-month projection widget (Ticket #228) ---------- */
+    /* ---------- 12-month projection widget (Ticket #231) ---------- */
 
     .monthly-projection {
         background: var(--color-bg-surface);

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -685,6 +685,306 @@ select:focus[data-flux-control] {
         outline: 2px solid var(--color-cib-yellow-600);
         outline-offset: 2px;
     }
+
+    /* ---------- Pay-cycle calendar widget (Ticket #228) ---------- */
+
+    .pay-cycle-cal { display: flex; flex-direction: column; gap: 14px; }
+    .pay-cycle-cal .cyc-empty-link {
+        color: var(--color-cib-teal-500);
+        text-decoration: underline;
+        font: 700 13px/1 var(--font-sans);
+    }
+    .cyc-head {
+        display: flex;
+        align-items: flex-start;
+        justify-content: space-between;
+        gap: 10px;
+        flex-wrap: wrap;
+    }
+    .cyc-title {
+        font: 900 16px/1 var(--font-display);
+        letter-spacing: -0.01em;
+    }
+    .cyc-sub {
+        font: 700 12px/1.3 var(--font-sans);
+        color: var(--color-fg-3);
+        margin-top: 4px;
+    }
+    .cyc-nav {
+        display: inline-flex;
+        gap: 4px;
+        background: var(--color-bg-surface);
+        border: 2px solid var(--color-border-strong);
+        border-radius: 999px;
+        padding: 3px;
+        box-shadow: var(--shadow-pop-sm);
+    }
+    .cyc-nav button {
+        appearance: none;
+        background: transparent;
+        border: 0;
+        padding: 6px 10px;
+        font: 700 12px/1 var(--font-sans);
+        color: var(--color-fg-1);
+        border-radius: 999px;
+        cursor: pointer;
+    }
+    .cyc-nav button:hover { background: var(--color-cib-n-100); }
+    .cyc-nav button:disabled { opacity: 0.5; cursor: not-allowed; }
+
+    .cyc-grid {
+        background: var(--color-bg-surface);
+        border: 2px solid var(--color-border-strong);
+        border-radius: var(--radius-md);
+        box-shadow: var(--shadow-pop);
+        overflow: hidden;
+    }
+    .cyc-dows {
+        display: grid;
+        grid-template-columns: repeat(7, 1fr);
+        background: var(--color-cib-ink);
+        color: var(--color-cib-white);
+    }
+    .cyc-dow {
+        font: 900 11px/1 var(--font-display);
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        padding: 10px 8px;
+        text-align: center;
+        border-right: 1px solid rgba(255, 255, 255, 0.12);
+    }
+    .cyc-dow:last-child { border-right: 0; }
+    .cyc-week-stream {
+        display: grid;
+        grid-template-columns: repeat(7, 1fr);
+        border-top: 2px solid var(--color-border-strong);
+    }
+    .cyc-day {
+        appearance: none;
+        background: var(--color-bg-surface);
+        border: 0;
+        border-right: 1px solid var(--color-border-1);
+        border-bottom: 1px solid var(--color-border-1);
+        text-align: left;
+        padding: 8px 8px 6px;
+        min-height: 110px;
+        cursor: pointer;
+        display: flex;
+        flex-direction: column;
+        font-family: var(--font-sans), serif;
+        position: relative;
+        transition: background 200ms var(--ease-snap);
+    }
+    .cyc-day:hover { background: var(--color-cib-n-50); }
+    .cyc-day.past { background: var(--color-cib-n-50); }
+    .cyc-day.past:hover { background: var(--color-cib-n-100); }
+    .cyc-day.today { background: var(--color-cib-cream-50); }
+    .cyc-day.today::before {
+        content: '';
+        position: absolute;
+        inset: 0;
+        border: 3px solid var(--color-border-strong);
+        pointer-events: none;
+        z-index: 2;
+    }
+    .cyc-day.payday { background: var(--color-cib-yellow-400); }
+    .cyc-day.lastpay { background: var(--color-money-available-soft); }
+    .cyc-day.active {
+        outline: 3px solid var(--color-cib-teal-500);
+        outline-offset: -3px;
+        z-index: 3;
+    }
+
+    .cyc-day-top {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        margin-bottom: 6px;
+    }
+    .cyc-dnum {
+        font: 900 18px/1 var(--font-display);
+        letter-spacing: -0.01em;
+        color: var(--color-fg-1);
+    }
+    .cyc-today-pill {
+        background: var(--color-cib-ink);
+        color: var(--color-cib-white);
+        font: 900 9px/1 var(--font-display);
+        padding: 3px 6px;
+        border-radius: 999px;
+        letter-spacing: 0.08em;
+    }
+    .cyc-paytag {
+        background: var(--color-cib-ink);
+        color: var(--color-cib-yellow-400);
+        font: 900 9px/1 var(--font-display);
+        padding: 3px 6px;
+        border-radius: 999px;
+        letter-spacing: 0.08em;
+    }
+    .cyc-paytag.dim {
+        background: var(--color-cib-green-600);
+        color: var(--color-cib-white);
+    }
+    .cyc-day-body {
+        display: flex;
+        flex-direction: column;
+        gap: 3px;
+        flex: 1;
+    }
+    .cyc-pip {
+        display: flex;
+        align-items: center;
+        gap: 5px;
+        font: 700 11px/1.2 var(--font-sans);
+        padding: 2px 0;
+        white-space: nowrap;
+        overflow: hidden;
+    }
+    .cyc-pip-dot {
+        width: 6px;
+        height: 6px;
+        border-radius: 50%;
+        flex-shrink: 0;
+    }
+    .cyc-pip.out .cyc-pip-dot { background: var(--color-money-owed); }
+    .cyc-pip.inc .cyc-pip-dot { background: var(--color-cib-green-500); }
+    .cyc-pip.plan .cyc-pip-dot { background: var(--color-money-planned); }
+    .cyc-pip-name {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        color: var(--color-fg-2);
+    }
+    .cyc-pip.inc .cyc-pip-name {
+        color: var(--color-cib-green-600);
+        font-weight: 900;
+    }
+    .cyc-pip-more {
+        font: 700 10px/1 var(--font-sans);
+        color: var(--color-fg-3);
+        padding-top: 2px;
+    }
+    .cyc-day-net {
+        font: 900 12px/1 var(--font-display);
+        font-variant-numeric: tabular-nums;
+        margin-top: 4px;
+    }
+    .cyc-day-net.pos { color: var(--color-cib-green-600); }
+    .cyc-day-net.neg { color: var(--color-money-owed); }
+
+    .cyc-detail { margin-top: 8px; }
+    .cyc-detail-head {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        margin-bottom: 10px;
+    }
+    .cyc-detail-dow {
+        font: 900 11px/1 var(--font-display);
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        color: var(--color-fg-3);
+    }
+    .cyc-detail-date {
+        font: 900 22px/1 var(--font-display);
+        letter-spacing: -0.01em;
+        margin-top: 5px;
+    }
+    .cyc-detail-meta { display: flex; gap: 6px; }
+    .cyc-detail-body { display: flex; flex-direction: column; gap: 6px; }
+    .chip-today,
+    .chip-pay,
+    .chip-count {
+        font: 700 11px/1 var(--font-sans);
+        padding: 6px 10px;
+        border-radius: 999px;
+        border: 2px solid var(--color-border-strong);
+    }
+    .chip-today { background: var(--color-cib-cream-50); }
+    .chip-pay { background: var(--color-cib-yellow-400); }
+    .chip-count { background: var(--color-bg-surface); color: var(--color-fg-2); }
+    .pay-cycle-cal .cyc-empty {
+        padding: 14px;
+        text-align: center;
+        color: var(--color-fg-3);
+        font: 700 13px/1.5 var(--font-sans);
+    }
+
+    /* ---------- 12-month projection widget (Ticket #228) ---------- */
+
+    .monthly-projection {
+        background: var(--color-bg-surface);
+        border: 2px solid var(--color-border-strong);
+        border-radius: var(--radius-md);
+        box-shadow: var(--shadow-pop);
+        padding: 18px 20px 16px;
+    }
+    .proj-head {
+        display: flex;
+        align-items: flex-start;
+        justify-content: space-between;
+        gap: 16px;
+        flex-wrap: wrap;
+        margin-bottom: 12px;
+    }
+    .proj-head h3 {
+        font: 900 16px/1 var(--font-display);
+        letter-spacing: -0.01em;
+    }
+    .proj-sub {
+        font: 700 12px/1.3 var(--font-sans);
+        color: var(--color-fg-3);
+        margin-top: 5px;
+    }
+    .proj-sub b { color: var(--color-fg-1); }
+    .proj-legend {
+        display: flex;
+        gap: 12px;
+        flex-wrap: wrap;
+    }
+    .proj-legend .lg {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        font: 700 11px/1 var(--font-sans);
+        color: var(--color-fg-2);
+    }
+    .proj-legend .sw {
+        width: 12px;
+        height: 12px;
+        border-radius: 3px;
+        border: 2px solid var(--color-border-strong);
+    }
+    .proj-legend .lg-inc .sw { background: var(--color-cib-green-400); }
+    .proj-legend .lg-exp .sw { background: var(--color-money-owed); }
+    .proj-legend .lg-cum .sw {
+        background: var(--color-cib-teal-600);
+        border-radius: 999px;
+        height: 4px;
+        align-self: center;
+        border: 0;
+        box-shadow: 0 0 0 1px var(--color-border-strong);
+    }
+    .proj-warn {
+        display: flex;
+        align-items: flex-start;
+        gap: 10px;
+        background: var(--color-money-owed-soft);
+        border: 2px solid var(--color-money-owed);
+        color: var(--color-money-owed);
+        border-radius: 10px;
+        padding: 10px 12px;
+        font: 700 12px/1.4 var(--font-sans);
+        margin-bottom: 12px;
+    }
+    .proj-warn b { color: var(--color-fg-1); }
+    .proj-canvas { min-height: 320px; }
+    .proj-empty {
+        text-align: center;
+        padding: 32px 16px;
+        color: var(--color-fg-3);
+        font: 700 13px/1.5 var(--font-sans);
+    }
 }
 
 /* Flux modal slide-up (Ticket #196). Outside @layer components so it matches

--- a/resources/views/components/cib/day-net.blade.php
+++ b/resources/views/components/cib/day-net.blade.php
@@ -1,0 +1,24 @@
+@use('App\Casts\MoneyCast')
+
+@props([
+    'cents',
+])
+
+@php
+    $value = (int) $cents;
+    $tone = match (true) {
+        $value > 0 => 'pos',
+        $value < 0 => 'neg',
+        default => '',
+    };
+    $sign = match (true) {
+        $value > 0 => '+',
+        $value < 0 => '−',
+        default => '',
+    };
+    $abs = MoneyCast::format(abs($value));
+@endphp
+
+@if ($value !== 0)
+    <span {{ $attributes->class(['cyc-day-net', $tone]) }}>{{ $sign }}{{ $abs }}</span>
+@endif

--- a/resources/views/livewire/dashboard.blade.php
+++ b/resources/views/livewire/dashboard.blade.php
@@ -1,92 +1,80 @@
 @use('App\Casts\MoneyCast')
-@use('App\Enums\TransactionDirection')
 
-<div class="grid gap-4 lg:grid-cols-[1fr_300px]">
-    <div class="space-y-4">
-        @php
-            $buf = $this->buffer;
-        @endphp
+<div class="space-y-6">
+    <div class="grid gap-4 lg:grid-cols-[1fr_300px]">
+        <div class="space-y-4">
+            @php
+                $buf = $this->buffer;
+            @endphp
 
-        <section @class([
-            'buffer-hero border-2 border-black rounded-[28px] p-6 shadow-[3px_3px_0_0_#111]',
-            'bg-cib-green-400' => $buf !== null && $buf >= 0,
-            'bg-red-400' => $buf !== null && $buf < 0,
-            'bg-cib-cream-50' => $buf === null,
-            'pos' => $buf !== null && $buf >= 0,
-            'neg' => $buf !== null && $buf < 0,
-        ])>
-            @if ($buf === null)
-                <h2 class="font-display text-2xl font-black tracking-tight">SET UP PAY CYCLE</h2>
-                <p class="mt-2 text-sm">Configure your next pay date and amount to see your buffer.</p>
-            @elseif ($buf >= 0)
-                <h2 class="font-display text-2xl font-black tracking-tight">YOU CAN AFFORD</h2>
-                <div class="buffer-amt mt-2 text-5xl font-black">{{ MoneyCast::format($buf) }}</div>
-                <p class="mt-2 text-sm">After covering {{ MoneyCast::format($this->totalNeeded) }} of planned spend until payday.</p>
-            @else
-                <h2 class="font-display text-2xl font-black tracking-tight">YOU ARE SHORT BY</h2>
-                <div class="buffer-amt mt-2 text-5xl font-black">{{ MoneyCast::format(abs($buf)) }}</div>
-                <p class="mt-2 text-sm">Planned spend exceeds what you have available by payday.</p>
-            @endif
-        </section>
+            <section @class([
+                'buffer-hero border-2 border-black rounded-[28px] p-6 shadow-[3px_3px_0_0_#111]',
+                'bg-cib-green-400' => $buf !== null && $buf >= 0,
+                'bg-red-400' => $buf !== null && $buf < 0,
+                'bg-cib-cream-50' => $buf === null,
+                'pos' => $buf !== null && $buf >= 0,
+                'neg' => $buf !== null && $buf < 0,
+            ])>
+                @if ($buf === null)
+                    <h2 class="font-display text-2xl font-black tracking-tight">SET UP PAY CYCLE</h2>
+                    <p class="mt-2 text-sm">Configure your next pay date and amount to see your buffer.</p>
+                @elseif ($buf >= 0)
+                    <h2 class="font-display text-2xl font-black tracking-tight">YOU CAN AFFORD</h2>
+                    <div class="buffer-amt mt-2 text-5xl font-black">{{ MoneyCast::format($buf) }}</div>
+                    <p class="mt-2 text-sm">After covering {{ MoneyCast::format($this->totalNeeded) }} of planned spend until payday.</p>
+                @else
+                    <h2 class="font-display text-2xl font-black tracking-tight">YOU ARE SHORT BY</h2>
+                    <div class="buffer-amt mt-2 text-5xl font-black">{{ MoneyCast::format(abs($buf)) }}</div>
+                    <p class="mt-2 text-sm">Planned spend exceeds what you have available by payday.</p>
+                @endif
+            </section>
 
-        <div class="grid gap-3 sm:grid-cols-3">
-            <x-cib.money-card label="Owed" :amount="$this->numbers['owed']" tone="owed"/>
-            <x-cib.money-card label="Available" :amount="$this->numbers['available']" tone="available"/>
-            <x-cib.money-card label="Needed" :amount="$this->numbers['needed']" tone="needed"/>
+            <div class="grid gap-3 sm:grid-cols-3">
+                <x-cib.money-card label="Owed" :amount="$this->numbers['owed']" tone="owed"/>
+                <x-cib.money-card label="Available" :amount="$this->numbers['available']" tone="available"/>
+                <x-cib.money-card label="Needed" :amount="$this->numbers['needed']" tone="needed"/>
+            </div>
+
+            <livewire:dashboard.pay-cycle-calendar/>
         </div>
 
-        <section>
-            <x-cib.sec-head title="Recent activity" :href="route('transactions')"/>
-            <div class="space-y-2">
-                @forelse ($this->recentTransactions as $tx)
-                    <x-cib.tx-row
-                            :transaction-id="$tx->id"
-                            :name="$tx->description ?? '—'"
-                            :amount="$tx->amount"
-                            :tone="$tx->direction === TransactionDirection::Debit ? 'out' : 'in'"
-                            :icon="$tx->category?->resolveIcon()"
+        <aside class="space-y-4">
+            <section>
+                <x-cib.sec-head title="Budgets this cycle"/>
+                @forelse ($this->budgetsThisCycle as $row)
+                    <x-cib.budget-row
+                            :name="$row['budget']->name"
+                            :spent="$row['spent']"
+                            :limit="$row['limit']"
                     />
                 @empty
-                    <p class="text-sm text-gray-500">No recent activity.</p>
+                    <p class="text-sm text-gray-500">No budgets yet.</p>
                 @endforelse
-            </div>
-        </section>
+            </section>
+
+            <section>
+                <x-cib.sec-head title="Next 3 planned"/>
+                @forelse ($this->nextThreePlanned as $row)
+                    <div class="planned-row flex items-center justify-between py-1 text-sm">
+                        <span class="font-medium">{{ $row['planned']->description }}</span>
+                        <span class="text-gray-600">{{ $row['next']->format('M j') }}</span>
+                        <span class="font-bold">{{ MoneyCast::format(abs((int) $row['planned']->amount)) }}</span>
+                    </div>
+                @empty
+                    <p class="text-sm text-gray-500">Nothing planned.</p>
+                @endforelse
+            </section>
+
+            <section>
+                <x-cib.sec-head title="Spend last 7 days"/>
+                <div class="spend-total text-2xl font-bold">{{ MoneyCast::format($this->spendLast7Days['sum']) }}</div>
+                <x-cib.spark
+                        :values="$this->spendLast7Days['sparkline']"
+                        :payday-indexes="$this->spendLast7Days['paydayIndexes']"
+                />
+            </section>
+        </aside>
     </div>
 
-    <aside class="space-y-4">
-        <section>
-            <x-cib.sec-head title="Budgets this cycle"/>
-            @forelse ($this->budgetsThisCycle as $row)
-                <x-cib.budget-row
-                        :name="$row['budget']->name"
-                        :spent="$row['spent']"
-                        :limit="$row['limit']"
-                />
-            @empty
-                <p class="text-sm text-gray-500">No budgets yet.</p>
-            @endforelse
-        </section>
-
-        <section>
-            <x-cib.sec-head title="Next 3 planned"/>
-            @forelse ($this->nextThreePlanned as $row)
-                <div class="planned-row flex items-center justify-between py-1 text-sm">
-                    <span class="font-medium">{{ $row['planned']->description }}</span>
-                    <span class="text-gray-600">{{ $row['next']->format('M j') }}</span>
-                    <span class="font-bold">{{ MoneyCast::format(abs((int) $row['planned']->amount)) }}</span>
-                </div>
-            @empty
-                <p class="text-sm text-gray-500">Nothing planned.</p>
-            @endforelse
-        </section>
-
-        <section>
-            <x-cib.sec-head title="Spend last 7 days"/>
-            <div class="spend-total text-2xl font-bold">{{ MoneyCast::format($this->spendLast7Days['sum']) }}</div>
-            <x-cib.spark
-                    :values="$this->spendLast7Days['sparkline']"
-                    :payday-indexes="$this->spendLast7Days['paydayIndexes']"
-            />
-        </section>
-    </aside>
+    <livewire:dashboard.monthly-projection lazy/>
 </div>

--- a/resources/views/livewire/dashboard/monthly-projection.blade.php
+++ b/resources/views/livewire/dashboard/monthly-projection.blade.php
@@ -1,0 +1,153 @@
+@use('App\Casts\MoneyCast')
+
+<section class="monthly-projection">
+    @if ($this->projection->isEmpty())
+        <x-cib.empty-state
+                icon="chart-bar-square"
+                title="12-month projection unavailable"
+                description="Set up your pay cycle and a few planned transactions to forecast the next year."
+        >
+            <x-slot:action>
+                <a class="link" href="{{ route('pay-cycle.edit') }}">
+                    Configure pay cycle →
+                </a>
+            </x-slot:action>
+        </x-cib.empty-state>
+    @else
+        <header class="proj-head">
+            <div>
+                <h3>Next 12 months</h3>
+                <p class="proj-sub">
+                    Income smoothed across pay cycles · expenses from active planned transactions.
+                </p>
+            </div>
+            <div class="proj-legend">
+                <span class="lg lg-inc"><span class="sw"></span>Income</span>
+                <span class="lg lg-exp"><span class="sw"></span>Expenses</span>
+                <span class="lg lg-cum"><span class="sw"></span>Cumulative buffer</span>
+            </div>
+        </header>
+
+        @if ($this->firstRiskyMonth !== null)
+            <div class="proj-warn">
+                <flux:icon.exclamation-triangle variant="micro"/>
+                <div>
+                    <b>{{ $this->firstRiskyMonth->label }} {{ $this->firstRiskyMonth->year }}</b>
+                    is the first month where planned spend exceeds projected income.
+                    Expenses {{ MoneyCast::format($this->firstRiskyMonth->expenseCents) }} vs income {{ MoneyCast::format($this->firstRiskyMonth->incomeCents) }}.
+                </div>
+            </div>
+        @endif
+
+        <div
+                wire:ignore
+                x-data="{
+                    chart: null,
+                    init() {
+                        const payload = @js($this->chartPayload, JSON_THROW_ON_ERROR);
+                        const riskyIndexSet = new Set(payload.riskyIndexes);
+
+                        const formatMoney = (cents) => {
+                            const dollars = Math.abs(cents / 100);
+                            const formatted = dollars.toLocaleString('en-AU', {
+                                minimumFractionDigits: 2,
+                                maximumFractionDigits: 2,
+                            });
+                            return (cents < 0 ? '-$' : '$') + formatted;
+                        };
+
+                        const expenseColors = payload.expense.map((_, idx) =>
+                            riskyIndexSet.has(idx) ? '#E5484D' : '#FBA3A6'
+                        );
+
+                        this.chart = new ApexCharts(this.$refs.canvas, {
+                            chart: {
+                                type: 'line',
+                                height: 320,
+                                toolbar: { show: false },
+                                fontFamily: 'Lato, ui-sans-serif, system-ui, sans-serif',
+                            },
+                            stroke: {
+                                width: [0, 0, 3],
+                                curve: 'smooth',
+                            },
+                            series: [
+                                { name: 'Income', type: 'bar', data: payload.income },
+                                { name: 'Expenses', type: 'bar', data: payload.expense },
+                                { name: 'Cumulative', type: 'line', data: payload.cumulative },
+                            ],
+                            colors: ['#2AAF46', '#E5484D', '#0E5E57'],
+                            fill: {
+                                opacity: [1, 1, 1],
+                                colors: ['#2AAF46', ({ seriesIndex, dataPointIndex }) => {
+                                    if (seriesIndex !== 1) {
+                                        return '#0E5E57';
+                                    }
+                                    return expenseColors[dataPointIndex];
+                                }, '#0E5E57'],
+                            },
+                            plotOptions: {
+                                bar: {
+                                    columnWidth: '60%',
+                                    borderRadius: 3,
+                                },
+                            },
+                            dataLabels: { enabled: false },
+                            legend: { show: false },
+                            grid: {
+                                borderColor: '#DBDEDD',
+                                strokeDashArray: 3,
+                            },
+                            xaxis: {
+                                categories: payload.categories,
+                                labels: { style: { fontWeight: 700, fontSize: '11px' } },
+                                axisBorder: { color: '#111' },
+                                axisTicks: { color: '#111' },
+                            },
+                            yaxis: {
+                                labels: {
+                                    formatter: (value) => formatMoney(value),
+                                    style: { fontWeight: 700, fontSize: '10px' },
+                                },
+                            },
+                            tooltip: {
+                                shared: true,
+                                intersect: false,
+                                y: { formatter: (value) => formatMoney(value) },
+                            },
+                            annotations: {
+                                points: payload.oneOffs.map((oneOff) => ({
+                                    x: oneOff.x,
+                                    y: 0,
+                                    marker: {
+                                        size: 5,
+                                        fillColor: '#F1A51C',
+                                        strokeColor: '#111',
+                                        strokeWidth: 1.5,
+                                    },
+                                    label: {
+                                        borderColor: '#111',
+                                        style: {
+                                            color: '#111',
+                                            background: '#FCF0D6',
+                                            fontWeight: 700,
+                                            fontSize: '10px',
+                                        },
+                                        text: oneOff.label + ' · ' + formatMoney(oneOff.amountCents),
+                                    },
+                                })),
+                            },
+                        });
+                        this.chart.render();
+                    },
+                    destroy() {
+                        this.chart?.destroy();
+                    },
+                }"
+                x-init="init()"
+                class="proj-canvas"
+        >
+            <div x-ref="canvas"></div>
+        </div>
+    @endif
+</section>

--- a/resources/views/livewire/dashboard/pay-cycle-calendar.blade.php
+++ b/resources/views/livewire/dashboard/pay-cycle-calendar.blade.php
@@ -1,0 +1,134 @@
+@use('App\Casts\MoneyCast')
+@use('App\Livewire\Dashboard\PayCycleCalendar')
+
+<section class="pay-cycle-cal">
+    @if ($this->bounds === null)
+        <x-cib.empty-state
+                icon="calendar-days"
+                title="Set up your pay cycle"
+                description="Configure your pay frequency and next payday to see your fortnight at a glance."
+        >
+            <x-slot:action>
+                <a class="link cyc-empty-link" href="{{ route('pay-cycle.edit') }}">
+                    Configure pay cycle →
+                </a>
+            </x-slot:action>
+        </x-cib.empty-state>
+    @else
+        <header class="cyc-head">
+            <div>
+                <h3 class="cyc-title">Pay cycle</h3>
+                <p class="cyc-sub">
+                    {{ $this->header['rangeLabel'] }}
+                    @if ($this->header['daysUntilPay'] !== null)
+                        · {{ $this->header['daysUntilPay'] }}d to payday
+                    @endif
+                </p>
+            </div>
+            <div class="cyc-nav">
+                <button type="button" wire:click="previousCycle" title="Previous cycle" aria-label="Previous cycle">
+                    <flux:icon.chevron-left variant="micro"/>
+                </button>
+                <button type="button" wire:click="goToCurrentCycle" @disabled($this->isCurrentCycle)>
+                    Today
+                </button>
+                <button type="button" wire:click="nextCycle" title="Next cycle" aria-label="Next cycle">
+                    <flux:icon.chevron-right variant="micro"/>
+                </button>
+            </div>
+        </header>
+
+        <div class="cyc-grid" role="grid">
+            <div class="cyc-dows" role="row">
+                @foreach (['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'] as $label)
+                    <div class="cyc-dow" role="columnheader">{{ $label }}</div>
+                @endforeach
+            </div>
+            <div class="cyc-week-stream">
+                @foreach ($this->days as $day)
+                    <button
+                            type="button"
+                            wire:click="selectDay('{{ $day->iso }}')"
+                            wire:key="cyc-day-{{ $day->iso }}"
+                            @class([
+                                'cyc-day',
+                                'past' => $day->isPast && ! $day->isToday,
+                                'today' => $day->isToday,
+                                'payday' => $day->isCycleEnd && $this->isCurrentCycle,
+                                'lastpay' => $day->isCycleStart,
+                                'active' => $day->iso === $this->selectedDate,
+                            ])
+                    >
+                        <div class="cyc-day-top">
+                            <span class="cyc-dnum">{{ $day->day }}</span>
+                            @if ($day->isToday)
+                                <span class="cyc-today-pill">TODAY</span>
+                            @endif
+                            @if ($day->isCycleEnd && $this->isCurrentCycle)
+                                <span class="cyc-paytag">PAYDAY</span>
+                            @elseif ($day->isCycleStart)
+                                <span class="cyc-paytag dim">PAID</span>
+                            @endif
+                        </div>
+                        <div class="cyc-day-body">
+                            @foreach (array_slice($day->pips, 0, PayCycleCalendar::MAX_PIPS_PER_DAY) as $pip)
+                                <div @class(['cyc-pip', $pip->kind])>
+                                    <span class="cyc-pip-dot"></span>
+                                    <span class="cyc-pip-name">{{ $pip->name }}</span>
+                                </div>
+                            @endforeach
+                            @if ($day->hiddenCount > 0)
+                                <div class="cyc-pip-more">+{{ $day->hiddenCount }} more</div>
+                            @endif
+                        </div>
+                        <x-cib.day-net :cents="$day->netCents"/>
+                    </button>
+                @endforeach
+            </div>
+        </div>
+
+        @if ($this->selectedDay !== null)
+            <div class="cyc-detail">
+                <div class="cyc-detail-head">
+                    <div>
+                        <div class="cyc-detail-dow">{{ $this->selectedDay['dayLabel'] }}</div>
+                        <div class="cyc-detail-date">{{ $this->selectedDay['dateLabel'] }}</div>
+                    </div>
+                    <div class="cyc-detail-meta">
+                        @if ($this->selectedDay['isToday'])
+                            <span class="chip-today">Today</span>
+                        @endif
+                        @if ($this->selectedDay['isCycleEnd'] && $this->isCurrentCycle)
+                            <span class="chip-pay">Payday eve</span>
+                        @endif
+                        <span class="chip-count">
+                            {{ count($this->selectedDay['pips']) }} item{{ count($this->selectedDay['pips']) === 1 ? '' : 's' }}
+                        </span>
+                    </div>
+                </div>
+                <div class="cyc-detail-body">
+                    @forelse ($this->selectedDay['pips'] as $pip)
+                        @php
+                            $rowTone = match ($pip->kind) {
+                                'inc' => 'inc',
+                                'plan' => 'plan',
+                                default => 'out',
+                            };
+                        @endphp
+                        <x-cib.tx-row
+                                :transaction-id="$pip->transactionId"
+                                :planned-transaction-id="$pip->plannedTransactionId"
+                                :occurrence-date="$pip->occurrenceDate"
+                                :name="$pip->name"
+                                :amount="$pip->amount"
+                                :tone="$rowTone"
+                                :icon="$pip->icon"
+                        />
+                    @empty
+                        <p class="cyc-empty">Nothing on this day.</p>
+                    @endforelse
+                </div>
+            </div>
+        @endif
+    @endif
+</section>

--- a/tests/Feature/Livewire/Dashboard/MonthlyProjectionTest.php
+++ b/tests/Feature/Livewire/Dashboard/MonthlyProjectionTest.php
@@ -1,0 +1,73 @@
+<?php
+
+/** @noinspection StaticClosureCanBeUsedInspection */
+
+declare(strict_types=1);
+
+use App\Enums\PayFrequency;
+use App\Enums\RecurrenceFrequency;
+use App\Enums\TransactionDirection;
+use App\Livewire\Dashboard\MonthlyProjection;
+use App\Models\Account;
+use App\Models\PlannedTransaction;
+use App\Models\User;
+use Carbon\CarbonImmutable;
+use Livewire\Livewire;
+
+test('renders empty-state when pay cycle is not configured', function () {
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(MonthlyProjection::class)
+        ->assertSee('12-month projection unavailable');
+});
+
+test('renders chart canvas when projection has data', function () {
+    $user = User::factory()->withPayCycle()->create([
+        'pay_amount' => 200000,
+        'pay_frequency' => PayFrequency::Fortnightly,
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(MonthlyProjection::class)
+        ->assertSee('Next 12 months')
+        ->assertSeeHtml('wire:ignore');
+});
+
+test('surfaces the closest risky month in a warning banner', function () {
+    $user = User::factory()->withPayCycle()->create([
+        'pay_amount' => 100000,
+        'pay_frequency' => PayFrequency::Monthly,
+    ]);
+    $account = Account::factory()->for($user)->create();
+
+    PlannedTransaction::factory()->for($user)->for($account)->create([
+        'direction' => TransactionDirection::Debit,
+        'amount' => 250000,
+        'start_date' => CarbonImmutable::today()->startOfMonth()->addDays(3),
+        'frequency' => RecurrenceFrequency::DontRepeat,
+        'is_active' => true,
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(MonthlyProjection::class)
+        ->assertSee('first month where planned spend exceeds projected income');
+});
+
+test('chart payload categories label January with year for non-current January', function () {
+    $user = User::factory()->withPayCycle()->create([
+        'pay_amount' => 100000,
+        'pay_frequency' => PayFrequency::Monthly,
+    ]);
+
+    $payload = Livewire::actingAs($user)
+        ->test(MonthlyProjection::class)
+        ->instance()
+        ->chartPayload();
+
+    $hasYearLabel = collect($payload['categories'])
+        ->skip(1)
+        ->contains(fn (string $label) => str_contains($label, ' '));
+
+    expect($hasYearLabel)->toBeTrue();
+});

--- a/tests/Feature/Livewire/Dashboard/PayCycleCalendarTest.php
+++ b/tests/Feature/Livewire/Dashboard/PayCycleCalendarTest.php
@@ -1,0 +1,508 @@
+<?php
+
+/** @noinspection StaticClosureCanBeUsedInspection */
+
+declare(strict_types=1);
+
+use App\Enums\PayFrequency;
+use App\Enums\RecurrenceFrequency;
+use App\Enums\TransactionDirection;
+use App\Livewire\Dashboard\Data\PayCycleDayData;
+use App\Livewire\Dashboard\PayCycleCalendar;
+use App\Models\Account;
+use App\Models\Category;
+use App\Models\PlannedTransaction;
+use App\Models\Transaction;
+use App\Models\User;
+use Carbon\CarbonImmutable;
+use Carbon\Constants\UnitValue;
+use Livewire\Livewire;
+
+function nextMondayAtLeastDaysAhead(int $minDaysAhead): CarbonImmutable
+{
+    $candidate = CarbonImmutable::today()->addDays($minDaysAhead);
+
+    while ($candidate->dayOfWeek !== UnitValue::MONDAY) {
+        $candidate = $candidate->addDay();
+    }
+
+    return $candidate;
+}
+
+test('shows empty-state when pay cycle is not configured', function () {
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(PayCycleCalendar::class)
+        ->assertSee('Set up your pay cycle')
+        ->assertSee(route('pay-cycle.edit'));
+});
+
+test('renders 14 days for fortnightly cycle starting Monday', function () {
+    $nextPay = nextMondayAtLeastDaysAhead(7);
+
+    $user = User::factory()->withPayCycle()->create([
+        'pay_frequency' => PayFrequency::Fortnightly,
+        'next_pay_date' => $nextPay,
+    ]);
+    Account::factory()->for($user)->create();
+
+    /** @var list<PayCycleDayData> $days */
+    $days = Livewire::actingAs($user)
+        ->test(PayCycleCalendar::class)
+        ->instance()
+        ->days();
+
+    expect($days)->toHaveCount(14);
+});
+
+test('renders 7 days for weekly cycle', function () {
+    $nextPay = nextMondayAtLeastDaysAhead(3);
+
+    $user = User::factory()->withPayCycle()->create([
+        'pay_frequency' => PayFrequency::Weekly,
+        'next_pay_date' => $nextPay,
+    ]);
+    Account::factory()->for($user)->create();
+
+    /** @var list<PayCycleDayData> $days */
+    $days = Livewire::actingAs($user)
+        ->test(PayCycleCalendar::class)
+        ->instance()
+        ->days();
+
+    expect($days)->toHaveCount(7);
+});
+
+test('renders ~30 days for monthly cycle', function () {
+    $user = User::factory()->withPayCycle()->create([
+        'pay_frequency' => PayFrequency::Monthly,
+        'next_pay_date' => CarbonImmutable::today()->addDays(15),
+    ]);
+    Account::factory()->for($user)->create();
+
+    /** @var list<PayCycleDayData> $days */
+    $days = Livewire::actingAs($user)
+        ->test(PayCycleCalendar::class)
+        ->instance()
+        ->days();
+
+    expect(count($days))->toBeGreaterThanOrEqual(27)
+        ->and(count($days))->toBeLessThanOrEqual(31);
+});
+
+test('labels first day as PAID and last as PAYDAY', function () {
+    $nextPay = nextMondayAtLeastDaysAhead(7);
+
+    $user = User::factory()->withPayCycle()->create([
+        'pay_frequency' => PayFrequency::Fortnightly,
+        'next_pay_date' => $nextPay,
+    ]);
+    Account::factory()->for($user)->create();
+
+    /** @var list<PayCycleDayData> $days */
+    $days = Livewire::actingAs($user)
+        ->test(PayCycleCalendar::class)
+        ->instance()
+        ->days();
+
+    expect($days[0]->isCycleStart)->toBeTrue()
+        ->and($days[count($days) - 1]->isCycleEnd)->toBeTrue();
+});
+
+test('today modifier set when cycle offset is 0 and today is in the cycle', function () {
+    $nextPay = nextMondayAtLeastDaysAhead(3);
+
+    $user = User::factory()->withPayCycle()->create([
+        'pay_frequency' => PayFrequency::Fortnightly,
+        'next_pay_date' => $nextPay,
+    ]);
+    Account::factory()->for($user)->create();
+
+    /** @var list<PayCycleDayData> $days */
+    $days = Livewire::actingAs($user)
+        ->test(PayCycleCalendar::class)
+        ->instance()
+        ->days();
+
+    $todayIso = CarbonImmutable::today()->format('Y-m-d');
+    $todayDay = collect($days)->first(fn (PayCycleDayData $day) => $day->iso === $todayIso);
+
+    expect($todayDay?->isToday)->toBeTrue();
+});
+
+test('credits group as inc pips and debits as out pips', function () {
+    $nextPay = nextMondayAtLeastDaysAhead(7);
+
+    $user = User::factory()->withPayCycle()->create([
+        'pay_frequency' => PayFrequency::Fortnightly,
+        'next_pay_date' => $nextPay,
+    ]);
+    $account = Account::factory()->for($user)->create();
+
+    $start = $nextPay->subWeeks(2);
+
+    Transaction::factory()->credit()->for($user)->for($account)->create([
+        'amount' => 50000,
+        'post_date' => $start->addDay(),
+    ]);
+    Transaction::factory()->debit()->for($user)->for($account)->create([
+        'amount' => 12000,
+        'post_date' => $start->addDays(2),
+    ]);
+
+    /** @var list<PayCycleDayData> $days */
+    $days = Livewire::actingAs($user)
+        ->test(PayCycleCalendar::class)
+        ->instance()
+        ->days();
+
+    $allPips = collect($days)->flatMap(fn (PayCycleDayData $day) => $day->pips);
+
+    expect($allPips->where('kind', 'inc'))->toHaveCount(1)
+        ->and($allPips->where('kind', 'out'))->toHaveCount(1);
+});
+
+test('planned transactions render as plan pips on occurrence dates', function () {
+    $nextPay = nextMondayAtLeastDaysAhead(7);
+
+    $user = User::factory()->withPayCycle()->create([
+        'pay_frequency' => PayFrequency::Fortnightly,
+        'next_pay_date' => $nextPay,
+    ]);
+    $account = Account::factory()->for($user)->create();
+
+    $start = $nextPay->subWeeks(2);
+
+    PlannedTransaction::factory()->for($user)->for($account)->create([
+        'description' => 'Rent',
+        'direction' => TransactionDirection::Debit,
+        'amount' => 60000,
+        'start_date' => $start->addDays(3),
+        'frequency' => RecurrenceFrequency::DontRepeat,
+        'is_active' => true,
+    ]);
+
+    /** @var list<PayCycleDayData> $days */
+    $days = Livewire::actingAs($user)
+        ->test(PayCycleCalendar::class)
+        ->instance()
+        ->days();
+
+    $planPips = collect($days)->flatMap(fn (PayCycleDayData $day) => $day->pips)->where('kind', 'plan');
+
+    expect($planPips)->toHaveCount(1);
+});
+
+test('stores all pips and surfaces +N more hiddenCount for grid overflow', function () {
+    $nextPay = nextMondayAtLeastDaysAhead(7);
+
+    $user = User::factory()->withPayCycle()->create([
+        'pay_frequency' => PayFrequency::Fortnightly,
+        'next_pay_date' => $nextPay,
+    ]);
+    $account = Account::factory()->for($user)->create();
+
+    $busyDay = $nextPay->subWeeks(2)->addDays(2);
+
+    Transaction::factory()->debit()->for($user)->for($account)->count(5)->create([
+        'amount' => 1000,
+        'post_date' => $busyDay,
+    ]);
+
+    /** @var list<PayCycleDayData> $days */
+    $days = Livewire::actingAs($user)
+        ->test(PayCycleCalendar::class)
+        ->instance()
+        ->days();
+
+    $busyDayData = collect($days)->first(fn (PayCycleDayData $day) => $day->iso === $busyDay->format('Y-m-d'));
+
+    expect($busyDayData?->pips)->toHaveCount(5)
+        ->and($busyDayData?->hiddenCount)->toBe(2);
+});
+
+test('detail panel exposes all pips for a day even when more than the grid cap', function () {
+    $nextPay = nextMondayAtLeastDaysAhead(7);
+
+    $user = User::factory()->withPayCycle()->create([
+        'pay_frequency' => PayFrequency::Fortnightly,
+        'next_pay_date' => $nextPay,
+    ]);
+    $account = Account::factory()->for($user)->create();
+
+    $busyDay = $nextPay->subWeeks(2)->addDays(2);
+    $iso = $busyDay->format('Y-m-d');
+
+    Transaction::factory()->debit()->for($user)->for($account)->count(5)->create([
+        'amount' => 1000,
+        'post_date' => $busyDay,
+    ]);
+
+    $component = Livewire::actingAs($user)->test(PayCycleCalendar::class);
+    $component->call('selectDay', $iso);
+
+    $selected = $component->instance()->selectedDay();
+
+    expect($selected['pips'] ?? [])->toHaveCount(5);
+});
+
+test('excludes transfer-pair transactions from pips', function () {
+    $nextPay = nextMondayAtLeastDaysAhead(7);
+
+    $user = User::factory()->withPayCycle()->create([
+        'pay_frequency' => PayFrequency::Fortnightly,
+        'next_pay_date' => $nextPay,
+    ]);
+    $accountA = Account::factory()->for($user)->create();
+    $accountB = Account::factory()->for($user)->create();
+
+    $start = $nextPay->subWeeks(2);
+
+    $debit = Transaction::factory()->debit()->for($user)->for($accountA)->create([
+        'amount' => 30000,
+        'post_date' => $start->addDay(),
+    ]);
+    $credit = Transaction::factory()->credit()->for($user)->for($accountB)->create([
+        'amount' => 30000,
+        'post_date' => $start->addDay(),
+        'transfer_pair_id' => $debit->id,
+    ]);
+    $debit->update(['transfer_pair_id' => $credit->id]);
+
+    Transaction::factory()->debit()->for($user)->for($accountA)->create([
+        'amount' => 4000,
+        'post_date' => $start->addDay(),
+    ]);
+
+    /** @var list<PayCycleDayData> $days */
+    $days = Livewire::actingAs($user)
+        ->test(PayCycleCalendar::class)
+        ->instance()
+        ->days();
+
+    $allPips = collect($days)->flatMap(fn (PayCycleDayData $day) => $day->pips);
+
+    expect($allPips)->toHaveCount(1)
+        ->and($allPips->first()->amount)->toBe(4000);
+});
+
+test('excludes transfer-categorised planned transactions', function () {
+    $nextPay = nextMondayAtLeastDaysAhead(7);
+
+    $user = User::factory()->withPayCycle()->create([
+        'pay_frequency' => PayFrequency::Fortnightly,
+        'next_pay_date' => $nextPay,
+    ]);
+    $account = Account::factory()->for($user)->create();
+    $transferCategory = Category::factory()->create(['name' => 'Transfer']);
+
+    $start = $nextPay->subWeeks(2);
+
+    PlannedTransaction::factory()->for($user)->for($account)->create([
+        'category_id' => $transferCategory->id,
+        'direction' => TransactionDirection::Debit,
+        'amount' => 50000,
+        'start_date' => $start->addDay(),
+        'frequency' => RecurrenceFrequency::DontRepeat,
+    ]);
+
+    /** @var list<PayCycleDayData> $days */
+    $days = Livewire::actingAs($user)
+        ->test(PayCycleCalendar::class)
+        ->instance()
+        ->days();
+
+    $planPips = collect($days)->flatMap(fn (PayCycleDayData $day) => $day->pips)->where('kind', 'plan');
+
+    expect($planPips)->toHaveCount(0);
+});
+
+test('netCents per day equals credits minus debits', function () {
+    $nextPay = nextMondayAtLeastDaysAhead(7);
+
+    $user = User::factory()->withPayCycle()->create([
+        'pay_frequency' => PayFrequency::Fortnightly,
+        'next_pay_date' => $nextPay,
+    ]);
+    $account = Account::factory()->for($user)->create();
+
+    $busyDay = $nextPay->subWeeks(2)->addDays(2);
+
+    Transaction::factory()->credit()->for($user)->for($account)->create([
+        'amount' => 100000,
+        'post_date' => $busyDay,
+    ]);
+    Transaction::factory()->debit()->for($user)->for($account)->create([
+        'amount' => 35000,
+        'post_date' => $busyDay,
+    ]);
+
+    /** @var list<PayCycleDayData> $days */
+    $days = Livewire::actingAs($user)
+        ->test(PayCycleCalendar::class)
+        ->instance()
+        ->days();
+
+    $busyDayData = collect($days)->first(fn (PayCycleDayData $day) => $day->iso === $busyDay->format('Y-m-d'));
+
+    expect($busyDayData?->netCents)->toBe(65000);
+});
+
+test('previousCycle shifts a fortnightly cycle by 14 days', function () {
+    $nextPay = nextMondayAtLeastDaysAhead(7);
+
+    $user = User::factory()->withPayCycle()->create([
+        'pay_frequency' => PayFrequency::Fortnightly,
+        'next_pay_date' => $nextPay,
+    ]);
+    Account::factory()->for($user)->create();
+
+    $component = Livewire::actingAs($user)->test(PayCycleCalendar::class);
+
+    $currentBounds = $component->instance()->bounds();
+    $component->call('previousCycle');
+    $previousBounds = $component->instance()->bounds();
+
+    expect($previousBounds['start']->equalTo($currentBounds['start']->subDays(14)))->toBeTrue()
+        ->and($previousBounds['end']->equalTo($currentBounds['end']->subDays(14)))->toBeTrue();
+});
+
+test('previousCycle shifts a weekly cycle by 7 days', function () {
+    $user = User::factory()->withPayCycle()->create([
+        'pay_frequency' => PayFrequency::Weekly,
+        'next_pay_date' => nextMondayAtLeastDaysAhead(3),
+    ]);
+    Account::factory()->for($user)->create();
+
+    $component = Livewire::actingAs($user)->test(PayCycleCalendar::class);
+
+    $currentBounds = $component->instance()->bounds();
+    $component->call('previousCycle');
+    $previousBounds = $component->instance()->bounds();
+
+    expect($previousBounds['start']->equalTo($currentBounds['start']->subDays(7)))->toBeTrue();
+});
+
+test('previousCycle shifts a monthly cycle by one month', function () {
+    $user = User::factory()->withPayCycle()->create([
+        'pay_frequency' => PayFrequency::Monthly,
+        'next_pay_date' => CarbonImmutable::today()->addDays(15),
+    ]);
+    Account::factory()->for($user)->create();
+
+    $component = Livewire::actingAs($user)->test(PayCycleCalendar::class);
+
+    $currentBounds = $component->instance()->bounds();
+    $component->call('previousCycle');
+    $previousBounds = $component->instance()->bounds();
+
+    expect($previousBounds['start']->equalTo($currentBounds['start']->subMonthNoOverflow()))->toBeTrue()
+        ->and($previousBounds['end']->equalTo($currentBounds['end']->subMonthNoOverflow()))->toBeTrue();
+});
+
+test('handles cycles spanning a year boundary', function () {
+    $nextPay = CarbonImmutable::create(2027, 1, 5);
+
+    $user = User::factory()->withPayCycle()->create([
+        'pay_frequency' => PayFrequency::Fortnightly,
+        'next_pay_date' => $nextPay,
+    ]);
+    Account::factory()->for($user)->create();
+
+    /** @var list<PayCycleDayData> $days */
+    $days = Livewire::actingAs($user)
+        ->test(PayCycleCalendar::class)
+        ->instance()
+        ->days();
+
+    expect($days)->toHaveCount(14)
+        ->and($days[0]->iso)->toBe('2026-12-22')
+        ->and(end($days)->iso)->toBe('2027-01-04');
+});
+
+test('isolates current user from other users transactions', function () {
+    $nextPay = nextMondayAtLeastDaysAhead(7);
+
+    $user = User::factory()->withPayCycle()->create([
+        'pay_frequency' => PayFrequency::Fortnightly,
+        'next_pay_date' => $nextPay,
+    ]);
+    $otherUser = User::factory()->withPayCycle()->create([
+        'pay_frequency' => PayFrequency::Fortnightly,
+        'next_pay_date' => $nextPay,
+    ]);
+    $account = Account::factory()->for($user)->create();
+    $otherAccount = Account::factory()->for($otherUser)->create();
+
+    $start = $nextPay->subWeeks(2);
+
+    Transaction::factory()->debit()->for($user)->for($account)->create([
+        'amount' => 1000,
+        'post_date' => $start->addDay(),
+    ]);
+    Transaction::factory()->debit()->for($otherUser)->for($otherAccount)->create([
+        'amount' => 99999,
+        'post_date' => $start->addDay(),
+    ]);
+
+    /** @var list<PayCycleDayData> $days */
+    $days = Livewire::actingAs($user)
+        ->test(PayCycleCalendar::class)
+        ->instance()
+        ->days();
+
+    $allPips = collect($days)->flatMap(fn (PayCycleDayData $day) => $day->pips);
+
+    expect($allPips)->toHaveCount(1)
+        ->and($allPips->first()->amount)->toBe(1000);
+});
+
+test('selectDay updates selected day and surfaces it for the detail panel', function () {
+    $nextPay = nextMondayAtLeastDaysAhead(7);
+
+    $user = User::factory()->withPayCycle()->create([
+        'pay_frequency' => PayFrequency::Fortnightly,
+        'next_pay_date' => $nextPay,
+    ]);
+    $account = Account::factory()->for($user)->create();
+
+    $targetDay = $nextPay->subWeeks(2)->addDays(3);
+    $iso = $targetDay->format('Y-m-d');
+
+    Transaction::factory()->debit()->for($user)->for($account)->create([
+        'amount' => 7500,
+        'post_date' => $targetDay,
+    ]);
+
+    $component = Livewire::actingAs($user)->test(PayCycleCalendar::class);
+    $component->call('selectDay', $iso);
+
+    $selected = $component->instance()->selectedDay();
+
+    expect($component->get('selectedDate'))->toBe($iso)
+        ->and($selected['iso'] ?? null)->toBe($iso)
+        ->and($selected['pips'] ?? [])->toHaveCount(1);
+});
+
+test('goToCurrentCycle resets cycle offset to 0 and selects today', function () {
+    $nextPay = nextMondayAtLeastDaysAhead(7);
+
+    $user = User::factory()->withPayCycle()->create([
+        'pay_frequency' => PayFrequency::Fortnightly,
+        'next_pay_date' => $nextPay,
+    ]);
+    Account::factory()->for($user)->create();
+
+    $component = Livewire::actingAs($user)->test(PayCycleCalendar::class);
+
+    $component->call('previousCycle')
+        ->call('previousCycle');
+
+    expect($component->get('cycleOffset'))->toBe(-2);
+
+    $component->call('goToCurrentCycle');
+
+    expect($component->get('cycleOffset'))->toBe(0)
+        ->and($component->get('selectedDate'))->toBe(CarbonImmutable::today()->format('Y-m-d'));
+});

--- a/tests/Feature/Livewire/DashboardTest.php
+++ b/tests/Feature/Livewire/DashboardTest.php
@@ -132,17 +132,14 @@ test('triad matches User helper methods on the same seed', function () {
 
 // ── Sidebar widgets ────────────────────────────────────────────────
 
-test('recent activity shows last 5 current transactions', function () {
+test('renders pay cycle calendar widget in place of recent activity', function () {
     $user = User::factory()->withPayCycle()->create();
-    $account = Account::factory()->for($user)->create();
-
-    Transaction::factory()->for($user)->for($account)->count(10)->create([
-        'post_date' => now()->subDays(2),
-    ]);
+    Account::factory()->for($user)->create();
 
     Livewire::actingAs($user)
         ->test(Dashboard::class)
-        ->assertSee('Recent activity');
+        ->assertSeeLivewire('dashboard.pay-cycle-calendar')
+        ->assertDontSee('Recent activity');
 });
 
 test('budgets this cycle section renders when budgets exist', function () {

--- a/tests/Feature/Services/Projection/MonthlyProjectionServiceTest.php
+++ b/tests/Feature/Services/Projection/MonthlyProjectionServiceTest.php
@@ -1,0 +1,261 @@
+<?php
+
+/** @noinspection StaticClosureCanBeUsedInspection */
+
+declare(strict_types=1);
+
+use App\Enums\PayFrequency;
+use App\Enums\RecurrenceFrequency;
+use App\Enums\TransactionDirection;
+use App\Models\Account;
+use App\Models\Category;
+use App\Models\PlannedTransaction;
+use App\Models\User;
+use App\Services\Projection\MonthlyProjectionService;
+use App\Services\Projection\ProjectedMonth;
+use Carbon\CarbonImmutable;
+
+test('returns empty collection when pay cycle is not configured', function () {
+    $user = User::factory()->create();
+
+    $months = app(MonthlyProjectionService::class)->forUser($user);
+
+    expect($months)->toBeEmpty();
+});
+
+test('returns 12 months by default starting at the current month', function () {
+    $user = User::factory()->withPayCycle()->create();
+
+    $months = app(MonthlyProjectionService::class)->forUser($user);
+
+    expect($months)->toHaveCount(12)
+        ->and($months->first()->isCurrent)->toBeTrue()
+        ->and($months->first()->monthStart->equalTo(CarbonImmutable::today()->startOfMonth()))->toBeTrue();
+});
+
+test('returns the requested number of months when not 12', function () {
+    $user = User::factory()->withPayCycle()->create();
+
+    $months = app(MonthlyProjectionService::class)->forUser($user, 6);
+
+    expect($months)->toHaveCount(6);
+});
+
+test('isYearStart is true for the first month and for January', function () {
+    $user = User::factory()->withPayCycle()->create();
+
+    $months = app(MonthlyProjectionService::class)->forUser($user);
+
+    expect($months->first()->isYearStart)->toBeTrue();
+
+    $january = $months->first(fn (ProjectedMonth $month) => $month->monthStart->month === 1 && $month->monthIndex !== 0);
+
+    if ($january !== null) {
+        expect($january->isYearStart)->toBeTrue();
+    }
+});
+
+test('income is smoothed for fortnightly pay using the 26/12 average', function () {
+    $user = User::factory()->withPayCycle()->create([
+        'pay_amount' => 300000,
+        'pay_frequency' => PayFrequency::Fortnightly,
+    ]);
+
+    $months = app(MonthlyProjectionService::class)->forUser($user, 1);
+
+    expect($months->first()->incomeCents)->toBe(intdiv(300000 * 26, 12));
+});
+
+test('income is smoothed for weekly pay using the 52/12 average', function () {
+    $user = User::factory()->withPayCycle()->create([
+        'pay_amount' => 100000,
+        'pay_frequency' => PayFrequency::Weekly,
+    ]);
+
+    $months = app(MonthlyProjectionService::class)->forUser($user, 1);
+
+    expect($months->first()->incomeCents)->toBe(intdiv(100000 * 52, 12));
+});
+
+test('income equals raw pay amount for monthly frequency', function () {
+    $user = User::factory()->withPayCycle()->create([
+        'pay_amount' => 600000,
+        'pay_frequency' => PayFrequency::Monthly,
+    ]);
+
+    $months = app(MonthlyProjectionService::class)->forUser($user, 1);
+
+    expect($months->first()->incomeCents)->toBe(600000);
+});
+
+test('sums planned debit transactions occurring in the month into expenses', function () {
+    $user = User::factory()->withPayCycle()->create([
+        'pay_amount' => 500000,
+        'pay_frequency' => PayFrequency::Monthly,
+    ]);
+    $account = Account::factory()->for($user)->create();
+
+    $thisMonthStart = CarbonImmutable::today()->startOfMonth();
+
+    PlannedTransaction::factory()->for($user)->for($account)->create([
+        'direction' => TransactionDirection::Debit,
+        'amount' => 80000,
+        'start_date' => $thisMonthStart->addDays(2),
+        'frequency' => RecurrenceFrequency::DontRepeat,
+        'is_active' => true,
+    ]);
+
+    $months = app(MonthlyProjectionService::class)->forUser($user, 1);
+
+    expect($months->first()->expenseCents)->toBe(80000);
+});
+
+test('expands recurring planned transactions across all 12 months', function () {
+    $user = User::factory()->withPayCycle()->create([
+        'pay_amount' => 500000,
+        'pay_frequency' => PayFrequency::Monthly,
+    ]);
+    $account = Account::factory()->for($user)->create();
+
+    $thisMonthStart = CarbonImmutable::today()->startOfMonth();
+
+    PlannedTransaction::factory()->for($user)->for($account)->create([
+        'direction' => TransactionDirection::Debit,
+        'amount' => 25000,
+        'start_date' => $thisMonthStart->addDays(2),
+        'frequency' => RecurrenceFrequency::EveryMonth,
+        'is_active' => true,
+    ]);
+
+    $months = app(MonthlyProjectionService::class)->forUser($user);
+
+    foreach ($months as $month) {
+        expect($month->expenseCents)->toBe(25000);
+    }
+});
+
+test('credit-direction planned transactions are added to income', function () {
+    $user = User::factory()->withPayCycle()->create([
+        'pay_amount' => 100000,
+        'pay_frequency' => PayFrequency::Monthly,
+    ]);
+    $account = Account::factory()->for($user)->create();
+
+    $thisMonthStart = CarbonImmutable::today()->startOfMonth();
+
+    PlannedTransaction::factory()->for($user)->for($account)->create([
+        'direction' => TransactionDirection::Credit,
+        'amount' => 20000,
+        'start_date' => $thisMonthStart->addDays(5),
+        'frequency' => RecurrenceFrequency::DontRepeat,
+        'is_active' => true,
+    ]);
+
+    $months = app(MonthlyProjectionService::class)->forUser($user, 1);
+
+    expect($months->first()->incomeCents)->toBe(120000);
+});
+
+test('excludes transfer-categorised planned transactions from expenses', function () {
+    $user = User::factory()->withPayCycle()->create([
+        'pay_amount' => 500000,
+        'pay_frequency' => PayFrequency::Monthly,
+    ]);
+    $account = Account::factory()->for($user)->create();
+    $transferCategory = Category::factory()->create(['name' => 'Transfer']);
+
+    PlannedTransaction::factory()->for($user)->for($account)->create([
+        'category_id' => $transferCategory->id,
+        'direction' => TransactionDirection::Debit,
+        'amount' => 99000,
+        'start_date' => CarbonImmutable::today()->startOfMonth()->addDays(3),
+        'frequency' => RecurrenceFrequency::DontRepeat,
+        'is_active' => true,
+    ]);
+
+    $months = app(MonthlyProjectionService::class)->forUser($user, 1);
+
+    expect($months->first()->expenseCents)->toBe(0);
+});
+
+test('surfaces DontRepeat debit planned transactions as one-offs in matching month', function () {
+    $user = User::factory()->withPayCycle()->create([
+        'pay_amount' => 500000,
+        'pay_frequency' => PayFrequency::Monthly,
+    ]);
+    $account = Account::factory()->for($user)->create();
+
+    $thisMonthStart = CarbonImmutable::today()->startOfMonth();
+
+    PlannedTransaction::factory()->for($user)->for($account)->create([
+        'description' => 'Annual insurance',
+        'direction' => TransactionDirection::Debit,
+        'amount' => 150000,
+        'start_date' => $thisMonthStart->addDays(5),
+        'frequency' => RecurrenceFrequency::DontRepeat,
+        'is_active' => true,
+    ]);
+
+    $months = app(MonthlyProjectionService::class)->forUser($user);
+
+    $current = $months->first();
+    $next = $months->skip(1)->first();
+
+    expect($current->oneOffs)->toHaveCount(1)
+        ->and($current->oneOffs[0]->description)->toBe('Annual insurance')
+        ->and($next->oneOffs)->toHaveCount(0);
+});
+
+test('cumulative net is the running sum of monthly net', function () {
+    $user = User::factory()->withPayCycle()->create([
+        'pay_amount' => 100000,
+        'pay_frequency' => PayFrequency::Monthly,
+    ]);
+
+    $months = app(MonthlyProjectionService::class)->forUser($user, 3);
+
+    expect($months[0]->cumulativeNetCents)->toBe(100000)
+        ->and($months[1]->cumulativeNetCents)->toBe(200000)
+        ->and($months[2]->cumulativeNetCents)->toBe(300000);
+});
+
+test('isRisky is true when expenses exceed income', function () {
+    $user = User::factory()->withPayCycle()->create([
+        'pay_amount' => 100000,
+        'pay_frequency' => PayFrequency::Monthly,
+    ]);
+    $account = Account::factory()->for($user)->create();
+
+    PlannedTransaction::factory()->for($user)->for($account)->create([
+        'direction' => TransactionDirection::Debit,
+        'amount' => 200000,
+        'start_date' => CarbonImmutable::today()->startOfMonth()->addDays(3),
+        'frequency' => RecurrenceFrequency::DontRepeat,
+        'is_active' => true,
+    ]);
+
+    $months = app(MonthlyProjectionService::class)->forUser($user, 1);
+
+    expect($months->first()->isRisky())->toBeTrue();
+});
+
+test('isolates one user from another users planned transactions', function () {
+    $user = User::factory()->withPayCycle()->create([
+        'pay_amount' => 100000,
+        'pay_frequency' => PayFrequency::Monthly,
+    ]);
+    $otherUser = User::factory()->withPayCycle()->create();
+    $otherAccount = Account::factory()->for($otherUser)->create();
+
+    PlannedTransaction::factory()->for($otherUser)->for($otherAccount)->create([
+        'direction' => TransactionDirection::Debit,
+        'amount' => 99999,
+        'start_date' => CarbonImmutable::today()->startOfMonth()->addDays(3),
+        'frequency' => RecurrenceFrequency::EveryMonth,
+        'is_active' => true,
+    ]);
+
+    $months = app(MonthlyProjectionService::class)->forUser($user, 1);
+
+    expect($months->first()->expenseCents)->toBe(0);
+});


### PR DESCRIPTION
## Summary

Delivers Part 1 of the dashboard redesign per [EPIC #229](https://github.com/robwilde/can-eye-budget-v2/issues/229), bundling both subtasks in one branch:

- **#230** — Replaces the dashboard's "Recent Activity" list with a 14-day Pay Cycle Calendar widget (transaction pips, planned occurrences, daily net, click-to-detail panel, prev/next/today navigation).
- **#231** — Adds a lazy-loaded 12-month forward projection chart at the bottom of the dashboard with pay-cycle-smoothed income, planned-only expenses, cumulative buffer line, risky-month flagging, and one-off cost markers.

## What changed

**New components**
- `App\Livewire\Dashboard\PayCycleCalendar` (+ `PayCycleDayData` / `PayCyclePip` DTOs)
- `App\Livewire\Dashboard\MonthlyProjection` (+ `App\Services\Projection\MonthlyProjectionService`, `ProjectedMonth`, `ProjectedOneOff` DTOs)
- `<x-cib.day-net>` Blade primitive for the colored ±$ net pill
- Two new Blade views under `resources/views/livewire/dashboard/`

**Modified**
- `resources/views/livewire/dashboard.blade.php` — replaced "Recent activity" with the calendar widget; appended `<livewire:dashboard.monthly-projection lazy/>` below the grid; outer wrapper bumped to `space-y-6`.
- `resources/css/app.css` — ported `.cyc-*` and `.proj-*` rules from the prototype into `@layer components`, reusing existing CIB tokens.
- `app/Livewire/Dashboard.php` — removed unused `recentTransactions` computed.
- `tests/Feature/Livewire/DashboardTest.php` — replaced obsolete recent-activity assertions with `assertSeeLivewire('dashboard.pay-cycle-calendar')`.

## Architectural decisions

- **ApexCharts mounting**: chart container has `wire:ignore` and mounts via Alpine `x-init`. Without `wire:ignore`, Livewire's morphdom tears down the SVG on every roundtrip — non-negotiable per the plan's risk list.
- **Income smoothing**: weekly × 52/12, fortnightly × 26/12, monthly × 1. Avoids the "3-pay-month" calendar artifact for fortnightly users (26 pays/yr ≠ 24).
- **Expenses (v1) — planned only**: deterministic, testable, consistent with `User::totalNeededUntilPayday()`. Constructor flag `$includeHistoricalBaseline = false` reserved for v2 (planned + 90-day historical-debit baseline) without rewrite.
- **One-off detection**: `PlannedTransaction` rows with `RecurrenceFrequency::DontRepeat`, debit direction, amount ≥ $200 OR ≥ 25% of monthly pay (whichever is lower). Surfaced as ApexCharts `annotations.points`.
- **Cycle rendering**: half-open `[bounds.start, bounds.end)` — exactly 14 days for fortnightly with `cycleStart` = PAID and the last cell = PAYDAY. The actual next payday (`bounds.end`) is the start of the next cycle.
- **No caching for v1** — projection computed live (one query for active planned txns + PHP loop). Escape hatch documented in plan if it ever becomes a hot path.
- **Component composition**: `MonthlyProjection` is a separate Livewire component (not a computed on `Dashboard`) so `wire:ignore` scopes cleanly and the chart can lazy-load below the fold.

## Test plan

- [x] `op test.filter PayCycleCalendar` — 19/19 passing
- [x] `op test.filter MonthlyProjection` — 19/19 passing (service + Livewire combined)
- [x] `op test.filter Dashboard` — 52/52 passing (no regressions)
- [x] `op test` (full suite) — 1,561 passed, 0 failures (4 pre-existing skips)
- [x] `op analyse` (PHPStan) — clean
- [x] `op lint.dirty` (Pint) — clean
- [ ] Manual smoke on `/dashboard` with seeded user — confirm calendar replaces recent activity, today highlighted, prev/next cycles, click-to-detail
- [ ] Manual smoke — confirm 12-month projection chart renders below grid, risky-month banner shows when applicable, tooltips formatted as dollars
- [ ] Empty-state check — fresh user without pay cycle: both widgets render their empty-state with link to `pay-cycle.edit`
- [ ] Year-boundary check — set `next_pay_date` to early Jan: calendar renders 14 days correctly across boundary
- [ ] Verify `wire:ignore` correctness — trigger any Livewire action elsewhere on the page after chart renders, confirm chart is intact

## Risks (called out in plan, mitigated here)

- `wire:ignore` on chart container — required, easy to forget.
- `MoneyCast::format` (PHP) vs JS formatter parity — both produce `$1,234.56` style output; tooltips match the rest of the dashboard.
- `User::currentPayCycleBounds()` auto-fast-forwards past `next_pay_date` — tests assert against the bounds, never `next_pay_date` directly.
- `PlannedTransaction::occurrencesBetween` has `maxIterations = 1000` — fine for 12 months, future 24-month projection with `Everyday` plannings would need attention.

## Closes

Closes #229
Closes #230
Closes #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)