### PR TITLE
fix: [#240] Restore soft-deleted rows on CSV re-import and tolerate per-row failures

### DIFF
--- a/app/Jobs/ImportCsvTransactionsJob.php
+++ b/app/Jobs/ImportCsvTransactionsJob.php
@@ -12,6 +12,8 @@ use App\Models\Transaction;
 use App\Services\CsvImport\CsvParserService;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Database\QueryException;
+use Illuminate\Database\UniqueConstraintViolationException;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Queue\Middleware\WithoutOverlapping;
 use Illuminate\Support\Facades\Log;
@@ -62,8 +64,11 @@ final class ImportCsvTransactionsJob implements ShouldBeUnique, ShouldQueue
         ]);
 
         $imported = 0;
+        $updated = 0;
+        $restored = 0;
         $skipped = 0;
         $rowCount = 0;
+        $rowErrors = [];
         $mapping = $bankImport->column_mapping ?? [];
         $path = Storage::disk('local')->path($bankImport->stored_path);
 
@@ -71,12 +76,13 @@ final class ImportCsvTransactionsJob implements ShouldBeUnique, ShouldQueue
             foreach ($parser->eachRow($path, $mapping) as $row) {
                 $rowCount++;
 
-                $result = Transaction::query()->updateOrCreate(
-                    [
-                        'account_id' => $bankImport->account_id,
-                        'csv_hash' => $row->csvHash,
-                    ],
-                    [
+                try {
+                    $existing = Transaction::withTrashed()
+                        ->where('account_id', $bankImport->account_id)
+                        ->where('csv_hash', $row->csvHash)
+                        ->first();
+
+                    $values = [
                         'user_id' => $bankImport->user_id,
                         'amount' => $row->amount,
                         'direction' => $row->direction,
@@ -85,13 +91,42 @@ final class ImportCsvTransactionsJob implements ShouldBeUnique, ShouldQueue
                         'transaction_date' => $row->postDate,
                         'status' => TransactionStatus::Posted,
                         'source' => TransactionSource::Csv,
-                    ],
-                );
+                    ];
 
-                if ($result->wasRecentlyCreated) {
-                    $imported++;
-                } else {
+                    if ($existing === null) {
+                        Transaction::query()->create([
+                            'account_id' => $bankImport->account_id,
+                            'csv_hash' => $row->csvHash,
+                            ...$values,
+                        ]);
+                        $imported++;
+
+                        continue;
+                    }
+
+                    if ($existing->trashed()) {
+                        $existing->fill($values);
+                        $existing->restore();
+                        $restored++;
+
+                        continue;
+                    }
+
+                    $existing->fill($values)->save();
+                    $updated++;
+                } catch (Throwable $rowException) {
                     $skipped++;
+                    $rowErrors[] = [
+                        'row' => $rowCount,
+                        'description' => $row->description ?? null,
+                        'message' => self::userSafeRowError($rowException),
+                    ];
+
+                    Log::warning('CSV import row failed', [
+                        'bankImportId' => $bankImport->id,
+                        'row' => $rowCount,
+                        'exception' => $rowException,
+                    ]);
                 }
             }
         } catch (Throwable $e) {
@@ -101,6 +136,8 @@ final class ImportCsvTransactionsJob implements ShouldBeUnique, ShouldQueue
                 'row_count' => $rowCount,
                 'imported_count' => $imported,
                 'skipped_count' => $skipped,
+                'restored_count' => $restored,
+                'row_errors' => $rowErrors !== [] ? $rowErrors : null,
                 'completed_at' => now(),
             ]);
 
@@ -118,6 +155,11 @@ final class ImportCsvTransactionsJob implements ShouldBeUnique, ShouldQueue
             'row_count' => $rowCount,
             'imported_count' => $imported,
             'skipped_count' => $skipped,
+            'restored_count' => $restored,
+            'row_errors' => $rowErrors !== [] ? $rowErrors : null,
+            'error_summary' => $rowErrors === []
+                ? null
+                : sprintf('%d row(s) failed; see details.', count($rowErrors)),
             'completed_at' => now(),
         ]);
 
@@ -126,6 +168,8 @@ final class ImportCsvTransactionsJob implements ShouldBeUnique, ShouldQueue
             'userId' => $bankImport->user_id,
             'rowCount' => $rowCount,
             'imported' => $imported,
+            'updated' => $updated,
+            'restored' => $restored,
             'skipped' => $skipped,
         ]);
 
@@ -144,5 +188,14 @@ final class ImportCsvTransactionsJob implements ShouldBeUnique, ShouldQueue
             'bankImportId' => $this->bankImport->id,
             'exception' => $exception,
         ]);
+    }
+
+    private static function userSafeRowError(Throwable $e): string
+    {
+        return match (true) {
+            $e instanceof UniqueConstraintViolationException => 'Duplicate row detected for this account.',
+            $e instanceof QueryException => 'Database rejected this row.',
+            default => 'Could not import this row.',
+        };
     }
 }

--- a/app/Models/BankImport.php
+++ b/app/Models/BankImport.php
@@ -21,7 +21,9 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property int $row_count
  * @property int $imported_count
  * @property int $skipped_count
+ * @property int $restored_count
  * @property string|null $error_summary
+ * @property array<int, array{row: int, description: string|null, message: string}>|null $row_errors
  * @property array<string, string>|null $column_mapping
  * @property CarbonImmutable|null $started_at
  * @property CarbonImmutable|null $completed_at
@@ -45,7 +47,9 @@ final class BankImport extends Model
         'row_count',
         'imported_count',
         'skipped_count',
+        'restored_count',
         'error_summary',
+        'row_errors',
         'column_mapping',
         'started_at',
         'completed_at',
@@ -76,6 +80,7 @@ final class BankImport extends Model
         return [
             'status' => BankImportStatus::class,
             'column_mapping' => 'array',
+            'row_errors' => 'array',
             'started_at' => 'datetime',
             'completed_at' => 'datetime',
         ];

--- a/database/migrations/2026_05_24_120000_widen_csv_hash_unique_to_include_deleted_at.php
+++ b/database/migrations/2026_05_24_120000_widen_csv_hash_unique_to_include_deleted_at.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('transactions', static function (Blueprint $table): void {
+            $table->unique(
+                ['account_id', 'csv_hash', 'deleted_at'],
+                'transactions_account_csv_hash_deleted_unique',
+            );
+            $table->dropUnique('transactions_account_csv_hash_unique');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('transactions', static function (Blueprint $table): void {
+            $table->unique(['account_id', 'csv_hash'], 'transactions_account_csv_hash_unique');
+            $table->dropUnique('transactions_account_csv_hash_deleted_unique');
+        });
+    }
+};

--- a/database/migrations/2026_05_24_120001_add_restored_count_and_row_errors_to_bank_imports_table.php
+++ b/database/migrations/2026_05_24_120001_add_restored_count_and_row_errors_to_bank_imports_table.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('bank_imports', static function (Blueprint $table): void {
+            $table->unsignedInteger('restored_count')->default(0)->after('skipped_count');
+            $table->json('row_errors')->nullable()->after('error_summary');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('bank_imports', static function (Blueprint $table): void {
+            $table->dropColumn(['restored_count', 'row_errors']);
+        });
+    }
+};

--- a/resources/views/livewire/import-bank.blade.php
+++ b/resources/views/livewire/import-bank.blade.php
@@ -201,13 +201,31 @@
                 <x-cib.stat-pill tone="income" data-testid="import-bank-result-imported">
                     {{ $bankImport->imported_count }} imported
                 </x-cib.stat-pill>
+                <x-cib.stat-pill tone="posted" data-testid="import-bank-result-restored">
+                    {{ $bankImport->restored_count }} restored
+                </x-cib.stat-pill>
                 <x-cib.stat-pill tone="planned" data-testid="import-bank-result-skipped">
-                    {{ $bankImport->skipped_count }} skipped (duplicates)
+                    {{ $bankImport->skipped_count }} skipped
                 </x-cib.stat-pill>
             </div>
 
             @if($bankImport->status === BankImportStatus::Failed && $bankImport->error_summary)
                 <flux:text class="mt-3 text-cib-red-600">{{ $bankImport->error_summary }}</flux:text>
+            @endif
+
+            @if(! empty($bankImport->row_errors))
+                <flux:callout variant="warning" class="mt-3" data-testid="import-bank-result-row-errors">
+                    <flux:callout.heading>{{ count($bankImport->row_errors) }} row(s) failed</flux:callout.heading>
+                    <ul class="mt-2 list-disc pl-5 text-sm">
+                        @foreach($bankImport->row_errors as $rowError)
+                            <li>
+                                Row {{ $rowError['row'] }} —
+                                {{ $rowError['description'] ?? '(unknown)' }}:
+                                {{ $rowError['message'] }}
+                            </li>
+                        @endforeach
+                    </ul>
+                </flux:callout>
             @endif
 
             @if($bankImport->status->isTerminal())

--- a/tests/Feature/Jobs/ImportCsvTransactionsJobTest.php
+++ b/tests/Feature/Jobs/ImportCsvTransactionsJobTest.php
@@ -12,10 +12,12 @@ use App\Jobs\ImportCsvTransactionsJob;
 use App\Jobs\RunTransactionAnalysisJob;
 use App\Models\Account;
 use App\Models\BankImport;
+use App\Models\Category;
 use App\Models\Transaction;
 use App\Models\User;
 use App\Services\CsvImport\CsvColumnMapper;
 use App\Services\CsvImport\CsvParserService;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Facades\Storage;
 use Random\RandomException;
@@ -89,6 +91,7 @@ test('re-running the same import is idempotent (dedupe via csv_hash)', function 
         'status' => BankImportStatus::Pending,
         'imported_count' => 0,
         'skipped_count' => 0,
+        'restored_count' => 0,
         'row_count' => 0,
         'completed_at' => null,
     ]);
@@ -98,7 +101,8 @@ test('re-running the same import is idempotent (dedupe via csv_hash)', function 
     $bankImport->refresh();
     expect($bankImport->status)->toBe(BankImportStatus::Completed)
         ->and($bankImport->imported_count)->toBe(0)
-        ->and($bankImport->skipped_count)->toBeGreaterThanOrEqual($firstImported)
+        ->and($bankImport->restored_count)->toBe(0)
+        ->and($bankImport->skipped_count)->toBe(0)
         ->and(Transaction::count())->toBe($totalAfterFirst);
 });
 
@@ -146,6 +150,111 @@ test('failure transitions status to Failed and records error_summary', function 
         ->and($bankImport->completed_at)->not->toBeNull();
 
     Queue::assertNotPushed(RunTransactionAnalysisJob::class);
+});
+
+test('re-importing restores a soft-deleted transaction and preserves its category', function () {
+    Queue::fake([RunTransactionAnalysisJob::class]);
+
+    $bankImport = makeBankImportFromFixture();
+
+    new ImportCsvTransactionsJob($bankImport)->handle(new CsvParserService());
+
+    $bankImport->refresh();
+    expect($bankImport->status)->toBe(BankImportStatus::Completed)
+        ->and($bankImport->imported_count)->toBeGreaterThan(0);
+
+    $target = Transaction::query()
+        ->where('account_id', $bankImport->account_id)
+        ->whereNotNull('csv_hash')
+        ->first();
+
+    $category = Category::factory()->create();
+    $target->update(['category_id' => $category->id]);
+    $targetId = $target->id;
+    $targetHash = $target->csv_hash;
+    $target->delete();
+
+    expect(Transaction::query()->find($targetId))->toBeNull()
+        ->and(Transaction::withTrashed()->find($targetId)->trashed())->toBeTrue();
+
+    $bankImport->update([
+        'status' => BankImportStatus::Pending,
+        'imported_count' => 0,
+        'skipped_count' => 0,
+        'restored_count' => 0,
+        'row_count' => 0,
+        'row_errors' => null,
+        'completed_at' => null,
+    ]);
+
+    new ImportCsvTransactionsJob($bankImport)->handle(new CsvParserService());
+
+    $bankImport->refresh();
+    $restored = Transaction::query()->find($targetId);
+
+    expect($bankImport->status)->toBe(BankImportStatus::Completed)
+        ->and($bankImport->restored_count)->toBe(1)
+        ->and($bankImport->imported_count)->toBe(0)
+        ->and($restored)->not->toBeNull()
+        ->and($restored->deleted_at)->toBeNull()
+        ->and($restored->csv_hash)->toBe($targetHash)
+        ->and($restored->category_id)->toBe($category->id);
+});
+
+test('per-row failure does not abort the import and is recorded in row_errors', function () {
+    Queue::fake([RunTransactionAnalysisJob::class]);
+
+    $eventKey = 'eloquent.creating: '.Transaction::class;
+
+    Transaction::creating(static function (Transaction $tx): void {
+        if (str_contains($tx->description ?? '', 'INTENTIONAL_FAILURE')) {
+            throw new RuntimeException('Simulated row failure for test');
+        }
+    });
+
+    try {
+        $user = User::factory()->create();
+        $account = Account::factory()->for($user)->csvImport()->create();
+
+        $csv = <<<'CSV'
+        Date,Description,Amount
+        01/01/2026,Good row one,100.00
+        02/01/2026,INTENTIONAL_FAILURE row,200.00
+        03/01/2026,Good row two,-300.00
+        CSV;
+
+        $storedPath = 'bank-imports/'.bin2hex(random_bytes(8)).'.csv';
+        Storage::disk('local')->put($storedPath, $csv);
+
+        $bankImport = BankImport::factory()
+            ->for($user)
+            ->for($account)
+            ->create([
+                'original_filename' => 'inline.csv',
+                'stored_path' => $storedPath,
+                'column_mapping' => [
+                    CsvColumnMapper::FIELD_DATE => 'Date',
+                    CsvColumnMapper::FIELD_DESCRIPTION => 'Description',
+                    CsvColumnMapper::FIELD_AMOUNT => 'Amount',
+                ],
+            ]);
+
+        new ImportCsvTransactionsJob($bankImport)->handle(new CsvParserService());
+
+        $bankImport->refresh();
+
+        expect($bankImport->status)->toBe(BankImportStatus::Completed)
+            ->and($bankImport->imported_count)->toBe(2)
+            ->and($bankImport->skipped_count)->toBe(1)
+            ->and($bankImport->row_errors)->toBeArray()
+            ->and($bankImport->row_errors)->toHaveCount(1)
+            ->and($bankImport->row_errors[0]['description'])->toContain('INTENTIONAL_FAILURE')
+            ->and($bankImport->row_errors[0]['message'])->toBe('Could not import this row.');
+
+        expect(Transaction::query()->where('account_id', $account->id)->count())->toBe(2);
+    } finally {
+        Event::forget($eventKey);
+    }
 });
 
 test('uniqueId is the bankImport id', function () {


### PR DESCRIPTION
Closes #240

## Summary

- **Widen the `transactions` unique index** to `(account_id, csv_hash, deleted_at)` so a re-import of a CSV row that matches a previously soft-deleted transaction no longer triggers `UniqueConstraintViolationException`. MariaDB treats each NULL in a unique index as distinct, so the constraint still rejects duplicate **live** rows.
- **Restore matching soft-deleted rows on re-import** in `ImportCsvTransactionsJob`, preserving `category_id`, `clean_description`, `parent_transaction_id`, and enrichment data while refreshing the CSV-derived fields.
- **Per-row try/catch** so a single bad row no longer aborts the whole import. Failed rows are collected into a new `bank_imports.row_errors` JSON column with row number, description, and message; successful rows around the failure still persist; the import ends in `Completed` state.
- **UI surfaces the new state**: a restored-count pill alongside imported/skipped, and a Flux warning callout listing each failed row when `row_errors` is non-empty.

## Why the migration drops-after-create

MariaDB rejects dropping the original `transactions_account_csv_hash_unique` because it's the only index covering the `account_id` foreign-key constraint. The migration creates the new wider index *first* (still `account_id`-prefixed, so it satisfies the FK), then drops the old one — using a distinct name (`transactions_account_csv_hash_deleted_unique`) to avoid name collision during the brief overlap.

## Semantic note

`bank_imports.skipped_count` semantics shift slightly: it previously meant "row already existed (no-op)" and now means "row could not be imported". Re-importing an unchanged CSV now produces `imported=0, restored=0, skipped=0` because matching live rows go silently through the update branch. No `updated_count` column was added (YAGNI — flagged optional in the plan).

## Test plan

- [x] `op migrate` applies both new migrations cleanly
- [x] `op test.filter ImportCsvTransactionsJob` — 9 passed (46 assertions), including new restore-on-reimport and per-row-failure tests
- [x] `op test.filter "import"` — 58 passed across all import flow tests
- [x] `op test` — 1,575 passed (4 pre-existing skips), no regressions
- [x] `op analyse` (PHPStan) — clean
- [x] `op lint.dirty` (Pint) — clean
- [x] DB sanity: `SHOW INDEX FROM transactions WHERE Key_name LIKE '%csv_hash%';` confirms 3-column index `(account_id, csv_hash, deleted_at)` with NULL allowed on cols 2 and 3
- [ ] Manual UI verification: re-upload `context/StatementCsv (1).csv` after soft-deleting a transaction; confirm Step-3 panel shows Imported/Restored/Skipped pills and any row-error callout