### PR TITLE
fix: #239 PlannedTransaction::excludingTransfers misses transfer_to_account_id

### DIFF
--- a/app/Models/PlannedTransaction.php
+++ b/app/Models/PlannedTransaction.php
@@ -93,13 +93,15 @@ final class PlannedTransaction extends Model
      */
     public function scopeExcludingTransfers(Builder $query): Builder
     {
-        return $query->whereDoesntHave('category', function (Builder $q): void {
-            $q->where('name', 'Transfer')
-                ->orWhereHas(
-                    'parent',
-                    fn (Builder $p): Builder => $p->where('name', 'Transfer'),
-                );
-        });
+        return $query
+            ->whereNull('transfer_to_account_id')
+            ->whereDoesntHave('category', function (Builder $q): void {
+                $q->where('name', 'Transfer')
+                    ->orWhereHas(
+                        'parent',
+                        fn (Builder $p): Builder => $p->where('name', 'Transfer'),
+                    );
+            });
     }
 
     /**

--- a/tests/Feature/Models/PlannedTransactionTest.php
+++ b/tests/Feature/Models/PlannedTransactionTest.php
@@ -469,3 +469,42 @@ test('upcoming scope orders by start_date ascending', function () {
 
     expect($results->pluck('id')->all())->toBe([$earlier->id, $later->id]);
 });
+
+// ── Scope: excludingTransfers ──────────────────────────────────────
+
+test('excludingTransfers excludes plans with transfer_to_account_id set', function () {
+    $user = User::factory()->create();
+    $source = Account::factory()->for($user)->create();
+    $destination = Account::factory()->for($user)->create();
+
+    PlannedTransaction::factory()->for($user)->for($source)->create([
+        'transfer_to_account_id' => $destination->id,
+    ]);
+
+    expect(PlannedTransaction::excludingTransfers()->count())->toBe(0);
+});
+
+test('excludingTransfers excludes plans categorised as Transfer', function () {
+    $transferCategory = Category::factory()->create(['name' => 'Transfer']);
+    PlannedTransaction::factory()->create(['category_id' => $transferCategory->id]);
+
+    expect(PlannedTransaction::excludingTransfers()->count())->toBe(0);
+});
+
+test('excludingTransfers excludes plans whose parent category is Transfer', function () {
+    $parent = Category::factory()->create(['name' => 'Transfer']);
+    $child = Category::factory()->create(['name' => 'Optimus to CC', 'parent_id' => $parent->id]);
+    PlannedTransaction::factory()->create(['category_id' => $child->id]);
+
+    expect(PlannedTransaction::excludingTransfers()->count())->toBe(0);
+});
+
+test('excludingTransfers includes plans with no transfer_to_account_id and non-Transfer category', function () {
+    $category = Category::factory()->create(['name' => 'Groceries']);
+    PlannedTransaction::factory()->create([
+        'category_id' => $category->id,
+        'transfer_to_account_id' => null,
+    ]);
+
+    expect(PlannedTransaction::excludingTransfers()->count())->toBe(1);
+});


### PR DESCRIPTION
## Summary

Fixes #239 — `PlannedTransaction::scopeExcludingTransfers()` only checked the category name, leaking planned transfers that use `transfer_to_account_id` without a "Transfer"-named category. This caused double-counted outflows in calendar pips, the user's planned-debit aggregation, and the monthly projection chart.

- Add `->whereNull('transfer_to_account_id')` to `PlannedTransaction::scopeExcludingTransfers()`, mirroring `Transaction::scopeExcludingTransfers()` which already combines its `transfer_pair_id` check with the category filter.
- Add four feature tests covering: the `transfer_to_account_id` regression (the specific #239 case), the `Transfer` category exclusion, the parent-category exclusion, and the positive "include normal expense" case.

## Why a model-layer fix

Three call sites consume this scope unchanged and are automatically corrected — no per-caller patches needed:

- `app/Support/Calendar/DayActivityLoader.php:42` — calendar pip rendering
- `app/Models/User.php:228` — planned-debit aggregation through pay-cycle end
- `app/Services/Projection/MonthlyProjectionService.php:28` — monthly projection chart

## Notes

The plan's first test originally used `PlannedTransaction::factory()->transfer()->create()`, but that factory state has a separate latent bug (it calls `User::find()` on an unresolved `UserFactory` instance). Worked around it inline in the test rather than touching the factory; the factory bug is worth a separate ticket.

## Test plan

- [x] `op test.filter PlannedTransactionTest` — 45 passed (4 new tests, including #239 regression)
- [x] `op test.filter PayCycleCalendar` — 41 passed
- [x] `op test.filter CalendarView` — 27 passed
- [x] `op test.filter DayActivityLoader` — 12 passed
- [x] `op test.filter MonthlyProjectionService` — 14 passed
- [x] `op lint.dirty` — pass
- [ ] Manual smoke: create a planned transaction with `transfer_to_account_id` set and `category_id = null`, verify it no longer appears as a `plan` pip on `/dashboard` and `/calendar`

🤖 Generated with [Claude Code](https://claude.com/claude-code)