### PR TITLE
fix: [#237] Rebuild /calendar as full-month grid with per-day totals and click-to-select detail panel

### DIFF
--- a/app/Livewire/CalendarView.php
+++ b/app/Livewire/CalendarView.php
@@ -5,13 +5,14 @@ declare(strict_types=1);
 namespace App\Livewire;
 
 use App\Casts\MoneyCast;
-use App\Enums\TransactionDirection;
-use App\Models\PlannedTransaction;
-use App\Models\Transaction;
-use App\Services\ReconciliationMatcher;
+use App\Enums\PayFrequency;
+use App\Livewire\Dashboard\Data\PayCyclePip;
+use App\Livewire\Data\CalendarDayData;
+use App\Models\User;
+use App\Support\Calendar\DayActivity;
+use App\Support\Calendar\DayActivityLoader;
 use Carbon\CarbonImmutable;
 use Carbon\Constants\UnitValue;
-use Illuminate\Support\Collection;
 use Illuminate\View\View;
 use Livewire\Attributes\Computed;
 use Livewire\Attributes\On;
@@ -19,6 +20,8 @@ use Livewire\Component;
 
 final class CalendarView extends Component
 {
+    public const int MAX_PIPS_PER_DAY = 3;
+
     public string $currentMonth = '';
 
     public string $selectedDate = '';
@@ -37,39 +40,43 @@ final class CalendarView extends Component
             ? $parsed->format('Y-m-d')
             : CarbonImmutable::today()->format('Y-m-d');
 
-        unset($this->agenda, $this->weekStrip); // @phpstan-ignore property.notFound
+        unset($this->selectedDay); // @phpstan-ignore property.notFound
     }
 
     public function previousMonth(): void
     {
-        $this->currentMonth = $this->monthStart()->subMonth()->format('Y-m');
-        $this->selectedDate = $this->monthStart()->format('Y-m-d');
-        unset($this->calendarData, $this->agenda, $this->weekStrip); // @phpstan-ignore property.notFound
+        $target = $this->monthStart()->subMonth();
+        $this->currentMonth = $target->format('Y-m');
+        $this->selectedDate = $target->format('Y-m-d');
+        $this->bustCache();
     }
 
     public function nextMonth(): void
     {
-        $this->currentMonth = $this->monthStart()->addMonth()->format('Y-m');
-        $this->selectedDate = $this->monthStart()->format('Y-m-d');
-        unset($this->calendarData, $this->agenda, $this->weekStrip); // @phpstan-ignore property.notFound
+        $target = $this->monthStart()->addMonth();
+        $this->currentMonth = $target->format('Y-m');
+        $this->selectedDate = $target->format('Y-m-d');
+        $this->bustCache();
     }
 
     public function goToToday(): void
     {
         $this->currentMonth = CarbonImmutable::now()->format('Y-m');
         $this->selectedDate = CarbonImmutable::today()->format('Y-m-d');
-        unset($this->calendarData, $this->agenda, $this->weekStrip); // @phpstan-ignore property.notFound
+        $this->bustCache();
     }
 
     #[On('transaction-saved')]
     public function refreshCalendar(): void
     {
-        unset($this->calendarData, $this->agenda, $this->weekStrip); // @phpstan-ignore property.notFound
+        $this->bustCache();
     }
 
-    /** @return array{monthLabel: string, weeks: list<list<array{date: int, fullDate: string, isCurrentMonth: bool, isToday: bool, transactions: list<array{id: int|null, category: string, icon: string|null, amount: int, direction: string, type: string, source: string, isTransfer: bool, planned_transaction_id: int|null, reconciliation_status: string|null, linked_transaction_id: int|null, occurrence_date: string|null}>}>>, isCurrentMonth: bool} */
-    #[Computed(persist: true)]
-    public function calendarData(): array
+    /**
+     * @return list<CalendarDayData>
+     */
+    #[Computed]
+    public function days(): array
     {
         $monthStart = $this->monthStart();
         $monthEnd = $monthStart->endOfMonth();
@@ -78,267 +85,132 @@ final class CalendarView extends Component
         $gridStart = $monthStart->startOfWeek(UnitValue::MONDAY);
         $gridEnd = $monthEnd->endOfWeek(UnitValue::SUNDAY);
 
-        $allTransactions = Transaction::query()
-            ->where('user_id', auth()->id())
-            ->current()
-            ->whereBetween('post_date', [$gridStart, $gridEnd])
-            ->with([
-                'category:id,name,icon,parent_id',
-                'category.parent:id,icon,parent_id',
-                'category.parent.parent:id,icon,parent_id',
-            ])
-            ->orderBy('post_date')
-            ->get();
-
-        /** @var Collection<string, Collection<int, Transaction>> $transactionsByDate */
-        $transactionsByDate = $allTransactions
-            ->groupBy(fn (Transaction $t) => $t->post_date->format('Y-m-d'));
-
-        /** @var Collection<int, Collection<int, Transaction>> $linkedByPlannedId */
-        $linkedByPlannedId = $allTransactions
-            ->filter(fn (Transaction $t) => $t->planned_transaction_id !== null)
-            ->groupBy('planned_transaction_id');
-
-        /** @var Collection<int, Collection<int, Transaction>> $unlinkedByAccount */
-        $unlinkedByAccount = $allTransactions
-            ->filter(fn (Transaction $t) => $t->planned_transaction_id === null)
-            ->groupBy('account_id');
-
-        $plannedByDate = collect();
-
-        $plannedTransactions = PlannedTransaction::query()
-            ->where('user_id', auth()->id())
-            ->where('is_active', true)
-            ->where('start_date', '<=', $gridEnd)
-            ->where(fn ($q) => $q->whereNull('until_date')->orWhere('until_date', '>=', $gridStart))
-            ->with([
-                'category:id,name,icon,parent_id',
-                'category.parent:id,icon,parent_id',
-                'category.parent.parent:id,icon,parent_id',
-            ])
-            ->get();
-
-        foreach ($plannedTransactions as $planned) {
-            foreach ($planned->occurrencesBetween($gridStart, $gridEnd) as $date) {
-                $dateKey = $date->format('Y-m-d');
-                $existing = $plannedByDate->get($dateKey, []);
-
-                $reconciliationResult = $this->resolveReconciliationStatus(
-                    $planned,
-                    $date,
-                    $linkedByPlannedId,
-                    $unlinkedByAccount,
-                );
-
-                $existing[] = [
-                    'id' => null,
-                    'category' => $planned->category?->name ?? $planned->description, // @phpstan-ignore nullsafe.neverNull
-                    'icon' => $planned->category?->resolveIcon(),
-                    'amount' => $planned->amount,
-                    'direction' => $planned->direction->value,
-                    'type' => 'planned',
-                    'source' => 'planned',
-                    'isTransfer' => $planned->transfer_to_account_id !== null,
-                    'planned_transaction_id' => $planned->id,
-                    'reconciliation_status' => $reconciliationResult['status'],
-                    'linked_transaction_id' => $reconciliationResult['linked_transaction_id'],
-                    'occurrence_date' => $dateKey,
-                ];
-                $plannedByDate->put($dateKey, $existing);
-            }
-        }
-
-        $weeks = [];
-        $current = $gridStart;
-
-        while ($current <= $gridEnd) {
-            $week = [];
-            for ($i = 0; $i < 7; $i++) {
-                $dateKey = $current->format('Y-m-d');
-                $dayTransactions = $transactionsByDate->get($dateKey, collect());
-
-                $actualTxns = $dayTransactions->map(fn (Transaction $t) => [
-                    'id' => $t->id,
-                    'category' => $t->category?->name ?? $t->description, // @phpstan-ignore nullsafe.neverNull
-                    'icon' => $t->category?->resolveIcon(),
-                    'amount' => $t->amount,
-                    'direction' => $t->direction->value,
-                    'type' => 'actual',
-                    'source' => $t->source->value,
-                    'isTransfer' => $t->transfer_pair_id !== null,
-                    'planned_transaction_id' => $t->planned_transaction_id,
-                    'reconciliation_status' => null,
-                    'linked_transaction_id' => null,
-                    'occurrence_date' => null,
-                ])->values()->all();
-
-                $week[] = [
-                    'date' => $current->day,
-                    'fullDate' => $dateKey,
-                    'isCurrentMonth' => $current->month === $monthStart->month && $current->year === $monthStart->year,
-                    'isToday' => $current->isSameDay($today),
-                    'transactions' => array_merge($actualTxns, (array) $plannedByDate->get($dateKey, [])),
-                ];
-
-                $current = $current->addDay();
-            }
-            $weeks[] = $week;
-        }
-
-        return [
-            'monthLabel' => $monthStart->format('F Y'),
-            'weeks' => $weeks,
-            'isCurrentMonth' => $monthStart->month === $today->month && $monthStart->year === $today->year,
-        ];
-    }
-
-    /**
-     * @return list<array{date: string, dayOfMonth: int, dayName: string, isToday: bool, isPayday: bool, isSelected: bool, dots: list<string>}>
-     */
-    #[Computed]
-    public function weekStrip(): array
-    {
-        $today = CarbonImmutable::today();
-        $start = $today->subDays(2);
-
+        $userId = (int) auth()->id();
         $user = auth()->user();
-        $paydayKey = $user?->next_pay_date?->format('Y-m-d');
 
-        /** @var Collection<string, array<string, mixed>> $byDate */
-        $byDate = collect($this->calendarData['weeks']) // @phpstan-ignore property.notFound, argument.templateType, argument.templateType
-            ->flatten(1)
-            ->keyBy('fullDate');
+        $activity = (new DayActivityLoader)->load($gridStart, $gridEnd, $userId);
 
-        $cells = [];
+        $paydays = $user instanceof User
+            ? $this->paydaysWithinGrid($gridStart, $gridEnd, $user)
+            : [];
 
-        for ($i = 0; $i < 7; $i++) {
-            $cursor = $start->addDays($i);
+        $activeCycle = $user?->currentPayCycleBounds();
+
+        $days = [];
+        $cursor = $gridStart;
+
+        while ($cursor->lessThanOrEqualTo($gridEnd)) {
             $key = $cursor->format('Y-m-d');
+            $dayActivity = $activity[$key] ?? DayActivity::empty();
 
-            /** @var list<array<string, mixed>> $txns */
-            $txns = $byDate->get($key)['transactions'] ?? [];
+            $hiddenCount = max(0, count($dayActivity->pips) - self::MAX_PIPS_PER_DAY);
 
-            $dots = [];
+            $isCurrentMonth = $cursor->month === $monthStart->month && $cursor->year === $monthStart->year;
+            $paydayKind = $paydays[$key] ?? null;
+            $isNextPayday = $paydayKind === 'next' && $isCurrentMonth;
 
-            if (collect($txns)->contains(fn (array $t): bool => ($t['direction'] ?? null) === 'credit' && ($t['type'] ?? 'actual') === 'actual')) {
-                $dots[] = 'income';
-            }
+            $isInActiveCycle = $activeCycle !== null
+                && $cursor->greaterThanOrEqualTo($activeCycle['start'])
+                && $cursor->lessThan($activeCycle['end']);
 
-            if (collect($txns)->contains(fn (array $t): bool => ($t['direction'] ?? null) === 'debit' && ($t['type'] ?? 'actual') === 'actual')) {
-                $dots[] = 'posted';
-            }
+            $days[] = new CalendarDayData(
+                iso: $key,
+                day: $cursor->day,
+                dayName: $cursor->format('D'),
+                isoWeekday: $cursor->isoWeekday(),
+                isToday: $cursor->isSameDay($today),
+                isPast: $cursor->lessThan($today),
+                isCurrentMonth: $isCurrentMonth,
+                isPastPayday: $paydayKind === 'past',
+                isNextPayday: $isNextPayday,
+                isInActiveCycle: $isInActiveCycle,
+                pips: $dayActivity->pips,
+                hiddenCount: $hiddenCount,
+                netCents: $dayActivity->incomeCents - $dayActivity->postedCents,
+                incomeCents: $dayActivity->incomeCents,
+                postedCents: $dayActivity->postedCents,
+                plannedCents: $dayActivity->plannedCents,
+            );
 
-            if (collect($txns)->contains(fn (array $t): bool => ($t['type'] ?? 'actual') === 'planned')) {
-                $dots[] = 'planned';
-            }
-
-            $cells[] = [
-                'date' => $key,
-                'dayOfMonth' => $cursor->day,
-                'dayName' => $cursor->format('D'),
-                'isToday' => $cursor->isSameDay($today),
-                'isPayday' => $paydayKey === $key,
-                'isSelected' => $this->selectedDate === $key,
-                'dots' => $dots,
-            ];
+            $cursor = $cursor->addDay();
         }
 
-        return $cells;
+        return $days;
     }
 
     /**
-     * @return list<array{date: string, heading: string, net: int, transactions: list<array<string, mixed>>}>
+     * @return array{income: int, spend: int, net: int}
      */
     #[Computed]
-    public function agenda(): array
+    public function monthTotals(): array
     {
-        $fromKey = $this->selectedDate;
+        $income = 0;
+        $spend = 0;
 
-        return collect($this->calendarData['weeks']) // @phpstan-ignore property.notFound, argument.templateType, argument.templateType
-            ->flatten(1)
-            ->filter(fn (array $d): bool => $d['fullDate'] >= $fromKey)
-            ->filter(fn (array $d): bool => count($d['transactions']) > 0)
-            ->sortBy('fullDate')
-            ->values()
-            ->map(function (array $d): array {
-                $net = (int) collect($d['transactions']) // @phpstan-ignore argument.templateType, argument.templateType
-                    ->sum(fn (array $t): int => (($t['direction'] ?? null) === 'credit' ? 1 : -1) * abs((int) $t['amount']));
+        foreach ($this->days as $day) { // @phpstan-ignore property.notFound
+            if (! $day->isCurrentMonth) {
+                continue;
+            }
 
-                return [
-                    'date' => $d['fullDate'],
-                    'heading' => CarbonImmutable::parse($d['fullDate'])->format('j D M'),
-                    'net' => $net,
-                    'transactions' => $d['transactions'],
-                ];
-            })
-            ->all();
-    }
-
-    /**
-     * @return array{income: int, posted: int, planned: int, bufferAtPayday: int|null}
-     */
-    #[Computed]
-    public function quickline(): array
-    {
-        $user = auth()->user();
-        $bounds = $user?->currentPayCycleBounds();
-
-        if ($user === null || $bounds === null) {
-            return [
-                'income' => 0,
-                'posted' => 0,
-                'planned' => 0,
-                'bufferAtPayday' => null,
-            ];
+            $income += $day->incomeCents;
+            $spend += $day->postedCents;
         }
-
-        $txns = Transaction::query()
-            ->where('user_id', $user->id)
-            ->current()
-            ->whereBetween('post_date', [$bounds['start'], $bounds['end']])
-            ->get(['amount', 'direction']);
-
-        $income = (int) $txns
-            ->where('direction', TransactionDirection::Credit)
-            ->sum('amount');
-
-        $posted = (int) $txns
-            ->where('direction', TransactionDirection::Debit)
-            ->sum(fn (Transaction $t): int => abs((int) $t->amount));
-
-        $planned = (int) PlannedTransaction::query()
-            ->where('user_id', $user->id)
-            ->where('is_active', true)
-            ->where('direction', TransactionDirection::Debit)
-            ->where('start_date', '<=', $bounds['end'])
-            ->where(fn ($q) => $q->whereNull('until_date')->orWhere('until_date', '>=', $bounds['start']))
-            ->get()
-            ->sum(fn (PlannedTransaction $pt): int => $pt->occurrencesBetween($bounds['start'], $bounds['end'])->count() * abs((int) $pt->amount));
 
         return [
             'income' => $income,
-            'posted' => $posted,
-            'planned' => $planned,
-            'bufferAtPayday' => $user->bufferUntilNextPay($user->totalAvailable()),
+            'spend' => $spend,
+            'net' => $income - $spend,
         ];
     }
 
     /**
-     * @return array{label: string, rangeLabel: string|null}
+     * @return array{iso: string, dayLabel: string, dateLabel: string, pips: list<PayCyclePip>, netCents: int, isToday: bool, isPastPayday: bool, isNextPayday: bool}|null
+     */
+    #[Computed]
+    public function selectedDay(): ?array
+    {
+        if ($this->selectedDate === '') {
+            return null;
+        }
+
+        foreach ($this->days as $day) { // @phpstan-ignore property.notFound
+            if ($day->iso !== $this->selectedDate) {
+                continue;
+            }
+
+            $parsed = CarbonImmutable::createFromFormat('Y-m-d', $day->iso);
+
+            if (! $parsed instanceof CarbonImmutable) {
+                return null;
+            }
+
+            return [
+                'iso' => $day->iso,
+                'dayLabel' => $parsed->format('l'),
+                'dateLabel' => $parsed->format('j F'),
+                'pips' => $day->pips,
+                'netCents' => $day->netCents,
+                'isToday' => $day->isToday,
+                'isPastPayday' => $day->isPastPayday,
+                'isNextPayday' => $day->isNextPayday,
+            ];
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array{label: string, isCurrentMonth: bool}
      */
     #[Computed]
     public function headerLabel(): array
     {
         $month = $this->monthStart();
-        $bounds = auth()->user()?->currentPayCycleBounds();
-
-        $rangeLabel = $bounds
-            ? sprintf('Pay cycle · %s → %s', $bounds['start']->format('j M'), $bounds['end']->format('j M'))
-            : null;
+        $today = CarbonImmutable::today();
 
         return [
             'label' => $month->format('F Y'),
-            'rangeLabel' => $rangeLabel,
+            'isCurrentMonth' => $month->month === $today->month && $month->year === $today->year,
         ];
     }
 
@@ -351,18 +223,8 @@ final class CalendarView extends Component
                     <div class="animate-pulse h-9 w-28 rounded-full bg-(--color-cib-n-100)"></div>
                     <div class="animate-pulse h-9 w-28 rounded-full bg-(--color-cib-n-100)"></div>
                     <div class="animate-pulse h-9 w-28 rounded-full bg-(--color-cib-n-100)"></div>
-                    <div class="animate-pulse h-9 w-32 rounded-full bg-(--color-cib-n-100)"></div>
                 </div>
-                <div class="flex gap-2">
-                    <div class="animate-pulse h-16 w-14 rounded-xl bg-(--color-cib-n-100)"></div>
-                    <div class="animate-pulse h-16 w-14 rounded-xl bg-(--color-cib-n-100)"></div>
-                    <div class="animate-pulse h-16 w-14 rounded-xl bg-(--color-cib-n-100)"></div>
-                    <div class="animate-pulse h-16 w-14 rounded-xl bg-(--color-cib-n-100)"></div>
-                    <div class="animate-pulse h-16 w-14 rounded-xl bg-(--color-cib-n-100)"></div>
-                    <div class="animate-pulse h-16 w-14 rounded-xl bg-(--color-cib-n-100)"></div>
-                    <div class="animate-pulse h-16 w-14 rounded-xl bg-(--color-cib-n-100)"></div>
-                </div>
-                <div class="animate-pulse h-40 rounded-xl border-2 border-(--color-border-strong) bg-(--color-bg-surface)"></div>
+                <div class="animate-pulse h-96 rounded-xl border-2 border-(--color-border-strong) bg-(--color-bg-surface)"></div>
             </div>
             HTML;
     }
@@ -375,39 +237,57 @@ final class CalendarView extends Component
     }
 
     /**
-     * @param  Collection<int, Collection<int, Transaction>>  $linkedByPlannedId
-     * @param  Collection<int, Collection<int, Transaction>>  $unlinkedByAccount
-     * @return array{status: string, linked_transaction_id: int|null}
+     * Walk back/forward from the user's next_pay_date by pay_frequency to flag every payday
+     * inside the visible grid. Returns a map of iso-date => 'past' | 'next'. The 'next' tag
+     * is reserved for the single soonest payday >= today (only one cell ever wears it).
+     *
+     * @return array<string, 'past'|'next'>
      */
-    private function resolveReconciliationStatus(
-        PlannedTransaction $planned,
-        CarbonImmutable $occurrenceDate,
-        Collection $linkedByPlannedId,
-        Collection $unlinkedByAccount,
-    ): array {
-        $linked = $linkedByPlannedId->get($planned->id, collect())
-            ->first(fn (Transaction $t) => abs($t->post_date->diffInDays($occurrenceDate)) <= ReconciliationMatcher::DATE_TOLERANCE_DAYS);
-
-        if ($linked) {
-            return ['status' => 'reconciled', 'linked_transaction_id' => $linked->id];
+    private function paydaysWithinGrid(CarbonImmutable $gridStart, CarbonImmutable $gridEnd, User $user): array
+    {
+        if ($user->next_pay_date === null || $user->pay_frequency === null || ! $user->hasPayCycleConfigured()) {
+            return [];
         }
 
-        $hasSuggestion = $unlinkedByAccount->get($planned->account_id, collect())
-            ->contains(function (Transaction $t) use ($planned, $occurrenceDate) {
-                if ($t->direction !== $planned->direction) {
-                    return false;
+        $frequency = $user->pay_frequency;
+        $today = CarbonImmutable::today();
+        $anchor = CarbonImmutable::instance($user->next_pay_date);
+
+        $step = static fn (CarbonImmutable $date, int $direction): CarbonImmutable => match ($frequency) {
+            PayFrequency::Weekly => $date->addWeeks($direction),
+            PayFrequency::Fortnightly => $date->addWeeks($direction * 2),
+            PayFrequency::Monthly => $date->addMonthsNoOverflow($direction),
+        };
+
+        $maxIterations = 500;
+
+        $cursor = $anchor;
+        $iterations = 0;
+        while ($cursor->greaterThan($gridStart) && $iterations++ < $maxIterations) {
+            $cursor = $step($cursor, -1);
+        }
+
+        /** @var array<string, 'past'|'next'> $paydays */
+        $paydays = [];
+        $nextAssigned = false;
+        $iterations = 0;
+
+        while ($cursor->lessThanOrEqualTo($gridEnd) && $iterations++ < $maxIterations) {
+            if ($cursor->greaterThanOrEqualTo($gridStart)) {
+                $key = $cursor->format('Y-m-d');
+
+                if ($cursor->lessThan($today)) {
+                    $paydays[$key] = 'past';
+                } elseif (! $nextAssigned) {
+                    $paydays[$key] = 'next';
+                    $nextAssigned = true;
                 }
+            }
 
-                if (abs($t->post_date->diffInDays($occurrenceDate)) > ReconciliationMatcher::DATE_TOLERANCE_DAYS) {
-                    return false;
-                }
+            $cursor = $step($cursor, 1);
+        }
 
-                $amountDiff = abs(abs($t->amount) - abs($planned->amount));
-
-                return $amountDiff <= abs($planned->amount) * ReconciliationMatcher::AMOUNT_TOLERANCE;
-            });
-
-        return ['status' => $hasSuggestion ? 'suggested' : 'unreconciled', 'linked_transaction_id' => null];
+        return $paydays;
     }
 
     private function monthStart(): CarbonImmutable
@@ -420,5 +300,10 @@ final class CalendarView extends Component
         }
 
         return $date->startOfMonth();
+    }
+
+    private function bustCache(): void
+    {
+        unset($this->days, $this->monthTotals, $this->selectedDay, $this->headerLabel); // @phpstan-ignore property.notFound
     }
 }

--- a/app/Livewire/Dashboard/PayCycleCalendar.php
+++ b/app/Livewire/Dashboard/PayCycleCalendar.php
@@ -6,13 +6,11 @@ namespace App\Livewire\Dashboard;
 
 use App\Casts\MoneyCast;
 use App\Enums\PayFrequency;
-use App\Enums\TransactionDirection;
 use App\Livewire\Dashboard\Data\PayCycleDayData;
 use App\Livewire\Dashboard\Data\PayCyclePip;
-use App\Models\PlannedTransaction;
-use App\Models\Transaction;
+use App\Support\Calendar\DayActivity;
+use App\Support\Calendar\DayActivityLoader;
 use Carbon\CarbonImmutable;
-use Illuminate\Support\Collection;
 use Illuminate\View\View;
 use Livewire\Attributes\Computed;
 use Livewire\Component;
@@ -115,101 +113,16 @@ final class PayCycleCalendar extends Component
 
         $userId = (int) auth()->id();
 
-        $transactions = Transaction::query()
-            ->where('user_id', $userId)
-            ->current()
-            ->excludingTransfers()
-            ->whereBetween('post_date', [$cycleStart, $lastRenderedDay])
-            ->with([
-                'category:id,name,icon,parent_id',
-                'category.parent:id,icon,parent_id',
-                'category.parent.parent:id,icon,parent_id',
-            ])
-            ->orderBy('post_date')
-            ->get();
-
-        $plannedTransactions = PlannedTransaction::query()
-            ->where('user_id', $userId)
-            ->where('is_active', true)
-            ->excludingTransfers()
-            ->where('start_date', '<=', $lastRenderedDay)
-            ->where(static fn ($q) => $q->whereNull('until_date')->orWhere('until_date', '>=', $cycleStart))
-            ->with([
-                'category:id,name,icon,parent_id',
-                'category.parent:id,icon,parent_id',
-                'category.parent.parent:id,icon,parent_id',
-            ])
-            ->get();
-
-        /** @var Collection<string, Collection<int, Transaction>> $txByDate */
-        $txByDate = $transactions->groupBy(static fn (Transaction $t) => $t->post_date->format('Y-m-d'));
-
-        /** @var array<string, list<PayCyclePip>> $plannedByDate */
-        $plannedByDate = [];
-
-        foreach ($plannedTransactions as $planned) {
-            foreach ($planned->occurrencesBetween($cycleStart, $lastRenderedDay) as $occurrence) {
-                $key = $occurrence->format('Y-m-d');
-                $plannedByDate[$key] ??= [];
-                $plannedByDate[$key][] = new PayCyclePip(
-                    kind: 'plan',
-                    name: $planned->category?->name ?? $planned->description, // @phpstan-ignore nullsafe.neverNull
-                    amount: abs((int) $planned->amount),
-                    icon: $planned->category?->resolveIcon(),
-                    transactionId: null,
-                    plannedTransactionId: $planned->id,
-                    occurrenceDate: $key,
-                );
-            }
-        }
+        $activity = (new DayActivityLoader)->load($cycleStart, $lastRenderedDay, $userId);
 
         $days = [];
         $cursor = $cycleStart;
 
         while ($cursor->lessThanOrEqualTo($lastRenderedDay)) {
             $key = $cursor->format('Y-m-d');
-            $dayPips = [];
-            $incomeCents = 0;
-            $postedCents = 0;
-            $plannedCents = 0;
+            $dayActivity = $activity[$key] ?? DayActivity::empty();
 
-            /** @var Collection<int, Transaction> $dayTxns */
-            $dayTxns = $txByDate->get($key, collect());
-
-            foreach ($dayTxns as $tx) {
-                $absAmount = abs((int) $tx->amount);
-                $isCredit = $tx->direction === TransactionDirection::Credit;
-
-                if ($isCredit) {
-                    $incomeCents += $absAmount;
-                }
-
-                if (! $isCredit) {
-                    $postedCents += $absAmount;
-                }
-
-                $dayPips[] = new PayCyclePip(
-                    kind: $tx->direction === TransactionDirection::Credit ? 'inc' : 'out',
-                    name: $tx->category?->name ?? ($tx->description !== '' ? $tx->description : 'Transaction'), // @phpstan-ignore nullsafe.neverNull
-                    amount: $absAmount,
-                    icon: $tx->category?->resolveIcon(),
-                    transactionId: $tx->id,
-                    plannedTransactionId: null,
-                    occurrenceDate: null,
-                );
-            }
-
-            foreach ($plannedByDate[$key] ?? [] as $plannedPip) {
-                $plannedCents += $plannedPip->amount;
-                $dayPips[] = $plannedPip;
-            }
-
-            usort(
-                $dayPips,
-                static fn (PayCyclePip $a, PayCyclePip $b): int => $b->amount <=> $a->amount,
-            );
-
-            $hiddenCount = max(0, count($dayPips) - self::MAX_PIPS_PER_DAY);
+            $hiddenCount = max(0, count($dayActivity->pips) - self::MAX_PIPS_PER_DAY);
 
             $days[] = new PayCycleDayData(
                 iso: $key,
@@ -220,12 +133,12 @@ final class PayCycleCalendar extends Component
                 isCycleStart: $cursor->isSameDay($cycleStart),
                 isCycleEnd: $cursor->isSameDay($lastRenderedDay),
                 isPast: $cursor->lessThan($today),
-                pips: $dayPips,
+                pips: $dayActivity->pips,
                 hiddenCount: $hiddenCount,
-                netCents: $incomeCents - $postedCents,
-                incomeCents: $incomeCents,
-                postedCents: $postedCents,
-                plannedCents: $plannedCents,
+                netCents: $dayActivity->incomeCents - $dayActivity->postedCents,
+                incomeCents: $dayActivity->incomeCents,
+                postedCents: $dayActivity->postedCents,
+                plannedCents: $dayActivity->plannedCents,
             );
 
             $cursor = $cursor->addDay();

--- a/app/Livewire/Data/CalendarDayData.php
+++ b/app/Livewire/Data/CalendarDayData.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Data;
+
+use App\Livewire\Dashboard\Data\PayCyclePip;
+
+final readonly class CalendarDayData
+{
+    /**
+     * @param  list<PayCyclePip>  $pips  Full unsliced pip list for the day; the grid view slices for display, the detail panel uses the complete list.
+     */
+    public function __construct(
+        public string $iso,
+        public int $day,
+        public string $dayName,
+        public int $isoWeekday,
+        public bool $isToday,
+        public bool $isPast,
+        public bool $isCurrentMonth,
+        public bool $isPastPayday,
+        public bool $isNextPayday,
+        public bool $isInActiveCycle,
+        public array $pips,
+        public int $hiddenCount,
+        public int $netCents,
+        public int $incomeCents,
+        public int $postedCents,
+        public int $plannedCents,
+    ) {}
+}

--- a/app/Support/Calendar/DayActivity.php
+++ b/app/Support/Calendar/DayActivity.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support\Calendar;
+
+use App\Livewire\Dashboard\Data\PayCyclePip;
+
+final readonly class DayActivity
+{
+    /**
+     * @param  list<PayCyclePip>  $pips  Sorted by amount desc.
+     */
+    public function __construct(
+        public array $pips,
+        public int $incomeCents,
+        public int $postedCents,
+        public int $plannedCents,
+    ) {}
+
+    public static function empty(): self
+    {
+        return new self(pips: [], incomeCents: 0, postedCents: 0, plannedCents: 0);
+    }
+}

--- a/app/Support/Calendar/DayActivityLoader.php
+++ b/app/Support/Calendar/DayActivityLoader.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support\Calendar;
+
+use App\Enums\TransactionDirection;
+use App\Livewire\Dashboard\Data\PayCyclePip;
+use App\Models\PlannedTransaction;
+use App\Models\Transaction;
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Collection;
+
+final readonly class DayActivityLoader
+{
+    private const array CATEGORY_EAGER_LOAD = [
+        'category:id,name,icon,parent_id',
+        'category.parent:id,icon,parent_id',
+        'category.parent.parent:id,icon,parent_id',
+    ];
+
+    /**
+     * Load posted transactions and planned-transaction occurrences for the given date range,
+     * grouped by ISO date. Transfers are excluded. Pips per day are sorted by amount desc.
+     *
+     * @return array<string, DayActivity>
+     */
+    public function load(CarbonImmutable $start, CarbonImmutable $end, int $userId): array
+    {
+        $transactions = Transaction::query()
+            ->where('user_id', $userId)
+            ->current()
+            ->excludingTransfers()
+            ->whereBetween('post_date', [$start, $end])
+            ->with(self::CATEGORY_EAGER_LOAD)
+            ->orderBy('post_date')
+            ->get();
+
+        $plannedTransactions = PlannedTransaction::query()
+            ->where('user_id', $userId)
+            ->where('is_active', true)
+            ->excludingTransfers()
+            ->where('start_date', '<=', $end)
+            ->where(static fn ($q) => $q->whereNull('until_date')->orWhere('until_date', '>=', $start))
+            ->with(self::CATEGORY_EAGER_LOAD)
+            ->get();
+
+        /** @var Collection<string, Collection<int, Transaction>> $txByDate */
+        $txByDate = $transactions->groupBy(static fn (Transaction $t) => $t->post_date->format('Y-m-d'));
+
+        /** @var array<string, list<PayCyclePip>> $plannedPipsByDate */
+        $plannedPipsByDate = [];
+
+        foreach ($plannedTransactions as $planned) {
+            foreach ($planned->occurrencesBetween($start, $end) as $occurrence) {
+                $key = $occurrence->format('Y-m-d');
+                $plannedPipsByDate[$key] ??= [];
+                $plannedPipsByDate[$key][] = new PayCyclePip(
+                    kind: 'plan',
+                    name: $planned->category?->name ?? $planned->description, // @phpstan-ignore nullsafe.neverNull
+                    amount: abs((int) $planned->amount),
+                    icon: $planned->category?->resolveIcon(),
+                    transactionId: null,
+                    plannedTransactionId: $planned->id,
+                    occurrenceDate: $key,
+                );
+            }
+        }
+
+        $allKeys = array_unique(array_merge(
+            $txByDate->keys()->all(),
+            array_keys($plannedPipsByDate),
+        ));
+
+        $activity = [];
+
+        foreach ($allKeys as $key) {
+            $pips = [];
+            $incomeCents = 0;
+            $postedCents = 0;
+            $plannedCents = 0;
+
+            /** @var Collection<int, Transaction> $dayTxns */
+            $dayTxns = $txByDate->get($key, collect());
+
+            foreach ($dayTxns as $tx) {
+                $absAmount = abs((int) $tx->amount);
+                $isCredit = $tx->direction === TransactionDirection::Credit;
+
+                if ($isCredit) {
+                    $incomeCents += $absAmount;
+                }
+
+                if (! $isCredit) {
+                    $postedCents += $absAmount;
+                }
+
+                $pips[] = new PayCyclePip(
+                    kind: $isCredit ? 'inc' : 'out',
+                    name: $tx->category?->name ?? ($tx->description !== '' ? $tx->description : 'Transaction'), // @phpstan-ignore nullsafe.neverNull
+                    amount: $absAmount,
+                    icon: $tx->category?->resolveIcon(),
+                    transactionId: $tx->id,
+                    plannedTransactionId: null,
+                    occurrenceDate: null,
+                );
+            }
+
+            foreach ($plannedPipsByDate[$key] ?? [] as $plannedPip) {
+                $plannedCents += $plannedPip->amount;
+                $pips[] = $plannedPip;
+            }
+
+            usort(
+                $pips,
+                static fn (PayCyclePip $a, PayCyclePip $b): int => $b->amount <=> $a->amount,
+            );
+
+            $activity[$key] = new DayActivity(
+                pips: $pips,
+                incomeCents: $incomeCents,
+                postedCents: $postedCents,
+                plannedCents: $plannedCents,
+            );
+        }
+
+        return $activity;
+    }
+}

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -776,6 +776,12 @@ select:focus[data-flux-control] {
         transition: background 200ms var(--ease-snap);
     }
     .cyc-day:hover { background: var(--color-cib-n-50); }
+    .cyc-day.out {
+        background: repeating-linear-gradient(135deg, transparent 0 6px, rgba(0, 0, 0, 0.025) 6px 7px);
+        color: var(--color-fg-3);
+    }
+    .cyc-day.out .cyc-dnum { color: var(--color-fg-3); }
+    .cyc-day.cycle-band { background: color-mix(in oklab, var(--color-money-available-soft) 50%, var(--color-bg-surface)); }
     .cyc-day.past { background: var(--color-cib-n-50); }
     .cyc-day.past:hover { background: var(--color-cib-n-100); }
     .cyc-day.today { background: var(--color-cib-cream-50); }
@@ -897,6 +903,7 @@ select:focus[data-flux-control] {
     .cyc-detail-body { display: flex; flex-direction: column; gap: 6px; }
     .chip-today,
     .chip-pay,
+    .chip-paid,
     .chip-count {
         font: 700 11px/1 var(--font-sans);
         padding: 6px 10px;
@@ -905,6 +912,7 @@ select:focus[data-flux-control] {
     }
     .chip-today { background: var(--color-cib-cream-50); }
     .chip-pay { background: var(--color-cib-yellow-400); }
+    .chip-paid { background: var(--color-money-available-soft); color: var(--color-cib-green-600); }
     .chip-count { background: var(--color-bg-surface); color: var(--color-fg-2); }
     .pay-cycle-cal .cyc-empty {
         padding: 14px;

--- a/resources/views/livewire/calendar-view.blade.php
+++ b/resources/views/livewire/calendar-view.blade.php
@@ -1,120 +1,139 @@
-@use('Carbon\CarbonImmutable')
-<div data-testid="calendar-view" class="space-y-4">
-    <header class="flex flex-wrap items-center justify-between gap-2">
-        <div class="flex items-center gap-3">
-            <flux:button wire:click="previousMonth" variant="ghost" icon="chevron-left" size="sm" />
-            <div>
-                <h1 class="cib-title">{{ $this->headerLabel['label'] }}</h1>
-                @if ($this->headerLabel['rangeLabel'])
-                    <div class="cib-subtitle">{{ $this->headerLabel['rangeLabel'] }}</div>
-                @endif
-            </div>
-            <flux:button wire:click="nextMonth" variant="ghost" icon="chevron-right" size="sm" />
+@use('App\Livewire\CalendarView')
+
+<div data-testid="calendar-view" class="pay-cycle-cal">
+    <header class="cyc-head">
+        <div>
+            <h1 class="cyc-title">{{ $this->headerLabel['label'] }}</h1>
+            <p class="cyc-sub">All transactions · history & planned · Mon–Sun</p>
         </div>
-        @unless ($this->calendarData['isCurrentMonth'])
-            <flux:button wire:click="goToToday" variant="subtle" size="sm">Today</flux:button>
-        @endunless
+        <div class="cyc-nav">
+            <button type="button" wire:click="previousMonth" title="Previous month" aria-label="Previous month">
+                <flux:icon.chevron-left variant="micro"/>
+            </button>
+            <button type="button" wire:click="goToToday" @disabled($this->headerLabel['isCurrentMonth'])>
+                Today
+            </button>
+            <button type="button" wire:click="nextMonth" title="Next month" aria-label="Next month">
+                <flux:icon.chevron-right variant="micro"/>
+            </button>
+        </div>
     </header>
 
     <div class="quickline">
         <span class="pill pill-income">
             <span class="pill-label">Income</span>
-            <span class="pill-value tabular-nums">{{ $formatMoney($this->quickline['income']) }}</span>
+            <span class="pill-value tabular-nums">{{ $formatMoney($this->monthTotals['income']) }}</span>
         </span>
         <span class="pill pill-posted">
-            <span class="pill-label">Posted</span>
-            <span class="pill-value tabular-nums">{{ $formatMoney($this->quickline['posted']) }}</span>
-        </span>
-        <span class="pill pill-planned">
-            <span class="pill-label">Planned</span>
-            <span class="pill-value tabular-nums">{{ $formatMoney($this->quickline['planned']) }}</span>
+            <span class="pill-label">Spend</span>
+            <span class="pill-value tabular-nums">{{ $formatMoney($this->monthTotals['spend']) }}</span>
         </span>
         <span @class([
             'pill',
-            'pill-buffer-pos' => ($this->quickline['bufferAtPayday'] ?? 0) >= 0 && $this->quickline['bufferAtPayday'] !== null,
-            'pill-buffer-neg' => ($this->quickline['bufferAtPayday'] ?? 0) < 0,
-            'pill-buffer-empty' => $this->quickline['bufferAtPayday'] === null,
+            'pill-buffer-pos' => $this->monthTotals['net'] >= 0,
+            'pill-buffer-neg' => $this->monthTotals['net'] < 0,
         ])>
-            <span class="pill-label">Buffer</span>
-            <span class="pill-value tabular-nums">
-                @if ($this->quickline['bufferAtPayday'] === null)
-                    set pay cycle
-                @else
-                    {{ $formatMoney($this->quickline['bufferAtPayday']) }}
-                @endif
-            </span>
+            <span class="pill-label">Net</span>
+            <span class="pill-value tabular-nums">{{ $formatMoney($this->monthTotals['net']) }}</span>
         </span>
     </div>
 
-    <div class="week-strip">
-        @foreach ($this->weekStrip as $cell)
-            <button
-                type="button"
-                wire:key="day-{{ $cell['date'] }}"
-                wire:click="selectDate('{{ $cell['date'] }}')"
-                aria-pressed="{{ $cell['isSelected'] ? 'true' : 'false' }}"
-                @class([
-                    'day-cell',
-                    'is-today' => $cell['isToday'],
-                    'is-payday' => $cell['isPayday'],
-                    'is-selected' => $cell['isSelected'],
-                ])
-            >
-                <div class="day-name">{{ $cell['dayName'] }}</div>
-                <div class="day-num">{{ $cell['dayOfMonth'] }}</div>
-                @if ($cell['isPayday'])
-                    <div class="badge-payday">PAYDAY</div>
-                @endif
-                @if (count($cell['dots']) > 0)
-                    <div class="dots">
-                        @foreach ($cell['dots'] as $dot)
-                            <span @class(['dot', "dot-{$dot}"])></span>
-                        @endforeach
+    <div class="cyc-grid" role="grid">
+        <div class="cyc-dows" role="row">
+            @foreach (['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'] as $label)
+                <div class="cyc-dow" role="columnheader">{{ $label }}</div>
+            @endforeach
+        </div>
+        <div class="cyc-week-stream">
+            @foreach ($this->days as $day)
+                <button
+                        type="button"
+                        wire:click="selectDate('{{ $day->iso }}')"
+                        wire:key="cal-day-{{ $day->iso }}"
+                        style="grid-column-start: {{ $day->isoWeekday }}"
+                        @class([
+                            'cyc-day',
+                            'out' => ! $day->isCurrentMonth,
+                            'past' => $day->isPast && ! $day->isToday && $day->isCurrentMonth,
+                            'cycle-band' => $day->isInActiveCycle && $day->isCurrentMonth,
+                            'today' => $day->isToday,
+                            'lastpay' => $day->isPastPayday,
+                            'payday' => $day->isNextPayday,
+                            'active' => $day->iso === $this->selectedDate,
+                        ])
+                >
+                    <div class="cyc-day-top">
+                        <span class="cyc-dnum">{{ $day->day }}</span>
+                        @if ($day->isToday)
+                            <span class="cyc-today-pill">TODAY</span>
+                        @endif
+                        @if ($day->isNextPayday)
+                            <span class="cyc-paytag">PAYDAY</span>
+                        @elseif ($day->isPastPayday)
+                            <span class="cyc-paytag dim">PAID</span>
+                        @endif
                     </div>
-                @endif
-            </button>
-        @endforeach
+                    <div class="cyc-day-body">
+                        @foreach (array_slice($day->pips, 0, CalendarView::MAX_PIPS_PER_DAY) as $pip)
+                            <div @class(['cyc-pip', $pip->kind])>
+                                <span class="cyc-pip-dot"></span>
+                                <span class="cyc-pip-name">{{ $pip->name }}</span>
+                            </div>
+                        @endforeach
+                        @if ($day->hiddenCount > 0)
+                            <div class="cyc-pip-more">+{{ $day->hiddenCount }} more</div>
+                        @endif
+                    </div>
+                    <x-cib.day-net :cents="$day->netCents"/>
+                </button>
+            @endforeach
+        </div>
     </div>
 
-    @if (count($this->agenda) === 0)
-        <div class="empty-state">
-            <flux:icon.calendar class="mx-auto size-12 text-zinc-400" />
-            <flux:heading size="lg" class="mt-4">No transactions</flux:heading>
-            <flux:text class="mt-2">No transactions found from {{ CarbonImmutable::parse($this->selectedDate)->format('j M Y') }} onward.</flux:text>
-        </div>
-    @else
-        <div class="agenda">
-            @foreach ($this->agenda as $group)
-                <section wire:key="agenda-{{ $group['date'] }}" class="agenda-group">
-                    <header class="agenda-head">
-                        <h3>{{ $group['heading'] }}</h3>
-                        <span @class(['net tabular-nums', 'pos' => $group['net'] >= 0, 'neg' => $group['net'] < 0])>
-                            {{ $formatMoney($group['net']) }}
-                        </span>
-                    </header>
-                    <div class="day-card">
-                        @foreach ($group['transactions'] as $txn)
-                            @php
-                                $isPlanned = ($txn['type'] ?? 'actual') === 'planned';
-                                $tone = match (true) {
-                                    $isPlanned => 'plan',
-                                    ($txn['direction'] ?? null) === 'credit' => 'inc',
-                                    default => 'out',
-                                };
-                            @endphp
-                            <x-cib.tx-row
-                                :transaction-id="$isPlanned ? null : $txn['id']"
-                                :planned-transaction-id="$isPlanned ? $txn['planned_transaction_id'] : null"
-                                :occurrence-date="$isPlanned ? $txn['occurrence_date'] : null"
-                                :name="$txn['category']"
-                                :amount="$txn['amount']"
-                                :tone="$tone"
-                                :icon="$txn['icon'] ?? null"
-                            />
-                        @endforeach
-                    </div>
-                </section>
-            @endforeach
+    @if ($this->selectedDay !== null)
+        <div class="cyc-detail">
+            <div class="cyc-detail-head">
+                <div>
+                    <div class="cyc-detail-dow">{{ $this->selectedDay['dayLabel'] }}</div>
+                    <div class="cyc-detail-date">{{ $this->selectedDay['dateLabel'] }}</div>
+                </div>
+                <div class="cyc-detail-meta">
+                    @if ($this->selectedDay['isToday'])
+                        <span class="chip-today">Today</span>
+                    @endif
+                    @if ($this->selectedDay['isPastPayday'])
+                        <span class="chip-paid">Paid</span>
+                    @endif
+                    @if ($this->selectedDay['isNextPayday'])
+                        <span class="chip-pay">Payday</span>
+                    @endif
+                    <span class="chip-count">
+                        {{ count($this->selectedDay['pips']) }} item{{ count($this->selectedDay['pips']) === 1 ? '' : 's' }}
+                    </span>
+                </div>
+            </div>
+            <div class="cyc-detail-body">
+                @forelse ($this->selectedDay['pips'] as $pip)
+                    @php
+                        $rowTone = match ($pip->kind) {
+                            'inc' => 'inc',
+                            'plan' => 'plan',
+                            default => 'out',
+                        };
+                    @endphp
+                    <x-cib.tx-row
+                            :transaction-id="$pip->transactionId"
+                            :planned-transaction-id="$pip->plannedTransactionId"
+                            :occurrence-date="$pip->occurrenceDate"
+                            :name="$pip->name"
+                            :amount="$pip->amount"
+                            :tone="$rowTone"
+                            :icon="$pip->icon"
+                    />
+                @empty
+                    <p class="cyc-empty">Nothing on this day.</p>
+                @endforelse
+            </div>
         </div>
     @endif
 </div>

--- a/tests/Feature/Livewire/CalendarViewTest.php
+++ b/tests/Feature/Livewire/CalendarViewTest.php
@@ -4,14 +4,17 @@
 
 declare(strict_types=1);
 
+use App\Enums\PayFrequency;
 use App\Enums\TransactionDirection;
 use App\Livewire\CalendarView;
+use App\Livewire\Data\CalendarDayData;
 use App\Models\Account;
 use App\Models\Category;
 use App\Models\PlannedTransaction;
 use App\Models\Transaction;
 use App\Models\User;
 use Carbon\CarbonImmutable;
+use Carbon\Constants\UnitValue;
 use Livewire\Livewire;
 
 test('component renders for authenticated user', function () {
@@ -28,35 +31,93 @@ test('defaults to current month', function () {
     $component = Livewire::actingAs($user)
         ->test(CalendarView::class);
 
-    $data = $component->get('calendarData');
+    $header = $component->get('headerLabel');
 
-    expect($data['monthLabel'])->toBe(now()->format('F Y'))
-        ->and($data['isCurrentMonth'])->toBeTrue();
+    expect($header['label'])->toBe(now()->format('F Y'))
+        ->and($header['isCurrentMonth'])->toBeTrue();
+});
+
+test('renders a full month grid Monday through Sunday', function () {
+    $user = User::factory()->create();
+
+    /** @var CalendarView $instance */
+    $instance = Livewire::actingAs($user)
+        ->test(CalendarView::class)
+        ->instance();
+    /** @var list<CalendarDayData> $days */
+    $days = $instance->days();
+
+    expect($days)->not->toBeEmpty()
+        ->and(count($days) % 7)->toBe(0)
+        ->and(count($days))->toBeIn([28, 35, 42])
+        ->and($days[0]->isoWeekday)->toBe(UnitValue::MONDAY)
+        ->and(end($days)->isoWeekday)->toBe(7);
+});
+
+test('marks leading and trailing days as out-of-month', function () {
+    $user = User::factory()->create();
+
+    /** @var CalendarView $instance */
+    $instance = Livewire::actingAs($user)
+        ->test(CalendarView::class)
+        ->instance();
+    /** @var list<CalendarDayData> $days */
+    $days = $instance->days();
+
+    $monthStart = CarbonImmutable::now()->startOfMonth();
+    $outDays = collect($days)->filter(fn (CalendarDayData $d) => ! $d->isCurrentMonth);
+    $inDays = collect($days)->filter(fn (CalendarDayData $d) => $d->isCurrentMonth);
+
+    expect($inDays->isNotEmpty())->toBeTrue()
+        ->and($inDays->every(fn (CalendarDayData $d) => str_starts_with($d->iso, $monthStart->format('Y-m'))))->toBeTrue();
+
+    if ($monthStart->isoWeekday() !== UnitValue::MONDAY || CarbonImmutable::now()->endOfMonth()->isoWeekday() !== UnitValue::SUNDAY) {
+        expect($outDays->isNotEmpty())->toBeTrue();
+    }
+});
+
+test('today is marked when current month is in view', function () {
+    $user = User::factory()->create();
+
+    /** @var CalendarView $instance */
+    $instance = Livewire::actingAs($user)
+        ->test(CalendarView::class)
+        ->instance();
+    /** @var list<CalendarDayData> $days */
+    $days = $instance->days();
+
+    $todayDay = collect($days)->first(fn (CalendarDayData $d) => $d->isToday);
+
+    expect($todayDay)->not->toBeNull()
+        ->and($todayDay?->iso)->toBe(CarbonImmutable::today()->format('Y-m-d'));
 });
 
 test('shows transactions for current month', function () {
     $user = User::factory()->create();
     $account = Account::factory()->for($user)->create();
     $category = Category::factory()->create(['name' => 'Groceries']);
+    $date = CarbonImmutable::now()->startOfMonth()->addDays(5);
 
     Transaction::factory()->for($user)->debit()->create([
         'account_id' => $account->id,
         'category_id' => $category->id,
         'amount' => -4250,
-        'post_date' => now()->startOfMonth()->addDays(5),
+        'post_date' => $date,
     ]);
 
-    $component = Livewire::actingAs($user)
-        ->test(CalendarView::class);
+    /** @var CalendarView $instance */
+    $instance = Livewire::actingAs($user)
+        ->test(CalendarView::class)
+        ->instance();
+    /** @var list<CalendarDayData> $days */
+    $days = $instance->days();
 
-    $data = $component->get('calendarData');
-    $allTransactions = collect($data['weeks'])->flatten(1)
-        ->flatMap(fn (array $day) => $day['transactions']);
+    $cell = collect($days)->firstWhere('iso', $date->format('Y-m-d'));
 
-    expect($allTransactions)->toHaveCount(1)
-        ->and($allTransactions->first()['category'])->toBe('Groceries')
-        ->and($allTransactions->first()['amount'])->toBe(-4250)
-        ->and($allTransactions->first()['direction'])->toBe('debit');
+    expect($cell)->not->toBeNull()
+        ->and($cell->pips)->toHaveCount(1)
+        ->and($cell->pips[0]->name)->toBe('Groceries')
+        ->and($cell->pips[0]->kind)->toBe('out');
 });
 
 test('only shows current user transactions', function () {
@@ -64,60 +125,145 @@ test('only shows current user transactions', function () {
     $otherUser = User::factory()->create();
     $account = Account::factory()->for($user)->create();
     $otherAccount = Account::factory()->for($otherUser)->create();
+    $date = CarbonImmutable::now()->startOfMonth()->addDays(3);
 
     Transaction::factory()->for($user)->debit()->create([
         'account_id' => $account->id,
         'amount' => -3000,
-        'post_date' => now()->startOfMonth()->addDays(3),
+        'post_date' => $date,
     ]);
 
     Transaction::factory()->for($otherUser)->debit()->create([
         'account_id' => $otherAccount->id,
         'amount' => -8000,
-        'post_date' => now()->startOfMonth()->addDays(3),
+        'post_date' => $date,
     ]);
 
-    $component = Livewire::actingAs($user)
-        ->test(CalendarView::class);
+    /** @var CalendarView $instance */
+    $instance = Livewire::actingAs($user)
+        ->test(CalendarView::class)
+        ->instance();
+    /** @var list<CalendarDayData> $days */
+    $days = $instance->days();
 
-    $data = $component->get('calendarData');
-    $allTransactions = collect($data['weeks'])->flatten(1)
-        ->flatMap(fn (array $day) => $day['transactions']);
+    $allPips = collect($days)->flatMap(fn (CalendarDayData $d) => $d->pips);
 
-    expect($allTransactions)->toHaveCount(1)
-        ->and($allTransactions->first()['amount'])->toBe(-3000);
+    expect($allPips)->toHaveCount(1)
+        ->and($allPips->first()->amount)->toBe(3000);
 });
 
-test('groups transactions by date correctly', function () {
+test('groups transactions by date', function () {
     $user = User::factory()->create();
     $account = Account::factory()->for($user)->create();
-
-    $dateA = now()->startOfMonth()->addDays(2);
-    $dateB = now()->startOfMonth()->addDays(5);
+    $dateA = CarbonImmutable::now()->startOfMonth()->addDays(2);
+    $dateB = CarbonImmutable::now()->startOfMonth()->addDays(5);
 
     Transaction::factory()->for($user)->debit()->count(2)->create([
         'account_id' => $account->id,
         'amount' => -1000,
         'post_date' => $dateA,
     ]);
-
     Transaction::factory()->for($user)->debit()->create([
         'account_id' => $account->id,
         'amount' => -2000,
         'post_date' => $dateB,
     ]);
 
+    /** @var CalendarView $instance */
+    $instance = Livewire::actingAs($user)
+        ->test(CalendarView::class)
+        ->instance();
+    /** @var list<CalendarDayData> $days */
+    $days = $instance->days();
+
+    $cellA = collect($days)->firstWhere('iso', $dateA->format('Y-m-d'));
+    $cellB = collect($days)->firstWhere('iso', $dateB->format('Y-m-d'));
+
+    expect($cellA->pips)->toHaveCount(2)
+        ->and($cellB->pips)->toHaveCount(1);
+});
+
+test('computes per-day net of income minus outflow', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $date = CarbonImmutable::now()->startOfMonth()->addDays(7);
+
+    Transaction::factory()->for($user)->credit()->create([
+        'account_id' => $account->id,
+        'amount' => 8000,
+        'post_date' => $date,
+    ]);
+    Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'amount' => -3000,
+        'post_date' => $date,
+    ]);
+
+    /** @var CalendarView $instance */
+    $instance = Livewire::actingAs($user)
+        ->test(CalendarView::class)
+        ->instance();
+    /** @var list<CalendarDayData> $days */
+    $days = $instance->days();
+
+    $cell = collect($days)->firstWhere('iso', $date->format('Y-m-d'));
+
+    expect($cell->incomeCents)->toBe(8000)
+        ->and($cell->postedCents)->toBe(3000)
+        ->and($cell->netCents)->toBe(5000);
+});
+
+test('selectDate updates selectedDay computed', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $date = CarbonImmutable::now()->startOfMonth()->addDays(4);
+
+    Transaction::factory()->for($user)->credit()->create([
+        'account_id' => $account->id,
+        'amount' => 12000,
+        'post_date' => $date,
+    ]);
+
     $component = Livewire::actingAs($user)
-        ->test(CalendarView::class);
+        ->test(CalendarView::class)
+        ->call('selectDate', $date->format('Y-m-d'));
 
-    $data = $component->get('calendarData');
-    $days = collect($data['weeks'])->flatten(1);
+    $selected = $component->get('selectedDay');
 
-    $dayA = $days->firstWhere('fullDate', $dateA->format('Y-m-d'));
-    $dayB = $days->firstWhere('fullDate', $dateB->format('Y-m-d'));
+    expect($selected)->not->toBeNull()
+        ->and($selected['iso'])->toBe($date->format('Y-m-d'))
+        ->and($selected['pips'])->toHaveCount(1);
+});
 
-    expect($dayA['transactions'])->toHaveCount(2)
-        ->and($dayB['transactions'])->toHaveCount(1);
+test('monthTotals only sums current-month days', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $monthStart = CarbonImmutable::now()->startOfMonth();
+
+    Transaction::factory()->for($user)->credit()->create([
+        'account_id' => $account->id,
+        'amount' => 100000,
+        'post_date' => $monthStart->addDays(3),
+    ]);
+    Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'amount' => -25000,
+        'post_date' => $monthStart->addDays(8),
+    ]);
+
+    Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'amount' => -99999,
+        'post_date' => $monthStart->subDay(),
+    ]);
+
+    $totals = Livewire::actingAs($user)
+        ->test(CalendarView::class)
+        ->get('monthTotals');
+
+    expect($totals['income'])->toBe(100000)
+        ->and($totals['spend'])->toBe(25000)
+        ->and($totals['net'])->toBe(75000);
 });
 
 test('previous month navigation works', function () {
@@ -127,11 +273,11 @@ test('previous month navigation works', function () {
         ->test(CalendarView::class)
         ->call('previousMonth');
 
-    $data = $component->get('calendarData');
-    $expectedLabel = now()->startOfMonth()->subMonth()->format('F Y');
+    $header = $component->get('headerLabel');
+    $expectedLabel = CarbonImmutable::now()->startOfMonth()->subMonth()->format('F Y');
 
-    expect($data['monthLabel'])->toBe($expectedLabel)
-        ->and($data['isCurrentMonth'])->toBeFalse();
+    expect($header['label'])->toBe($expectedLabel)
+        ->and($header['isCurrentMonth'])->toBeFalse();
 });
 
 test('next month navigation works', function () {
@@ -141,11 +287,11 @@ test('next month navigation works', function () {
         ->test(CalendarView::class)
         ->call('nextMonth');
 
-    $data = $component->get('calendarData');
-    $expectedLabel = now()->startOfMonth()->addMonth()->format('F Y');
+    $header = $component->get('headerLabel');
+    $expectedLabel = CarbonImmutable::now()->startOfMonth()->addMonth()->format('F Y');
 
-    expect($data['monthLabel'])->toBe($expectedLabel)
-        ->and($data['isCurrentMonth'])->toBeFalse();
+    expect($header['label'])->toBe($expectedLabel)
+        ->and($header['isCurrentMonth'])->toBeFalse();
 });
 
 test('today button resets to current month', function () {
@@ -157,115 +303,60 @@ test('today button resets to current month', function () {
         ->call('previousMonth')
         ->call('goToToday');
 
-    $data = $component->get('calendarData');
+    $header = $component->get('headerLabel');
 
-    expect($data['monthLabel'])->toBe(now()->format('F Y'))
-        ->and($data['isCurrentMonth'])->toBeTrue();
+    expect($header['label'])->toBe(now()->format('F Y'))
+        ->and($header['isCurrentMonth'])->toBeTrue()
+        ->and($component->get('selectedDate'))->toBe(CarbonImmutable::today()->format('Y-m-d'));
 });
 
-test('transactions include category names', function () {
+test('uncategorised transaction falls back to description', function () {
     $user = User::factory()->create();
     $account = Account::factory()->for($user)->create();
-    $category = Category::factory()->create(['name' => 'Transport']);
-
-    Transaction::factory()->for($user)->debit()->create([
-        'account_id' => $account->id,
-        'category_id' => $category->id,
-        'amount' => -1500,
-        'post_date' => now()->startOfMonth()->addDays(1),
-    ]);
-
-    $component = Livewire::actingAs($user)
-        ->test(CalendarView::class);
-
-    $data = $component->get('calendarData');
-    $txn = collect($data['weeks'])->flatten(1)
-        ->flatMap(fn (array $day) => $day['transactions'])
-        ->first();
-
-    expect($txn['category'])->toBe('Transport');
-});
-
-test('uncategorised transactions show description as fallback', function () {
-    $user = User::factory()->create();
-    $account = Account::factory()->for($user)->create();
+    $date = CarbonImmutable::now()->startOfMonth()->addDays(1);
 
     Transaction::factory()->for($user)->debit()->create([
         'account_id' => $account->id,
         'category_id' => null,
         'description' => 'WOOLWORTHS 1234 SYDNEY',
         'amount' => -500,
-        'post_date' => now()->startOfMonth()->addDays(1),
+        'post_date' => $date,
     ]);
 
-    $component = Livewire::actingAs($user)
-        ->test(CalendarView::class);
-
-    $data = $component->get('calendarData');
-    $txn = collect($data['weeks'])->flatten(1)
-        ->flatMap(fn (array $day) => $day['transactions'])
-        ->first();
-
-    expect($txn['category'])->toBe('WOOLWORTHS 1234 SYDNEY');
-});
-
-test('empty state when no transactions', function () {
-    $user = User::factory()->create();
-
-    Livewire::actingAs($user)
+    /** @var CalendarView $instance */
+    $instance = Livewire::actingAs($user)
         ->test(CalendarView::class)
-        ->assertSee('No transactions');
+        ->instance();
+    /** @var list<CalendarDayData> $days */
+    $days = $instance->days();
+
+    $cell = collect($days)->firstWhere('iso', $date->format('Y-m-d'));
+
+    expect($cell->pips[0]->name)->toBe('WOOLWORTHS 1234 SYDNEY');
 });
 
-test('credit transactions have credit direction', function () {
+test('credit transactions become inc pips', function () {
     $user = User::factory()->create();
     $account = Account::factory()->for($user)->create();
+    $date = CarbonImmutable::now()->startOfMonth()->addDays(1);
 
     Transaction::factory()->for($user)->credit()->create([
         'account_id' => $account->id,
         'amount' => 5000,
-        'post_date' => now()->startOfMonth()->addDays(1),
+        'post_date' => $date,
     ]);
 
-    $component = Livewire::actingAs($user)
-        ->test(CalendarView::class);
+    /** @var CalendarView $instance */
+    $instance = Livewire::actingAs($user)
+        ->test(CalendarView::class)
+        ->instance();
+    /** @var list<CalendarDayData> $days */
+    $days = $instance->days();
 
-    $data = $component->get('calendarData');
-    $txn = collect($data['weeks'])->flatten(1)
-        ->flatMap(fn (array $day) => $day['transactions'])
-        ->first();
+    $cell = collect($days)->firstWhere('iso', $date->format('Y-m-d'));
 
-    expect($txn['direction'])->toBe('credit')
-        ->and($txn['amount'])->toBe(5000);
-});
-
-test('overflow days from adjacent months are marked', function () {
-    $user = User::factory()->create();
-
-    $component = Livewire::actingAs($user)
-        ->test(CalendarView::class);
-
-    $data = $component->get('calendarData');
-    $allDays = collect($data['weeks'])->flatten(1);
-
-    $overflowDays = $allDays->filter(fn (array $day) => ! $day['isCurrentMonth']);
-    $currentMonthDays = $allDays->filter(fn (array $day) => $day['isCurrentMonth']);
-
-    expect($overflowDays->isNotEmpty())->toBeTrue()
-        ->and($currentMonthDays->isNotEmpty())->toBeTrue();
-});
-
-test('calendar weeks always have 7 days', function () {
-    $user = User::factory()->create();
-
-    $component = Livewire::actingAs($user)
-        ->test(CalendarView::class);
-
-    $data = $component->get('calendarData');
-
-    foreach ($data['weeks'] as $week) {
-        expect($week)->toHaveCount(7);
-    }
+    expect($cell->pips[0]->kind)->toBe('inc')
+        ->and($cell->pips[0]->amount)->toBe(5000);
 });
 
 test('calendar refreshes after transaction-saved event', function () {
@@ -275,745 +366,21 @@ test('calendar refreshes after transaction-saved event', function () {
     $component = Livewire::actingAs($user)
         ->test(CalendarView::class);
 
-    $dataBefore = $component->get('calendarData');
-    $allBefore = collect($dataBefore['weeks'])->flatten(1)
-        ->flatMap(fn (array $day) => $day['transactions']);
-
-    expect($allBefore)->toHaveCount(0);
+    /** @var CalendarView $instance */
+    $instance = $component->instance();
+    $before = collect($instance->days())->flatMap(fn (CalendarDayData $d) => $d->pips);
+    expect($before)->toHaveCount(0);
 
     Transaction::factory()->for($user)->debit()->create([
         'account_id' => $account->id,
         'amount' => -2500,
-        'post_date' => now()->startOfMonth()->addDays(1),
+        'post_date' => CarbonImmutable::now()->startOfMonth()->addDays(1),
     ]);
 
     $component->dispatch('transaction-saved');
 
-    $dataAfter = $component->get('calendarData');
-    $allAfter = collect($dataAfter['weeks'])->flatten(1)
-        ->flatMap(fn (array $day) => $day['transactions']);
-
-    expect($allAfter)->toHaveCount(1);
-});
-
-test('transaction data includes id and source fields', function () {
-    $user = User::factory()->create();
-    $account = Account::factory()->for($user)->create();
-
-    $transaction = Transaction::factory()->for($user)->manual()->debit()->create([
-        'account_id' => $account->id,
-        'amount' => -3000,
-        'post_date' => now()->startOfMonth()->addDays(2),
-    ]);
-
-    $component = Livewire::actingAs($user)
-        ->test(CalendarView::class);
-
-    $data = $component->get('calendarData');
-    $txn = collect($data['weeks'])->flatten(1)
-        ->flatMap(fn (array $day) => $day['transactions'])
-        ->first();
-
-    expect($txn)
-        ->toHaveKey('id', $transaction->id)
-        ->toHaveKey('source', 'manual');
-});
-
-test('transaction data includes source for basiq transactions', function () {
-    $user = User::factory()->create();
-    $account = Account::factory()->for($user)->create();
-
-    Transaction::factory()->for($user)->fromBasiq()->debit()->create([
-        'account_id' => $account->id,
-        'amount' => -5000,
-        'post_date' => now()->startOfMonth()->addDays(4),
-    ]);
-
-    $component = Livewire::actingAs($user)
-        ->test(CalendarView::class);
-
-    $data = $component->get('calendarData');
-    $txn = collect($data['weeks'])->flatten(1)
-        ->flatMap(fn (array $day) => $day['transactions'])
-        ->first();
-
-    expect($txn['source'])->toBe('basiq');
-});
-
-test('transaction data includes isTransfer flag for transfer transactions', function () {
-    $user = User::factory()->create();
-    $fromAccount = Account::factory()->for($user)->create();
-    $toAccount = Account::factory()->for($user)->create();
-
-    $debit = Transaction::factory()->for($user)->create([
-        'account_id' => $fromAccount->id,
-        'direction' => TransactionDirection::Debit,
-        'post_date' => now()->startOfMonth()->addDays(3),
-    ]);
-
-    $credit = Transaction::factory()->for($user)->create([
-        'account_id' => $toAccount->id,
-        'direction' => TransactionDirection::Credit,
-        'post_date' => now()->startOfMonth()->addDays(3),
-        'transfer_pair_id' => $debit->id,
-    ]);
-
-    $debit->update(['transfer_pair_id' => $credit->id]);
-
-    $component = Livewire::actingAs($user)
-        ->test(CalendarView::class);
-
-    $data = $component->get('calendarData');
-    $txns = collect($data['weeks'])->flatten(1)
-        ->flatMap(fn (array $day) => $day['transactions']);
-
-    $transferTxn = $txns->firstWhere('id', $debit->id);
-    expect($transferTxn['isTransfer'])->toBeTrue();
-});
-
-test('non-transfer transaction has isTransfer false', function () {
-    $user = User::factory()->create();
-    $account = Account::factory()->for($user)->create();
-
-    Transaction::factory()->for($user)->manual()->create([
-        'account_id' => $account->id,
-        'post_date' => now()->startOfMonth()->addDays(3),
-    ]);
-
-    $component = Livewire::actingAs($user)
-        ->test(CalendarView::class);
-
-    $data = $component->get('calendarData');
-    $txn = collect($data['weeks'])->flatten(1)
-        ->flatMap(fn (array $day) => $day['transactions'])
-        ->first();
-
-    expect($txn['isTransfer'])->toBeFalse();
-});
-
-test('today is marked in current month', function () {
-    $user = User::factory()->create();
-
-    $component = Livewire::actingAs($user)
-        ->test(CalendarView::class);
-
-    $data = $component->get('calendarData');
-    $todayCell = collect($data['weeks'])->flatten(1)
-        ->first(fn (array $day) => $day['isToday']);
-
-    expect($todayCell)->not->toBeNull()
-        ->and($todayCell['date'])->toBe((int) now()->format('j'))
-        ->and($todayCell['isCurrentMonth'])->toBeTrue();
-});
-
-// ── Planned Transactions ─────────────────────────────────────────
-
-test('planned transaction occurrences appear on correct dates', function () {
-    $user = User::factory()->create();
-    $account = Account::factory()->for($user)->create();
-    $category = Category::factory()->create(['name' => 'Rent']);
-
-    $planned = PlannedTransaction::factory()->for($user)->for($account)->monthly()->create([
-        'category_id' => $category->id,
-        'amount' => 150000,
-        'direction' => TransactionDirection::Debit,
-        'start_date' => now()->startOfMonth()->addDays(14),
-    ]);
-
-    $component = Livewire::actingAs($user)->test(CalendarView::class);
-
-    $data = $component->get('calendarData');
-    $allTxns = collect($data['weeks'])->flatten(1)
-        ->flatMap(fn (array $day) => $day['transactions']);
-
-    $plannedTxns = $allTxns->where('type', 'planned');
-
-    expect($plannedTxns)->toHaveCount(1)
-        ->and($plannedTxns->first()['category'])->toBe('Rent')
-        ->and($plannedTxns->first()['amount'])->toBe(150000)
-        ->and($plannedTxns->first()['direction'])->toBe('debit')
-        ->and($plannedTxns->first()['id'])->toBeNull()
-        ->and($plannedTxns->first()['planned_transaction_id'])->toBe($planned->id);
-});
-
-test('weekly planned transaction shows on multiple weeks', function () {
-    $user = User::factory()->create();
-    $account = Account::factory()->for($user)->create();
-
-    PlannedTransaction::factory()->for($user)->for($account)->weekly()->create([
-        'start_date' => now()->startOfMonth(),
-        'amount' => 5000,
-    ]);
-
-    $component = Livewire::actingAs($user)->test(CalendarView::class);
-
-    $data = $component->get('calendarData');
-    $planned = collect($data['weeks'])->flatten(1)
-        ->flatMap(fn (array $day) => $day['transactions'])
-        ->where('type', 'planned');
-
-    expect($planned->count())->toBeGreaterThanOrEqual(4);
-});
-
-test('monthly planned transaction shows once in current month days', function () {
-    $user = User::factory()->create();
-    $account = Account::factory()->for($user)->create();
-
-    PlannedTransaction::factory()->for($user)->for($account)->monthly()->create([
-        'start_date' => now()->startOfMonth()->addDays(9),
-        'amount' => 10000,
-    ]);
-
-    $component = Livewire::actingAs($user)->test(CalendarView::class);
-
-    $data = $component->get('calendarData');
-    $planned = collect($data['weeks'])->flatten(1)
-        ->filter(fn (array $day) => $day['isCurrentMonth'])
-        ->flatMap(fn (array $day) => $day['transactions'])
-        ->where('type', 'planned');
-
-    expect($planned)->toHaveCount(1);
-});
-
-test('planned entries have type planned and actual entries have type actual', function () {
-    $user = User::factory()->create();
-    $account = Account::factory()->for($user)->create();
-    $date = now()->startOfMonth()->addDays(4);
-
-    Transaction::factory()->for($user)->debit()->create([
-        'account_id' => $account->id,
-        'amount' => -3000,
-        'post_date' => $date,
-    ]);
-
-    PlannedTransaction::factory()->for($user)->for($account)->noRepeat()->create([
-        'start_date' => $date,
-        'amount' => 5000,
-    ]);
-
-    $component = Livewire::actingAs($user)->test(CalendarView::class);
-
-    $data = $component->get('calendarData');
-    $day = collect($data['weeks'])->flatten(1)
-        ->firstWhere('fullDate', $date->format('Y-m-d'));
-
-    $actual = collect($day['transactions'])->where('type', 'actual');
-    $planned = collect($day['transactions'])->where('type', 'planned');
-
-    expect($actual)->toHaveCount(1)
-        ->and($planned)->toHaveCount(1);
-});
-
-test('planned transaction respects until_date', function () {
-    $user = User::factory()->create();
-    $account = Account::factory()->for($user)->create();
-
-    PlannedTransaction::factory()->for($user)->for($account)->weekly()->create([
-        'start_date' => now()->startOfMonth(),
-        'until_date' => now()->startOfMonth()->addDays(7),
-        'amount' => 2000,
-    ]);
-
-    $component = Livewire::actingAs($user)->test(CalendarView::class);
-
-    $data = $component->get('calendarData');
-    $planned = collect($data['weeks'])->flatten(1)
-        ->flatMap(fn (array $day) => $day['transactions'])
-        ->where('type', 'planned');
-
-    expect($planned->count())->toBeLessThanOrEqual(2);
-});
-
-test('inactive planned transactions are not shown', function () {
-    $user = User::factory()->create();
-    $account = Account::factory()->for($user)->create();
-
-    PlannedTransaction::factory()->for($user)->for($account)->inactive()->create([
-        'start_date' => now()->startOfMonth()->addDays(4),
-        'amount' => 5000,
-    ]);
-
-    $component = Livewire::actingAs($user)->test(CalendarView::class);
-
-    $data = $component->get('calendarData');
-    $planned = collect($data['weeks'])->flatten(1)
-        ->flatMap(fn (array $day) => $day['transactions'])
-        ->where('type', 'planned');
-
-    expect($planned)->toBeEmpty();
-});
-
-test('actual and planned transactions on the same day both appear', function () {
-    $user = User::factory()->create();
-    $account = Account::factory()->for($user)->create();
-    $date = now()->startOfMonth()->addDays(9);
-
-    Transaction::factory()->for($user)->debit()->create([
-        'account_id' => $account->id,
-        'amount' => -3000,
-        'post_date' => $date,
-    ]);
-
-    PlannedTransaction::factory()->for($user)->for($account)->noRepeat()->create([
-        'start_date' => $date,
-        'amount' => 7000,
-    ]);
-
-    $component = Livewire::actingAs($user)->test(CalendarView::class);
-
-    $data = $component->get('calendarData');
-    $day = collect($data['weeks'])->flatten(1)
-        ->firstWhere('fullDate', $date->format('Y-m-d'));
-
-    expect($day['transactions'])->toHaveCount(2);
-
-    $types = collect($day['transactions'])->pluck('type')->sort()->values()->all();
-    expect($types)->toBe(['actual', 'planned']);
-});
-
-test('planned transactions starting after grid end are excluded', function () {
-    $user = User::factory()->create();
-    $account = Account::factory()->for($user)->create();
-
-    PlannedTransaction::factory()->for($user)->for($account)->noRepeat()->create([
-        'start_date' => now()->startOfMonth()->addMonths(2),
-        'amount' => 9999,
-    ]);
-
-    $component = Livewire::actingAs($user)->test(CalendarView::class);
-
-    $data = $component->get('calendarData');
-    $planned = collect($data['weeks'])->flatten(1)
-        ->flatMap(fn (array $day) => $day['transactions'])
-        ->where('type', 'planned');
-
-    expect($planned)->toBeEmpty();
-});
-
-test('planned transactions with until_date before grid start are excluded', function () {
-    $user = User::factory()->create();
-    $account = Account::factory()->for($user)->create();
-
-    PlannedTransaction::factory()->for($user)->for($account)->weekly()->create([
-        'start_date' => now()->subMonths(6),
-        'until_date' => now()->subMonths(3),
-        'amount' => 5000,
-    ]);
-
-    $component = Livewire::actingAs($user)->test(CalendarView::class);
-
-    $data = $component->get('calendarData');
-    $planned = collect($data['weeks'])->flatten(1)
-        ->flatMap(fn (array $day) => $day['transactions'])
-        ->where('type', 'planned');
-
-    expect($planned)->toBeEmpty();
-});
-
-test('only current user planned transactions are shown', function () {
-    $user = User::factory()->create();
-    $otherUser = User::factory()->create();
-    $account = Account::factory()->for($user)->create();
-    $otherAccount = Account::factory()->for($otherUser)->create();
-
-    PlannedTransaction::factory()->for($user)->for($account)->noRepeat()->create([
-        'start_date' => now()->startOfMonth()->addDays(4),
-    ]);
-
-    PlannedTransaction::factory()->for($otherUser)->for($otherAccount)->noRepeat()->create([
-        'start_date' => now()->startOfMonth()->addDays(4),
-    ]);
-
-    $component = Livewire::actingAs($user)->test(CalendarView::class);
-
-    $data = $component->get('calendarData');
-    $planned = collect($data['weeks'])->flatten(1)
-        ->flatMap(fn (array $day) => $day['transactions'])
-        ->where('type', 'planned');
-
-    expect($planned)->toHaveCount(1);
-});
-
-// ── Reconciliation Status ────────────────────────────────────────
-
-test('planned entry has reconciled status when linked transaction exists near occurrence date', function () {
-    $user = User::factory()->create();
-    $account = Account::factory()->for($user)->create();
-    $date = now()->startOfMonth()->addDays(9);
-
-    $planned = PlannedTransaction::factory()->for($user)->for($account)->noRepeat()->create([
-        'amount' => 15000,
-        'direction' => TransactionDirection::Debit,
-        'start_date' => $date,
-    ]);
-
-    Transaction::factory()->for($user)->debit()->create([
-        'account_id' => $account->id,
-        'amount' => 15000,
-        'post_date' => $date,
-        'planned_transaction_id' => $planned->id,
-    ]);
-
-    $component = Livewire::actingAs($user)->test(CalendarView::class);
-
-    $data = $component->get('calendarData');
-    $plannedEntry = collect($data['weeks'])->flatten(1)
-        ->flatMap(fn (array $day) => $day['transactions'])
-        ->firstWhere('type', 'planned');
-
-    expect($plannedEntry['reconciliation_status'])->toBe('reconciled')
-        ->and($plannedEntry['linked_transaction_id'])->not->toBeNull();
-});
-
-test('planned entry has unreconciled status when no matching transactions exist', function () {
-    $user = User::factory()->create();
-    $account = Account::factory()->for($user)->create();
-
-    PlannedTransaction::factory()->for($user)->for($account)->noRepeat()->create([
-        'amount' => 15000,
-        'direction' => TransactionDirection::Debit,
-        'start_date' => now()->startOfMonth()->addDays(9),
-    ]);
-
-    $component = Livewire::actingAs($user)->test(CalendarView::class);
-
-    $data = $component->get('calendarData');
-    $plannedEntry = collect($data['weeks'])->flatten(1)
-        ->flatMap(fn (array $day) => $day['transactions'])
-        ->firstWhere('type', 'planned');
-
-    expect($plannedEntry['reconciliation_status'])->toBe('unreconciled')
-        ->and($plannedEntry['linked_transaction_id'])->toBeNull();
-});
-
-test('planned entry has suggested status when unlinked match exists', function () {
-    $user = User::factory()->create();
-    $account = Account::factory()->for($user)->create();
-    $date = now()->startOfMonth()->addDays(9);
-
-    PlannedTransaction::factory()->for($user)->for($account)->noRepeat()->create([
-        'amount' => 15000,
-        'direction' => TransactionDirection::Debit,
-        'start_date' => $date,
-    ]);
-
-    Transaction::factory()->for($user)->debit()->create([
-        'account_id' => $account->id,
-        'amount' => 15000,
-        'post_date' => $date,
-    ]);
-
-    $component = Livewire::actingAs($user)->test(CalendarView::class);
-
-    $data = $component->get('calendarData');
-    $plannedEntry = collect($data['weeks'])->flatten(1)
-        ->flatMap(fn (array $day) => $day['transactions'])
-        ->firstWhere('type', 'planned');
-
-    expect($plannedEntry['reconciliation_status'])->toBe('suggested');
-});
-
-test('suggestion status respects amount tolerance', function () {
-    $user = User::factory()->create();
-    $account = Account::factory()->for($user)->create();
-    $date = now()->startOfMonth()->addDays(9);
-
-    PlannedTransaction::factory()->for($user)->for($account)->noRepeat()->create([
-        'amount' => 10000,
-        'direction' => TransactionDirection::Debit,
-        'start_date' => $date,
-    ]);
-
-    Transaction::factory()->for($user)->debit()->create([
-        'account_id' => $account->id,
-        'amount' => 12000,
-        'post_date' => $date,
-    ]);
-
-    $component = Livewire::actingAs($user)->test(CalendarView::class);
-
-    $data = $component->get('calendarData');
-    $plannedEntry = collect($data['weeks'])->flatten(1)
-        ->flatMap(fn (array $day) => $day['transactions'])
-        ->firstWhere('type', 'planned');
-
-    expect($plannedEntry['reconciliation_status'])->toBe('unreconciled');
-});
-
-test('suggestion status respects date tolerance', function () {
-    $user = User::factory()->create();
-    $account = Account::factory()->for($user)->create();
-    $date = now()->startOfMonth()->addDays(9);
-
-    PlannedTransaction::factory()->for($user)->for($account)->noRepeat()->create([
-        'amount' => 10000,
-        'direction' => TransactionDirection::Debit,
-        'start_date' => $date,
-    ]);
-
-    Transaction::factory()->for($user)->debit()->create([
-        'account_id' => $account->id,
-        'amount' => 10000,
-        'post_date' => $date->addDays(5),
-    ]);
-
-    $component = Livewire::actingAs($user)->test(CalendarView::class);
-
-    $data = $component->get('calendarData');
-    $plannedEntry = collect($data['weeks'])->flatten(1)
-        ->flatMap(fn (array $day) => $day['transactions'])
-        ->firstWhere('type', 'planned');
-
-    expect($plannedEntry['reconciliation_status'])->toBe('unreconciled');
-});
-
-test('suggestion status requires same account', function () {
-    $user = User::factory()->create();
-    $account = Account::factory()->for($user)->create();
-    $otherAccount = Account::factory()->for($user)->create();
-    $date = now()->startOfMonth()->addDays(9);
-
-    PlannedTransaction::factory()->for($user)->for($account)->noRepeat()->create([
-        'amount' => 10000,
-        'direction' => TransactionDirection::Debit,
-        'start_date' => $date,
-    ]);
-
-    Transaction::factory()->for($user)->debit()->create([
-        'account_id' => $otherAccount->id,
-        'amount' => 10000,
-        'post_date' => $date,
-    ]);
-
-    $component = Livewire::actingAs($user)->test(CalendarView::class);
-
-    $data = $component->get('calendarData');
-    $plannedEntry = collect($data['weeks'])->flatten(1)
-        ->flatMap(fn (array $day) => $day['transactions'])
-        ->firstWhere('type', 'planned');
-
-    expect($plannedEntry['reconciliation_status'])->toBe('unreconciled');
-});
-
-test('suggestion status requires same direction', function () {
-    $user = User::factory()->create();
-    $account = Account::factory()->for($user)->create();
-    $date = now()->startOfMonth()->addDays(9);
-
-    PlannedTransaction::factory()->for($user)->for($account)->noRepeat()->create([
-        'amount' => 10000,
-        'direction' => TransactionDirection::Debit,
-        'start_date' => $date,
-    ]);
-
-    Transaction::factory()->for($user)->credit()->create([
-        'account_id' => $account->id,
-        'amount' => 10000,
-        'post_date' => $date,
-    ]);
-
-    $component = Livewire::actingAs($user)->test(CalendarView::class);
-
-    $data = $component->get('calendarData');
-    $plannedEntry = collect($data['weeks'])->flatten(1)
-        ->flatMap(fn (array $day) => $day['transactions'])
-        ->firstWhere('type', 'planned');
-
-    expect($plannedEntry['reconciliation_status'])->toBe('unreconciled');
-});
-
-test('planned entry includes occurrence_date field', function () {
-    $user = User::factory()->create();
-    $account = Account::factory()->for($user)->create();
-    $date = now()->startOfMonth()->addDays(9);
-
-    PlannedTransaction::factory()->for($user)->for($account)->noRepeat()->create([
-        'start_date' => $date,
-    ]);
-
-    $component = Livewire::actingAs($user)->test(CalendarView::class);
-
-    $data = $component->get('calendarData');
-    $plannedEntry = collect($data['weeks'])->flatten(1)
-        ->flatMap(fn (array $day) => $day['transactions'])
-        ->firstWhere('type', 'planned');
-
-    expect($plannedEntry['occurrence_date'])->toBe($date->format('Y-m-d'));
-});
-
-test('actual transaction includes planned_transaction_id when linked', function () {
-    $user = User::factory()->create();
-    $account = Account::factory()->for($user)->create();
-    $date = now()->startOfMonth()->addDays(9);
-
-    $planned = PlannedTransaction::factory()->for($user)->for($account)->noRepeat()->create([
-        'start_date' => $date,
-    ]);
-
-    Transaction::factory()->for($user)->debit()->create([
-        'account_id' => $account->id,
-        'post_date' => $date,
-        'planned_transaction_id' => $planned->id,
-    ]);
-
-    $component = Livewire::actingAs($user)->test(CalendarView::class);
-
-    $data = $component->get('calendarData');
-    $actualEntry = collect($data['weeks'])->flatten(1)
-        ->flatMap(fn (array $day) => $day['transactions'])
-        ->firstWhere('type', 'actual');
-
-    expect($actualEntry['planned_transaction_id'])->toBe($planned->id);
-});
-
-// ── Week strip + agenda (Ticket 5 / #195) ────────────────────────
-
-test('selectedDate defaults to today on mount', function () {
-    $user = User::factory()->create();
-
-    $component = Livewire::actingAs($user)->test(CalendarView::class);
-
-    expect($component->get('selectedDate'))->toBe(CarbonImmutable::today()->format('Y-m-d'));
-});
-
-test('weekStrip contains 7 cells centred on today (-2/+5)', function () {
-    $user = User::factory()->create();
-    $today = CarbonImmutable::today();
-
-    $strip = Livewire::actingAs($user)
-        ->test(CalendarView::class)
-        ->get('weekStrip');
-
-    expect($strip)->toHaveCount(7)
-        ->and($strip[0]['date'])->toBe($today->subDays(2)->format('Y-m-d'))
-        ->and($strip[6]['date'])->toBe($today->addDays(4)->format('Y-m-d'))
-        ->and(collect($strip)->firstWhere('isToday', true)['date'])->toBe($today->format('Y-m-d'));
-});
-
-test('PAYDAY badge lands on next_pay_date', function () {
-    $payday = CarbonImmutable::today()->addDays(3);
-    $user = User::factory()->withPayCycle()->create([
-        'next_pay_date' => $payday,
-    ]);
-
-    $strip = Livewire::actingAs($user)
-        ->test(CalendarView::class)
-        ->get('weekStrip');
-
-    $paydayCell = collect($strip)->firstWhere('date', $payday->format('Y-m-d'));
-
-    expect($paydayCell)->not->toBeNull()
-        ->and($paydayCell['isPayday'])->toBeTrue();
-});
-
-test('selectDate action filters agenda to selected date onward', function () {
-    $user = User::factory()->create();
-    $account = Account::factory()->for($user)->create();
-
-    $earlier = CarbonImmutable::today()->startOfMonth()->addDays(2);
-    $later = CarbonImmutable::today()->startOfMonth()->addDays(10);
-
-    Transaction::factory()->for($user)->debit()->create([
-        'account_id' => $account->id,
-        'amount' => -1000,
-        'post_date' => $earlier,
-    ]);
-
-    Transaction::factory()->for($user)->debit()->create([
-        'account_id' => $account->id,
-        'amount' => -2000,
-        'post_date' => $later,
-    ]);
-
-    $component = Livewire::actingAs($user)
-        ->test(CalendarView::class)
-        ->call('selectDate', $later->format('Y-m-d'));
-
-    $agenda = $component->get('agenda');
-
-    expect(collect($agenda)->pluck('date')->all())->toBe([$later->format('Y-m-d')]);
-});
-
-test('quickline totals match pay cycle transaction sums', function () {
-    $today = CarbonImmutable::today();
-    $user = User::factory()->withPayCycle()->create([
-        'next_pay_date' => $today->addDays(5),
-    ]);
-    $account = Account::factory()->for($user)->create();
-
-    Transaction::factory()->for($user)->credit()->create([
-        'account_id' => $account->id,
-        'amount' => 150000,
-        'post_date' => $today->subDay(),
-    ]);
-
-    Transaction::factory()->for($user)->debit()->create([
-        'account_id' => $account->id,
-        'amount' => -30000,
-        'post_date' => $today->subDay(),
-    ]);
-
-    PlannedTransaction::factory()->for($user)->for($account)->noRepeat()->create([
-        'amount' => 15000,
-        'direction' => TransactionDirection::Debit,
-        'start_date' => $today->addDays(2),
-    ]);
-
-    $quickline = Livewire::actingAs($user)
-        ->test(CalendarView::class)
-        ->get('quickline');
-
-    expect($quickline['income'])->toBe(150000)
-        ->and($quickline['posted'])->toBe(30000)
-        ->and($quickline['planned'])->toBe(15000)
-        ->and($quickline['bufferAtPayday'])->toBeInt();
-});
-
-test('quickline returns zeroes and null buffer when pay cycle not configured', function () {
-    $user = User::factory()->create([
-        'pay_amount' => null,
-        'pay_frequency' => null,
-        'next_pay_date' => null,
-    ]);
-
-    $quickline = Livewire::actingAs($user)
-        ->test(CalendarView::class)
-        ->get('quickline');
-
-    expect($quickline)->toMatchArray([
-        'income' => 0,
-        'posted' => 0,
-        'planned' => 0,
-        'bufferAtPayday' => null,
-    ]);
-});
-
-test('agenda group net total is credit minus debit in cents', function () {
-    $user = User::factory()->create();
-    $account = Account::factory()->for($user)->create();
-    $date = CarbonImmutable::today();
-
-    Transaction::factory()->for($user)->credit()->create([
-        'account_id' => $account->id,
-        'amount' => 5000,
-        'post_date' => $date,
-    ]);
-
-    Transaction::factory()->for($user)->debit()->create([
-        'account_id' => $account->id,
-        'amount' => -2000,
-        'post_date' => $date,
-    ]);
-
-    $agenda = Livewire::actingAs($user)
-        ->test(CalendarView::class)
-        ->call('selectDate', $date->format('Y-m-d'))
-        ->get('agenda');
-
-    $group = collect($agenda)->firstWhere('date', $date->format('Y-m-d'));
-
-    expect($group)->not->toBeNull()
-        ->and($group['net'])->toBe(3000);
+    $after = collect($instance->days())->flatMap(fn (CalendarDayData $d) => $d->pips);
+    expect($after)->toHaveCount(1);
 });
 
 test('month nav resets selectedDate to start of new month', function () {
@@ -1028,36 +395,227 @@ test('month nav resets selectedDate to start of new month', function () {
     expect($component->get('selectedDate'))->toBe($expected);
 });
 
-test('weekStrip dots reflect transaction kinds on that date', function () {
+test('selectedDate defaults to today on mount', function () {
+    $user = User::factory()->create();
+
+    $component = Livewire::actingAs($user)->test(CalendarView::class);
+
+    expect($component->get('selectedDate'))->toBe(CarbonImmutable::today()->format('Y-m-d'));
+});
+
+// ── Planned transactions ─────────────────────────────────────────
+
+test('planned transaction occurrences appear as plan pips', function () {
     $user = User::factory()->create();
     $account = Account::factory()->for($user)->create();
-    $today = CarbonImmutable::today();
+    $category = Category::factory()->create(['name' => 'Rent']);
+    $date = CarbonImmutable::now()->startOfMonth()->addDays(14);
 
-    Transaction::factory()->for($user)->credit()->create([
-        'account_id' => $account->id,
-        'amount' => 1000,
-        'post_date' => $today,
+    PlannedTransaction::factory()->for($user)->for($account)->monthly()->create([
+        'category_id' => $category->id,
+        'amount' => 150000,
+        'direction' => TransactionDirection::Debit,
+        'start_date' => $date,
     ]);
+
+    /** @var CalendarView $instance */
+    $instance = Livewire::actingAs($user)
+        ->test(CalendarView::class)
+        ->instance();
+    /** @var list<CalendarDayData> $days */
+    $days = $instance->days();
+
+    $planPips = collect($days)->flatMap(fn (CalendarDayData $d) => $d->pips)->where('kind', 'plan');
+
+    expect($planPips)->toHaveCount(1)
+        ->and($planPips->first()->name)->toBe('Rent')
+        ->and($planPips->first()->amount)->toBe(150000);
+});
+
+test('inactive planned transactions are excluded', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+
+    PlannedTransaction::factory()->for($user)->for($account)->inactive()->create([
+        'start_date' => CarbonImmutable::now()->startOfMonth()->addDays(4),
+        'amount' => 5000,
+    ]);
+
+    /** @var CalendarView $instance */
+    $instance = Livewire::actingAs($user)
+        ->test(CalendarView::class)
+        ->instance();
+    /** @var list<CalendarDayData> $days */
+    $days = $instance->days();
+
+    $planPips = collect($days)->flatMap(fn (CalendarDayData $d) => $d->pips)->where('kind', 'plan');
+
+    expect($planPips)->toBeEmpty();
+});
+
+test('actual and planned on same day both render', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $date = CarbonImmutable::now()->startOfMonth()->addDays(9);
 
     Transaction::factory()->for($user)->debit()->create([
         'account_id' => $account->id,
-        'amount' => -500,
-        'post_date' => $today,
+        'amount' => -3000,
+        'post_date' => $date,
     ]);
 
     PlannedTransaction::factory()->for($user)->for($account)->noRepeat()->create([
-        'start_date' => $today,
-        'amount' => 2000,
-        'direction' => TransactionDirection::Debit,
+        'start_date' => $date,
+        'amount' => 7000,
     ]);
 
-    $strip = Livewire::actingAs($user)
+    /** @var CalendarView $instance */
+    $instance = Livewire::actingAs($user)
         ->test(CalendarView::class)
-        ->get('weekStrip');
+        ->instance();
+    /** @var list<CalendarDayData> $days */
+    $days = $instance->days();
 
-    $todayCell = collect($strip)->firstWhere('date', $today->format('Y-m-d'));
+    $cell = collect($days)->firstWhere('iso', $date->format('Y-m-d'));
 
-    expect($todayCell['dots'])->toContain('income')
-        ->and($todayCell['dots'])->toContain('posted')
-        ->and($todayCell['dots'])->toContain('planned');
+    expect($cell->pips)->toHaveCount(2);
+
+    $kinds = collect($cell->pips)->pluck('kind')->sort()->values()->all();
+
+    expect($kinds)->toBe(['out', 'plan']);
+});
+
+// ── Payday flagging ──────────────────────────────────────────────
+
+test('next upcoming payday in current month is flagged isNextPayday', function () {
+    CarbonImmutable::setTestNow(CarbonImmutable::create(2026, 6, 10));
+
+    $payday = CarbonImmutable::create(2026, 6, 20);
+
+    $user = User::factory()->withPayCycle()->create([
+        'pay_frequency' => PayFrequency::Fortnightly,
+        'next_pay_date' => $payday,
+    ]);
+
+    /** @var CalendarView $instance */
+    $instance = Livewire::actingAs($user)
+        ->test(CalendarView::class)
+        ->instance();
+    /** @var list<CalendarDayData> $days */
+    $days = $instance->days();
+
+    $paydayCell = collect($days)->firstWhere('iso', $payday->format('Y-m-d'));
+
+    expect($paydayCell)->not->toBeNull()
+        ->and($paydayCell->isCurrentMonth)->toBeTrue()
+        ->and($paydayCell->isNextPayday)->toBeTrue();
+
+    $nextCount = collect($days)->where('isNextPayday', true)->count();
+    expect($nextCount)->toBe(1);
+
+    CarbonImmutable::setTestNow();
+});
+
+test('past paydays in the visible grid are flagged isPastPayday', function () {
+    CarbonImmutable::setTestNow(CarbonImmutable::create(2026, 6, 15));
+
+    $nextPayday = CarbonImmutable::create(2026, 6, 18);
+    $previousPayday = $nextPayday->subWeek();
+
+    $user = User::factory()->withPayCycle()->create([
+        'pay_frequency' => PayFrequency::Weekly,
+        'next_pay_date' => $nextPayday,
+    ]);
+
+    /** @var CalendarView $instance */
+    $instance = Livewire::actingAs($user)
+        ->test(CalendarView::class)
+        ->instance();
+    /** @var list<CalendarDayData> $days */
+    $days = $instance->days();
+
+    $previousCell = collect($days)->firstWhere('iso', $previousPayday->format('Y-m-d'));
+
+    expect($previousCell)->not->toBeNull()
+        ->and($previousCell->isPastPayday)->toBeTrue()
+        ->and($previousCell->isNextPayday)->toBeFalse();
+
+    CarbonImmutable::setTestNow();
+});
+
+test('users without pay cycle have no payday flags', function () {
+    $user = User::factory()->create([
+        'pay_amount' => null,
+        'pay_frequency' => null,
+        'next_pay_date' => null,
+    ]);
+
+    /** @var CalendarView $instance */
+    $instance = Livewire::actingAs($user)
+        ->test(CalendarView::class)
+        ->instance();
+    /** @var list<CalendarDayData> $days */
+    $days = $instance->days();
+
+    $anyFlagged = collect($days)->contains(fn (CalendarDayData $d) => $d->isPastPayday || $d->isNextPayday);
+
+    expect($anyFlagged)->toBeFalse();
+});
+
+// ── Active pay-cycle band ─────────────────────────────────────────
+
+test('days inside the active pay cycle are flagged isInActiveCycle', function () {
+    $today = CarbonImmutable::today();
+    $user = User::factory()->withPayCycle()->create([
+        'pay_frequency' => PayFrequency::Fortnightly,
+        'next_pay_date' => $today->addDays(5),
+    ]);
+
+    /** @var CalendarView $instance */
+    $instance = Livewire::actingAs($user)
+        ->test(CalendarView::class)
+        ->instance();
+    /** @var list<CalendarDayData> $days */
+    $days = $instance->days();
+
+    $todayCell = collect($days)->firstWhere('iso', $today->format('Y-m-d'));
+
+    expect($todayCell?->isInActiveCycle)->toBeTrue();
+});
+
+// ── Transfers ─────────────────────────────────────────────────────
+
+test('transfer-pair transactions are excluded from pips', function () {
+    $user = User::factory()->create();
+    $fromAccount = Account::factory()->for($user)->create();
+    $toAccount = Account::factory()->for($user)->create();
+    $date = CarbonImmutable::now()->startOfMonth()->addDays(3);
+
+    $debit = Transaction::factory()->for($user)->create([
+        'account_id' => $fromAccount->id,
+        'direction' => TransactionDirection::Debit,
+        'amount' => -1000,
+        'post_date' => $date,
+    ]);
+
+    $credit = Transaction::factory()->for($user)->create([
+        'account_id' => $toAccount->id,
+        'direction' => TransactionDirection::Credit,
+        'amount' => 1000,
+        'post_date' => $date,
+        'transfer_pair_id' => $debit->id,
+    ]);
+
+    $debit->update(['transfer_pair_id' => $credit->id]);
+
+    /** @var CalendarView $instance */
+    $instance = Livewire::actingAs($user)
+        ->test(CalendarView::class)
+        ->instance();
+    /** @var list<CalendarDayData> $days */
+    $days = $instance->days();
+
+    $cell = collect($days)->firstWhere('iso', $date->format('Y-m-d'));
+
+    expect($cell->pips)->toBeEmpty();
 });

--- a/tests/Feature/Support/Calendar/DayActivityLoaderTest.php
+++ b/tests/Feature/Support/Calendar/DayActivityLoaderTest.php
@@ -1,0 +1,289 @@
+<?php
+
+/** @noinspection StaticClosureCanBeUsedInspection */
+
+declare(strict_types=1);
+
+use App\Enums\TransactionDirection;
+use App\Models\Account;
+use App\Models\Category;
+use App\Models\PlannedTransaction;
+use App\Models\Transaction;
+use App\Models\User;
+use App\Support\Calendar\DayActivity;
+use App\Support\Calendar\DayActivityLoader;
+use Carbon\CarbonImmutable;
+
+test('returns empty array when no activity in range', function () {
+    $user = User::factory()->create();
+    Account::factory()->for($user)->create();
+
+    $start = CarbonImmutable::create(2026, 6, 1);
+    $end = CarbonImmutable::create(2026, 6, 30);
+
+    $activity = (new DayActivityLoader)->load($start, $end, $user->id);
+
+    expect($activity)->toBeEmpty();
+});
+
+test('groups posted transactions by ISO date', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+
+    $dateA = CarbonImmutable::create(2026, 6, 5);
+    $dateB = CarbonImmutable::create(2026, 6, 12);
+
+    Transaction::factory()->for($user)->debit()->count(2)->create([
+        'account_id' => $account->id,
+        'amount' => -1000,
+        'post_date' => $dateA,
+    ]);
+    Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'amount' => -2500,
+        'post_date' => $dateB,
+    ]);
+
+    $activity = (new DayActivityLoader)->load(
+        CarbonImmutable::create(2026, 6, 1),
+        CarbonImmutable::create(2026, 6, 30),
+        $user->id,
+    );
+
+    expect($activity)->toHaveKey($dateA->format('Y-m-d'))
+        ->and($activity)->toHaveKey($dateB->format('Y-m-d'))
+        ->and($activity[$dateA->format('Y-m-d')]->pips)->toHaveCount(2)
+        ->and($activity[$dateB->format('Y-m-d')]->pips)->toHaveCount(1);
+});
+
+test('credit becomes inc pip and contributes to incomeCents', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+
+    $date = CarbonImmutable::create(2026, 6, 7);
+
+    Transaction::factory()->for($user)->credit()->create([
+        'account_id' => $account->id,
+        'amount' => 5000,
+        'post_date' => $date,
+    ]);
+
+    $activity = (new DayActivityLoader)->load($date, $date, $user->id);
+    $day = $activity[$date->format('Y-m-d')];
+
+    expect($day->pips[0]->kind)->toBe('inc')
+        ->and($day->incomeCents)->toBe(5000)
+        ->and($day->postedCents)->toBe(0);
+});
+
+test('debit becomes out pip and contributes to postedCents', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+
+    $date = CarbonImmutable::create(2026, 6, 7);
+
+    Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'amount' => -3000,
+        'post_date' => $date,
+    ]);
+
+    $activity = (new DayActivityLoader)->load($date, $date, $user->id);
+    $day = $activity[$date->format('Y-m-d')];
+
+    expect($day->pips[0]->kind)->toBe('out')
+        ->and($day->postedCents)->toBe(3000)
+        ->and($day->incomeCents)->toBe(0);
+});
+
+test('planned occurrences become plan pips and contribute to plannedCents', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $category = Category::factory()->create(['name' => 'Rent']);
+
+    $date = CarbonImmutable::create(2026, 6, 14);
+
+    PlannedTransaction::factory()->for($user)->for($account)->noRepeat()->create([
+        'category_id' => $category->id,
+        'amount' => 150000,
+        'direction' => TransactionDirection::Debit,
+        'start_date' => $date,
+    ]);
+
+    $activity = (new DayActivityLoader)->load(
+        CarbonImmutable::create(2026, 6, 1),
+        CarbonImmutable::create(2026, 6, 30),
+        $user->id,
+    );
+    $day = $activity[$date->format('Y-m-d')];
+
+    expect($day->pips)->toHaveCount(1)
+        ->and($day->pips[0]->kind)->toBe('plan')
+        ->and($day->pips[0]->name)->toBe('Rent')
+        ->and($day->plannedCents)->toBe(150000);
+});
+
+test('pips on the same day are sorted by amount descending', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $date = CarbonImmutable::create(2026, 6, 10);
+
+    Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'amount' => -1000,
+        'post_date' => $date,
+    ]);
+    Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'amount' => -8000,
+        'post_date' => $date,
+    ]);
+    Transaction::factory()->for($user)->credit()->create([
+        'account_id' => $account->id,
+        'amount' => 4000,
+        'post_date' => $date,
+    ]);
+
+    $activity = (new DayActivityLoader)->load($date, $date, $user->id);
+    $day = $activity[$date->format('Y-m-d')];
+
+    $amounts = array_map(fn ($pip) => $pip->amount, $day->pips);
+
+    expect($amounts)->toBe([8000, 4000, 1000]);
+});
+
+test('range filtering excludes activity outside start/end', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+
+    Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'amount' => -9999,
+        'post_date' => CarbonImmutable::create(2026, 5, 31),
+    ]);
+    Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'amount' => -8888,
+        'post_date' => CarbonImmutable::create(2026, 7, 1),
+    ]);
+
+    $activity = (new DayActivityLoader)->load(
+        CarbonImmutable::create(2026, 6, 1),
+        CarbonImmutable::create(2026, 6, 30),
+        $user->id,
+    );
+
+    expect($activity)->toBeEmpty();
+});
+
+test('only loads transactions for the given user id', function () {
+    $user = User::factory()->create();
+    $otherUser = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $otherAccount = Account::factory()->for($otherUser)->create();
+
+    $date = CarbonImmutable::create(2026, 6, 10);
+
+    Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'amount' => -1000,
+        'post_date' => $date,
+    ]);
+    Transaction::factory()->for($otherUser)->debit()->create([
+        'account_id' => $otherAccount->id,
+        'amount' => -9999,
+        'post_date' => $date,
+    ]);
+
+    $activity = (new DayActivityLoader)->load($date, $date, $user->id);
+    $day = $activity[$date->format('Y-m-d')];
+
+    expect($day->pips)->toHaveCount(1)
+        ->and($day->pips[0]->amount)->toBe(1000);
+});
+
+test('excludes transfer-pair transactions', function () {
+    $user = User::factory()->create();
+    $fromAccount = Account::factory()->for($user)->create();
+    $toAccount = Account::factory()->for($user)->create();
+    $date = CarbonImmutable::create(2026, 6, 10);
+
+    $debit = Transaction::factory()->for($user)->create([
+        'account_id' => $fromAccount->id,
+        'direction' => TransactionDirection::Debit,
+        'amount' => -1000,
+        'post_date' => $date,
+    ]);
+
+    $credit = Transaction::factory()->for($user)->create([
+        'account_id' => $toAccount->id,
+        'direction' => TransactionDirection::Credit,
+        'amount' => 1000,
+        'post_date' => $date,
+        'transfer_pair_id' => $debit->id,
+    ]);
+
+    $debit->update(['transfer_pair_id' => $credit->id]);
+
+    $activity = (new DayActivityLoader)->load($date, $date, $user->id);
+
+    expect($activity)->toBeEmpty();
+});
+
+test('inactive planned transactions are excluded', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $date = CarbonImmutable::create(2026, 6, 10);
+
+    PlannedTransaction::factory()->for($user)->for($account)->inactive()->create([
+        'start_date' => $date,
+        'amount' => 5000,
+    ]);
+
+    $activity = (new DayActivityLoader)->load(
+        CarbonImmutable::create(2026, 6, 1),
+        CarbonImmutable::create(2026, 6, 30),
+        $user->id,
+    );
+
+    expect($activity)->toBeEmpty();
+});
+
+test('actual and planned on same day appear together with correct tallies', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $date = CarbonImmutable::create(2026, 6, 10);
+
+    Transaction::factory()->for($user)->credit()->create([
+        'account_id' => $account->id,
+        'amount' => 8000,
+        'post_date' => $date,
+    ]);
+    Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'amount' => -3000,
+        'post_date' => $date,
+    ]);
+    PlannedTransaction::factory()->for($user)->for($account)->noRepeat()->create([
+        'amount' => 5000,
+        'direction' => TransactionDirection::Debit,
+        'start_date' => $date,
+    ]);
+
+    $activity = (new DayActivityLoader)->load($date, $date, $user->id);
+    $day = $activity[$date->format('Y-m-d')];
+
+    expect($day->pips)->toHaveCount(3)
+        ->and($day->incomeCents)->toBe(8000)
+        ->and($day->postedCents)->toBe(3000)
+        ->and($day->plannedCents)->toBe(5000);
+});
+
+test('DayActivity::empty returns a zero-state instance', function () {
+    $empty = DayActivity::empty();
+
+    expect($empty->pips)->toBe([])
+        ->and($empty->incomeCents)->toBe(0)
+        ->and($empty->postedCents)->toBe(0)
+        ->and($empty->plannedCents)->toBe(0);
+});


### PR DESCRIPTION
Closes #237

## Summary

Rebuilds the `/calendar` page from a 7-day strip + agenda into a true Mon–Sun month grid with per-day pips, per-day net totals, and a click-to-select detail panel — matching the prototype design in `thoughts/Can-Eye-Budget/`.

The PR also extracts a shared `DayActivityLoader` service so both `/calendar` and the dashboard `PayCycleCalendar` widget read from a single source of truth for per-day transaction aggregation, eliminating ~100 lines of duplicated query + pip-building logic.

## Files changed

### New

| File | Purpose |
|------|---------|
| `app/Support/Calendar/DayActivity.php` | Read-only DTO: `{ pips, incomeCents, postedCents, plannedCents }` keyed by ISO date |
| `app/Support/Calendar/DayActivityLoader.php` | Service owning the query + grouping + pip-building logic shared by both calendar widgets |
| `app/Livewire/Data/CalendarDayData.php` | Sibling DTO of `PayCycleDayData` carrying month-grid state flags (`isCurrentMonth`, `isPastPayday`, `isNextPayday`, `isInActiveCycle`) |
| `tests/Feature/Support/Calendar/DayActivityLoaderTest.php` | 12 specs covering range filtering, transfer exclusion, planned occurrences, pip ordering, tallies, multi-user isolation |

### Modified

| File | Change |
|------|--------|
| `app/Livewire/CalendarView.php` | Refactor: replace `calendarData/weeks[][]` with flat `days()` returning `list<CalendarDayData>`; drop `weekStrip` + `agenda`; add `monthTotals` + `selectedDay`; add `paydaysWithinGrid()` (with iteration cap); delegate per-day data loading to `DayActivityLoader` |
| `app/Livewire/Dashboard/PayCycleCalendar.php` | Delegate per-day data loading to `DayActivityLoader`; `days()` shrunk from ~120 lines to ~30 |
| `resources/views/livewire/calendar-view.blade.php` | Rewrite to month-grid + detail-panel layout using existing `cyc-*` shell |
| `resources/css/app.css` | Add `.cyc-day.out` (diagonal-stripe), `.cyc-day.cycle-band` (mint tint), `.chip-paid` (green chip) inside `@layer components` |
| `tests/Feature/Livewire/CalendarViewTest.php` | Rewrite: 27 specs covering grid shape, out-of-month flags, per-day net, selection, monthTotals, payday flagging, planned txns, transfer exclusion |

## Architectural decisions

### Single source of truth for day activity

The previous implementation duplicated ~47 lines of `Transaction::query()` + `PlannedTransaction::query()` + per-day pip aggregation between `CalendarView` and `PayCycleCalendar`. After this PR, both widgets call:

```php
$activity = (new DayActivityLoader)->load($start, $end, $userId);
```

Each widget then wraps the per-day `DayActivity` results in its own widget-specific DTO with widget-specific state flags (cycle bounds vs month bounds, payday flagging vs cycle-end labels). The seam is at "what's on this day" (shared) vs "what does this day mean in this widget's context" (widget-specific).

### Reuse over relocation for existing DTOs

`PayCycleDayData` and `PayCyclePip` stay in `App\Livewire\Dashboard\Data` — relocating them to a shared namespace was deferred as out-of-scope. They're already type-safe and shaped exactly for what the loader needs.

### Carbon `isoWeekday()` + `grid-column-start`

Mon=1..Sun=7 grid alignment uses the proven pattern from #234 (`pay-cycle-calendar.blade.php:53`). This eliminates the manual nested `weeks[][]` loop the old implementation used.

## Copilot review responses

Four review comments from the Copilot reviewer were addressed:

- **#2 (unbounded payday walk)** — Fixed: added a `$maxIterations = 500` guard on both backward and forward payday walks in `paydaysWithinGrid()`.
- **#3 (weak `isNextPayday` test)** — Fixed: test now uses `CarbonImmutable::setTestNow(2026-06-10)` with a deterministic payday on 2026-06-20, asserting `$nextCount === 1` and the cell's properties without conditional skipping.
- **#4 (tautological assertion in past-payday test)** — Fixed: test now finds the *expected* prior payday cell via `firstWhere('iso', ...)` and asserts both `isPastPayday=true` AND `isNextPayday=false`.
- **#1 (planned transfers leak through `excludingTransfers()`)** — Deferred to follow-up issue #239. This is a pre-existing model-layer asymmetry: `Transaction::scopeExcludingTransfers()` filters by both `transfer_pair_id` AND category names, but `PlannedTransaction::scopeExcludingTransfers()` only checks category names. The fix belongs at the model scope (one-line change benefits both calendar widgets), not patched inline at one call site.

## Test plan

### Automated

- [x] `op test.filter DayActivityLoaderTest` — 12 passed
- [x] `op test.filter CalendarViewTest` — 27 passed
- [x] `op test.filter Calendar` — 83 passed (44 PayCycleCalendar + 27 CalendarView + 12 loader)
- [x] `op lint.dirty` — pass (Pint)
- [x] `op analyse` — Larastan clean (No errors)
- [x] `op test` — 1573 passed, 4 skipped, 0 failed
- [x] Mago `Duplicated code fragment (47 lines long)` warning is gone

### Manual (reviewer)

- [ ] Visit `/calendar`; confirm month grid renders, leading/trailing days show diagonal-stripe, today has cream + black-frame, past paydays show green PAID chip, next payday in current month shows yellow PAYDAY, active pay-cycle band tinted, click-to-select reveals detail panel with correct chips
- [ ] Prev/next month navigation; "Today" button restores current month and selects today
- [ ] Visit `/dashboard`; confirm `PayCycleCalendar` widget still renders identically (no behavioural change expected)
- [ ] Responsive behaviour at < 768px viewport

## Out of scope (potential follow-ups)

- #239 — fix `PlannedTransaction::scopeExcludingTransfers()` to also filter `transfer_to_account_id`
- Drag-to-reschedule of planned transactions
- Mini-month picker / jump-to-month dropdown
- Keyboard navigation (arrow keys, Page Up/Down)
- Relocating `PayCycleDayData` / `PayCyclePip` to the new `App\Support\Calendar` namespace
- Flagging multiple future paydays in the same view (currently only the single soonest)