### PR TITLE
fix: #243 revert TransactionModal category section to searchable combobox

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -497,31 +497,6 @@ select:focus[data-flux-control] {
     .type-toggle button.active.out { color: var(--color-money-owed); }
     .type-toggle button.active.xfr { color: var(--color-cib-teal-600); }
 
-    .cat-chip {
-        appearance: none;
-        cursor: pointer;
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        gap: 5px;
-        padding: 10px 4px;
-        border-radius: 10px;
-        background: var(--color-cib-n-50);
-        border: 2px solid var(--color-border-1);
-        font: 700 11px/1.1 var(--font-sans);
-        color: var(--color-fg-2);
-        text-align: center;
-        min-height: 68px;
-    }
-    .cat-chip svg { width: 20px; height: 20px; }
-    .cat-chip[aria-pressed="true"] {
-        background: var(--color-cib-black);
-        color: var(--color-cib-white);
-        border-color: var(--color-cib-black);
-        box-shadow: 2px 2px 0 0 var(--color-cib-teal-400);
-    }
-    .cat-chip[aria-pressed="true"] .cat-color { color: var(--color-cib-yellow-400); }
-
     .rule-suggest {
         display: flex;
         align-items: flex-start;

--- a/resources/views/livewire/transaction-modal.blade.php
+++ b/resources/views/livewire/transaction-modal.blade.php
@@ -158,36 +158,12 @@
                 </flux:select>
             @endif
 
-            {{-- Category chip grid --}}
-            <div>
-                <label class="cib-label">{{ __('Category') }}</label>
-                <div class="grid grid-cols-4 gap-2 max-h-80 overflow-y-auto pr-1">
-                    <button type="button"
-                            class="cat-chip"
-                            aria-pressed="{{ $categoryId === null ? 'true' : 'false' }}"
-                            wire:click="$set('categoryId', null)">
-                        <span class="cat-color inline-grid h-5 w-5 place-items-center rounded-full bg-cib-n-100 font-black">
-                            &nbsp;
-                        </span>
-                        <span class="truncate">{{ __('Uncategorised') }}</span>
-                    </button>
-                    @foreach($categories as $c)
-                        <button type="button"
-                                class="cat-chip"
-                                aria-pressed="{{ $categoryId === $c->id ? 'true' : 'false' }}"
-                                wire:click="$set('categoryId', {{ $c->id }})">
-                            @if($c->icon)
-                                <flux:icon name="{{ $c->icon }}" class="cat-color" />
-                            @else
-                                <span class="cat-color inline-grid h-5 w-5 place-items-center rounded-full bg-cib-n-100 font-black text-xs">
-                                    {{ Str::upper(Str::substr($c->name, 0, 1)) }}
-                                </span>
-                            @endif
-                            <span class="truncate w-full">{{ $c->name }}</span>
-                        </button>
-                    @endforeach
-                </div>
-            </div>
+            <x-category-combobox
+                wire:model="categoryId"
+                :categories="$categories"
+                :label="__('Category')"
+                :placeholder="__('No category')"
+            />
 
             {{-- Plan-mode fields --}}
             @if($mode === 'plan')

--- a/tests/Browser/Livewire/TransactionModalBrowserTest.php
+++ b/tests/Browser/Livewire/TransactionModalBrowserTest.php
@@ -30,7 +30,7 @@ test('transaction modal renders the neo-brutalist type-toggle three-pill control
         ->assertSee('Transfer');
 });
 
-test('transaction modal renders the category chip grid with aria-pressed state', function () use ($openModal) {
+test('transaction modal renders the category combobox', function () use ($openModal) {
     $user = User::factory()->create();
     Account::factory()->for($user)->create();
     Category::factory()->create(['name' => 'Groceries', 'icon' => 'shopping-cart']);
@@ -42,9 +42,8 @@ test('transaction modal renders the category chip grid with aria-pressed state',
 
     $page->script($openModal);
 
-    $page->assertPresent('.cat-chip')
-        ->assertSee('Groceries')
-        ->assertSee('Utilities');
+    $page->assertPresent('[role="combobox"]')
+        ->assertPresent('[role="combobox"] input[placeholder]');
 });
 
 test('plan-mode pill reveals frequency and until-date controls', function () use ($openModal) {


### PR DESCRIPTION
## Summary

Closes #243. Reverts the category selection UI in the Edit Transaction / Plan modal from a 4-column scrollable chip grid back to the searchable `<x-category-combobox>` typeahead. The chip grid (introduced in #196 / commit a1b8c75) regressed UX: no text filter, no parent/sub-category path visibility, and visual crowding on long category lists.

- Replace ~30 lines of inline chip-grid markup with a single `<x-category-combobox>` tag — the component was never removed from the codebase and is still actively used by `user-rule-manager` and `analysis-suggestions`.
- Delete 24 lines of orphan `.cat-chip*` CSS rules in `app.css` (verified via grep — only the modal referenced them).
- Update the one browser test that asserted `.cat-chip` presence to assert the combobox shell instead.

## Why this is low-risk

The Livewire `categoryId` property and `$categories` collection on `TransactionModal.php` are unchanged. All 126 existing `tests/Feature/Livewire/TransactionModalTest.php` tests pass without a single test-code change — they drive behavior via `->set('categoryId', $id)` (the property), not the UI control.

## Plan reference

Full implementation plan at `thoughts/plans/revert-transaction-modal-category-to-combobox.md` in this repo (written via `laravel:writing-plans` skill).

## Test plan

- [x] `op test.filter TransactionModalTest` — 126 passed (524 assertions, unchanged test code)
- [x] `op test.filter UserRuleManagerTest` — 22 passed (combobox still works in adjacent flow)
- [x] `op test.filter AnalysisSuggestionsTest` — 30 passed (combobox still works in adjacent flow)
- [x] `op lint.dirty` — pass
- [x] `op ci` — no new errors reference changed files (pre-existing baseline noise unchanged)
- [ ] Manual smoke on `/calendar` and `/dashboard`:
    - [ ] Modal opens, **Category** is a text input (not a grid)
    - [ ] Typing 3+ characters shows matching categories with full path (`Parent / Child`)
    - [ ] Selecting sets `categoryId`, clear (×) button appears
    - [ ] Clearing resets `categoryId` to `null`
    - [ ] Save persists transaction with correct `category_id`
    - [ ] Mobile (375×812) and desktop (1920×1080) both render cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)