### PR TITLE
fix(#243): pre-fill category combobox in edit mode + interactive browser tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ tests/Basiq/http-client.env.json
 !/CLAUDE.md
 .claude/scheduled_tasks.lock
 /context
+/graphify-out
+/thoughts

--- a/resources/views/components/category-combobox.blade.php
+++ b/resources/views/components/category-combobox.blade.php
@@ -25,19 +25,31 @@
         wireModel: '{{ $wireModel }}',
 
         init() {
-            const currentValue = this.$wire.get(this.wireModel);
-            if (currentValue) {
-                const match = this.items.find(i => i.id == currentValue);
-                if (match) {
-                    this.selectedId = match.id;
-                    this.selectedLabel = match.label;
-                    this.search = match.label;
+            this.syncFromWire();
+
+            this.$wire.$watch(this.wireModel, (value) => {
+                if (value != this.selectedId) {
+                    this.syncFromWire();
                 }
-            }
+            });
 
             this.$watch('selectedId', (value) => {
                 this.$wire.set(this.wireModel, value);
             });
+        },
+
+        syncFromWire() {
+            const currentValue = this.$wire.get(this.wireModel);
+            const match = currentValue ? this.items.find(i => i.id == currentValue) : null;
+            if (match) {
+                this.selectedId = match.id;
+                this.selectedLabel = match.label;
+                this.search = match.label;
+            } else {
+                this.selectedId = null;
+                this.selectedLabel = '';
+                this.search = '';
+            }
         },
 
         get filtered() {

--- a/tests/Browser/Livewire/TransactionModalCategoryComboboxTest.php
+++ b/tests/Browser/Livewire/TransactionModalCategoryComboboxTest.php
@@ -1,0 +1,146 @@
+<?php
+
+/** @noinspection JSUnresolvedReference */
+/** @noinspection StaticClosureCanBeUsedInspection */
+
+declare(strict_types=1);
+
+use App\Enums\TransactionDirection;
+use App\Enums\TransactionSource;
+use App\Models\Account;
+use App\Models\Category;
+use App\Models\Transaction;
+use App\Models\User;
+
+$openModal = <<<'JS'
+    Livewire.dispatch('open-transaction-modal', { date: '2026-04-19' })
+JS;
+
+test('combobox shows the hint until three characters are typed', function () use ($openModal) {
+    $user = User::factory()->create();
+    Account::factory()->for($user)->create();
+    Category::factory()->create(['name' => 'Groceries']);
+
+    $this->actingAs($user);
+
+    $page = visit('/calendar');
+    $page->script($openModal);
+
+    $page->assertPresent('[role="combobox"] input')
+        ->click('[role="combobox"] input')
+        ->type('[role="combobox"] input', 'gr')
+        ->assertSee('Type 3+ characters to search...')
+        ->assertDontSee('Groceries');
+});
+
+test('combobox filters case-insensitively at three or more characters', function () use ($openModal) {
+    $user = User::factory()->create();
+    Account::factory()->for($user)->create();
+    Category::factory()->create(['name' => 'Groceries']);
+    Category::factory()->create(['name' => 'Utilities']);
+
+    $this->actingAs($user);
+
+    $page = visit('/calendar');
+    $page->script($openModal);
+
+    $page->assertPresent('[role="combobox"] input')
+        ->click('[role="combobox"] input')
+        ->type('[role="combobox"] input', 'GRO')
+        ->assertSee('Groceries')
+        ->assertDontSee('Utilities');
+});
+
+test('combobox shows the full parent and child path in results', function () use ($openModal) {
+    $user = User::factory()->create();
+    Account::factory()->for($user)->create();
+    $bills = Category::factory()->create(['name' => 'Bills']);
+    Category::factory()->withParent($bills)->create(['name' => 'Internet']);
+
+    $this->actingAs($user);
+
+    $page = visit('/calendar');
+    $page->script($openModal);
+
+    $page->assertPresent('[role="combobox"] input')
+        ->click('[role="combobox"] input')
+        ->type('[role="combobox"] input', 'inte')
+        ->assertSee('Bills / Internet');
+});
+
+test('combobox shows the no-results message for a non-matching term', function () use ($openModal) {
+    $user = User::factory()->create();
+    Account::factory()->for($user)->create();
+    Category::factory()->create(['name' => 'Groceries']);
+
+    $this->actingAs($user);
+
+    $page = visit('/calendar');
+    $page->script($openModal);
+
+    $page->assertPresent('[role="combobox"] input')
+        ->click('[role="combobox"] input')
+        ->type('[role="combobox"] input', 'zzzzz')
+        ->assertSee('No categories found');
+});
+
+test('combobox selection is reflected in the input and reveals the clear button', function () use ($openModal) {
+    $user = User::factory()->create();
+    Account::factory()->for($user)->create();
+    Category::factory()->create(['name' => 'Groceries']);
+
+    $this->actingAs($user);
+
+    $page = visit('/calendar');
+    $page->script($openModal);
+
+    $page->assertPresent('[role="combobox"] input')
+        ->click('[role="combobox"] input')
+        ->type('[role="combobox"] input', 'gro')
+        ->assertSee('Groceries')
+        ->click('Groceries')
+        ->assertValue('[role="combobox"] input', 'Groceries')
+        ->assertPresent('[role="combobox"] button[aria-label="Clear selection"]');
+});
+
+test('combobox clear button resets the selection', function () use ($openModal) {
+    $user = User::factory()->create();
+    Account::factory()->for($user)->create();
+    Category::factory()->create(['name' => 'Groceries']);
+
+    $this->actingAs($user);
+
+    $page = visit('/calendar');
+    $page->script($openModal);
+
+    $page->assertPresent('[role="combobox"] input')
+        ->click('[role="combobox"] input')
+        ->type('[role="combobox"] input', 'gro')
+        ->click('Groceries')
+        ->assertValue('[role="combobox"] input', 'Groceries')
+        ->click('[role="combobox"] button[aria-label="Clear selection"]')
+        ->assertValue('[role="combobox"] input', '')
+        ->assertMissing('[role="combobox"] button[aria-label="Clear selection"]');
+});
+
+test('combobox is pre-filled when editing a transaction with a category', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $category = Category::factory()->create(['name' => 'Groceries']);
+    $transaction = Transaction::factory()->for($user)->for($account)->create([
+        'amount' => 4250,
+        'direction' => TransactionDirection::Debit,
+        'description' => 'coffee and cake',
+        'post_date' => '2026-03-15',
+        'category_id' => $category->id,
+        'source' => TransactionSource::Manual,
+    ]);
+
+    $this->actingAs($user);
+
+    $page = visit('/calendar');
+    $page->script("Livewire.dispatch('edit-transaction', { id: {$transaction->id} })");
+
+    $page->assertPresent('[role="combobox"] input')
+        ->assertValue('[role="combobox"] input', 'Groceries');
+});

--- a/tests/Feature/Livewire/TransactionModalTest.php
+++ b/tests/Feature/Livewire/TransactionModalTest.php
@@ -206,6 +206,24 @@ test('categories are sorted by full path in transaction modal render', function 
         });
 });
 
+test('renders the category combobox wired with visible full-path options', function () {
+    $user = User::factory()->create();
+    $bills = Category::factory()->create(['name' => 'Bills']);
+    Category::factory()->withParent($bills)->create(['name' => 'Internet']);
+    Category::factory()->create(['name' => 'HiddenZebra', 'is_hidden' => true]);
+
+    $html = Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('open-transaction-modal', date: '2026-03-15')
+        ->html();
+
+    expect($html)
+        ->toContain('role="combobox"')
+        ->toContain('Bills')
+        ->toContain('Internet')
+        ->not->toContain('HiddenZebra');
+});
+
 test('dispatches transaction-saved event on save', function () {
     $user = User::factory()->create();
     $account = Account::factory()->for($user)->create();


### PR DESCRIPTION
## Summary
- Add Pest v4 browser tests exercising the real category-combobox UI — search threshold (<3 chars), case-insensitive filtering, full `Parent / Child` path, no-results message, selection, clear, and edit-mode pre-fill. Closes the interactive-coverage gap deferred by #243's plan (the existing 60+ feature tests drive `->set('categoryId', …)` and bypass the Alpine layer entirely).
- Add a fast feature-level render guard asserting the combobox renders with visible full-path options and excludes hidden categories.
- **Fix a real bug** found while writing the edit test: opening a transaction for edit showed "No category" despite a saved category. The combobox only synced Alpine→Livewire (`$watch('selectedId')`); it never reflected server-driven `categoryId` changes. Added a guarded `$wire.$watch` Livewire→Alpine sync (`syncFromWire()`). Because Livewire resolves the path via `dataGet`, the same fix also corrects the latent gap for the nested-`wire:model` consumers (Analysis Suggestions `recurringCategories.{id}`, Rule Manager `actions.{i}.value`).

## Related
- Follow-up to #243 (combobox revert — already merged/closed). No separate issue tracks the edit-mode pre-fill bug; it is fixed here.

## Test plan
- [x] `op test.browser.filter TransactionModalCategoryCombobox` — 7/7 pass
- [x] `op test.filter TransactionModalTest` — 127 pass (incl. new render guard)
- [x] `op analyse` (PHPStan) — No errors
- [x] `op lint.dirty` (Pint) — pass
- [x] `op test` (full: Unit + Feature + Browser + Arch) — 1587 passed, 4 skipped (no regression on any combobox consumer)

## Notes
- Selected state displays as the input's **value** (`x-model="search"`), not the placeholder. The new sync guards on `value != selectedId` so it only reflects server-driven changes and never wipes in-progress typing.
- Heads-up: `op ci` is currently red at the `op mago.lint` step on pre-existing, codebase-wide lint debt unrelated to this PR (literal passwords in seeders, non-static closures, numeric-literal warnings). Pint, PHPStan, and the full test suite all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)