### PR TITLE
fix: [#234] Pay cycle calendar misaligns dates with weekday column headers

### DIFF
--- a/app/Livewire/Dashboard/Data/PayCycleDayData.php
+++ b/app/Livewire/Dashboard/Data/PayCycleDayData.php
@@ -13,6 +13,7 @@ final readonly class PayCycleDayData
         public string $iso,
         public int $day,
         public string $dayName,
+        public int $isoWeekday,
         public bool $isToday,
         public bool $isCycleStart,
         public bool $isCycleEnd,

--- a/app/Livewire/Dashboard/PayCycleCalendar.php
+++ b/app/Livewire/Dashboard/PayCycleCalendar.php
@@ -215,6 +215,7 @@ final class PayCycleCalendar extends Component
                 iso: $key,
                 day: $cursor->day,
                 dayName: $cursor->format('D'),
+                isoWeekday: $cursor->isoWeekday(),
                 isToday: $cursor->isSameDay($today),
                 isCycleStart: $cursor->isSameDay($cycleStart),
                 isCycleEnd: $cursor->isSameDay($lastRenderedDay),

--- a/resources/views/livewire/dashboard/pay-cycle-calendar.blade.php
+++ b/resources/views/livewire/dashboard/pay-cycle-calendar.blade.php
@@ -50,6 +50,7 @@
                             type="button"
                             wire:click="selectDay('{{ $day->iso }}')"
                             wire:key="cyc-day-{{ $day->iso }}"
+                            style="grid-column-start: {{ $day->isoWeekday }}"
                             @class([
                                 'cyc-day',
                                 'past' => $day->isPast && ! $day->isToday,

--- a/tests/Feature/Layout/SidebarUserMenuTest.php
+++ b/tests/Feature/Layout/SidebarUserMenuTest.php
@@ -70,7 +70,7 @@ it('renders the trigger as a real button with an accessible name', function () {
 
     expect($html)->toMatch(
         '/<button[^>]*data-test="sidebar-menu-button"[\s\S]*?'
-        .preg_quote($this->user->name, '/')
+        .preg_quote(e($this->user->name), '/')
         .'[\s\S]*?<\/button>/'
     );
 });
@@ -101,9 +101,9 @@ it('renders a real aria-label attribute on the sidebar trigger button', function
 
     expect($html)->toMatch(
         '/<button[^>]*data-test="sidebar-menu-button"[^>]*aria-label="'
-        .preg_quote($this->user->name, '/')
+        .preg_quote(e($this->user->name), '/')
         .'"|<button[^>]*aria-label="'
-        .preg_quote($this->user->name, '/')
+        .preg_quote(e($this->user->name), '/')
         .'"[^>]*data-test="sidebar-menu-button"/'
     );
 

--- a/tests/Feature/Livewire/Dashboard/PayCycleCalendarTest.php
+++ b/tests/Feature/Livewire/Dashboard/PayCycleCalendarTest.php
@@ -29,6 +29,21 @@ function nextMondayAtLeastDaysAhead(int $minDaysAhead): CarbonImmutable
     return $candidate;
 }
 
+function nextDateOnIsoWeekday(int $isoWeekday, int $minDaysAhead): CarbonImmutable
+{
+    if ($isoWeekday < 1 || $isoWeekday > 7) {
+        throw new InvalidArgumentException(sprintf('isoWeekday must be 1..7, got %d', $isoWeekday));
+    }
+
+    $candidate = CarbonImmutable::today()->addDays($minDaysAhead);
+
+    while ($candidate->isoWeekday() !== $isoWeekday) {
+        $candidate = $candidate->addDay();
+    }
+
+    return $candidate;
+}
+
 test('shows empty-state when pay cycle is not configured', function () {
     $user = User::factory()->create();
 
@@ -506,3 +521,76 @@ test('goToCurrentCycle resets cycle offset to 0 and selects today', function () 
     expect($component->get('cycleOffset'))->toBe(0)
         ->and($component->get('selectedDate'))->toBe(CarbonImmutable::today()->format('Y-m-d'));
 });
+
+test('first day of cycle reports correct isoWeekday for any starting weekday', function (int $startWeekday) {
+    $cycleStart = nextDateOnIsoWeekday($startWeekday, 14);
+    $nextPay = $cycleStart->addDays(14);
+
+    $user = User::factory()->withPayCycle()->create([
+        'pay_frequency' => PayFrequency::Fortnightly,
+        'next_pay_date' => $nextPay,
+    ]);
+    Account::factory()->for($user)->create();
+
+    /** @var list<PayCycleDayData> $days */
+    $days = Livewire::actingAs($user)
+        ->test(PayCycleCalendar::class)
+        ->instance()
+        ->days();
+
+    expect($days[0]->isoWeekday)->toBe($startWeekday)
+        ->and($days[0]->iso)->toBe($cycleStart->format('Y-m-d'));
+})->with([
+    'Monday' => 1,
+    'Tuesday' => 2,
+    'Wednesday' => 3,
+    'Thursday' => 4,
+    'Friday' => 5,
+    'Saturday' => 6,
+    'Sunday' => 7,
+]);
+
+test('every day reports its real iso weekday', function (int $startWeekday) {
+    $cycleStart = nextDateOnIsoWeekday($startWeekday, 14);
+    $nextPay = $cycleStart->addDays(14);
+
+    $user = User::factory()->withPayCycle()->create([
+        'pay_frequency' => PayFrequency::Fortnightly,
+        'next_pay_date' => $nextPay,
+    ]);
+    Account::factory()->for($user)->create();
+
+    /** @var list<PayCycleDayData> $days */
+    $days = Livewire::actingAs($user)
+        ->test(PayCycleCalendar::class)
+        ->instance()
+        ->days();
+
+    foreach ($days as $day) {
+        $parsed = CarbonImmutable::createFromFormat('Y-m-d', $day->iso);
+        expect($day->isoWeekday)->toBe($parsed->isoWeekday());
+    }
+})->with([1, 2, 3, 4, 5, 6, 7]);
+
+test('blade renders grid-column-start matching the real weekday for the first day', function (int $startWeekday) {
+    $cycleStart = nextDateOnIsoWeekday($startWeekday, 14);
+    $nextPay = $cycleStart->addDays(14);
+
+    $user = User::factory()->withPayCycle()->create([
+        'pay_frequency' => PayFrequency::Fortnightly,
+        'next_pay_date' => $nextPay,
+    ]);
+    Account::factory()->for($user)->create();
+
+    $html = Livewire::actingAs($user)
+        ->test(PayCycleCalendar::class)
+        ->html();
+
+    $expectedPattern = sprintf(
+        '/<button\b[^>]*wire:key="%s"[^>]*style="[^"]*grid-column-start:\s*%d\b[^"]*"[^>]*>/s',
+        preg_quote(sprintf('cyc-day-%s', $cycleStart->format('Y-m-d')), '/'),
+        $startWeekday,
+    );
+
+    expect($html)->toMatch($expectedPattern);
+})->with([1, 2, 3, 4, 5, 6, 7]);


### PR DESCRIPTION
## Summary

Fixes [#234](https://github.com/robwilde/can-eye-budget-v2/issues/234). The dashboard "Pay cycle" calendar rendered dates in linear order under fixed Mon–Sun column headers, so any cycle that didn't start on a Monday placed every date under the wrong weekday.

**Reported example** (fortnightly, last payday Thu 23 Apr 2026):
- Before: 23 Apr → Mon column · 26 Apr (TODAY) → Thu column · 6 May (PAYDAY) → Sun column
- After: 23 Apr → Thu · 26 Apr → Sun · 6 May → Wed ✅

## Root cause

`pay-cycle-calendar.blade.php` emitted a flat `@foreach ($this->days as $day)` into a CSS Grid (`grid-template-columns: repeat(7, minmax(0, 1fr))`) with no leading offset. Auto-flow placed the first day in column 1 regardless of its real weekday — every subsequent date inherited the misalignment.

## Fix

A minimal three-line change drives layout from the cell's real ISO weekday:

| File | Change |
|---|---|
| `app/Livewire/Dashboard/Data/PayCycleDayData.php` | Added `public int $isoWeekday` to the DTO. |
| `app/Livewire/Dashboard/PayCycleCalendar.php` | Populated via `\$cursor->isoWeekday()` (Carbon: 1=Mon..7=Sun). |
| `resources/views/livewire/dashboard/pay-cycle-calendar.blade.php` | Added `style="grid-column-start: {{ \$day->isoWeekday }}"` to the day button. |

ISO weekday maps directly to CSS Grid's 1-indexed `grid-column-start`, so the first day lands under the correct column and CSS Grid auto-flow handles the rest.

## Test plan

- [x] **`first day of cycle reports correct isoWeekday for any starting weekday`** — dataset over all 7 weekdays, asserts the first day's `isoWeekday` matches its real Carbon weekday.
- [x] **`every day reports its real iso weekday`** — dataset over all 7 starting weekdays, asserts every cell's `isoWeekday` matches `CarbonImmutable::createFromFormat('Y-m-d', \$day->iso)->isoWeekday()`.
- [x] **`blade renders grid-column-start matching the real weekday for the first day`** — dataset over all 7 starting weekdays, asserts the rendered HTML contains the correct inline style.
- [x] Full local Pest suite green before push.
- [x] Tidy: removed stale `.claude/scheduled_tasks.lock`; escaped user name in `SidebarUserMenuTest` (unrelated drive-by fix).

## Why tests didn't catch this earlier

Existing `PayCycleCalendarTest` only seeded fixtures whose `start_date` happened to align with a Monday, so the bug was invisible to the tests. The new dataset-driven specs parameterize over all 7 starting weekdays, so any future regression in column placement will fail loudly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)