### PR TITLE
fix(#246): match imported transactions to planned items and show one 'Planned'-tagged calendar entry

### DIFF
--- a/app/Console/Commands/MatchPlannedTransactionsCommand.php
+++ b/app/Console/Commands/MatchPlannedTransactionsCommand.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\User;
+use App\Services\PlannedTransactionMatcher;
+use Illuminate\Console\Command;
+use Illuminate\Database\Eloquent\Collection;
+
+final class MatchPlannedTransactionsCommand extends Command
+{
+    protected $signature = 'app:match-planned-transactions {--user= : Match a single user id; omit to process every user with active planned transactions}';
+
+    protected $description = 'Tag imported transactions that match an active planned item (the same matching the sync/import pipeline performs)';
+
+    public function handle(PlannedTransactionMatcher $matcher): int
+    {
+        $userId = $this->option('user');
+
+        if ($userId !== null) {
+            $user = User::query()->find((int) $userId);
+
+            if ($user === null) {
+                $this->error("User {$userId} not found.");
+
+                return self::FAILURE;
+            }
+
+            $this->info("Matched {$matcher->matchForUser($user)} transaction(s).");
+
+            return self::SUCCESS;
+        }
+
+        $matched = 0;
+
+        User::query()
+            ->whereHas('plannedTransactions', fn ($query) => $query->where('is_active', true))
+            ->chunkById(100, function (Collection $users) use ($matcher, &$matched): void {
+                foreach ($users as $user) {
+                    $matched += $matcher->matchForUser($user);
+                }
+            });
+
+        $this->info("Matched {$matched} transaction(s).");
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Livewire/Dashboard/Data/PayCyclePip.php
+++ b/app/Livewire/Dashboard/Data/PayCyclePip.php
@@ -14,5 +14,6 @@ final readonly class PayCyclePip
         public ?int $transactionId,
         public ?int $plannedTransactionId,
         public ?string $occurrenceDate,
+        public bool $matched = false,
     ) {}
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -10,6 +10,7 @@ use App\Services\BasiqService;
 use App\Services\GitHubService;
 use App\Services\PipelineStages\IdentifyPrimaryAccountStage;
 use App\Services\PipelineStages\IdentifyRecurringTransactionsStage;
+use App\Services\PipelineStages\MatchPlannedTransactionsStage;
 use App\Services\PipelineStages\SetPayCycleStage;
 use App\Services\PipelineStages\UserRulesStage;
 use App\Services\TransactionAnalysisPipeline;
@@ -49,6 +50,7 @@ final class AppServiceProvider extends ServiceProvider
                 new SetPayCycleStage,
                 new IdentifyRecurringTransactionsStage,
                 $this->app->make(UserRulesStage::class),
+                $this->app->make(MatchPlannedTransactionsStage::class),
             ],
         ));
 

--- a/app/Services/PipelineStages/MatchPlannedTransactionsStage.php
+++ b/app/Services/PipelineStages/MatchPlannedTransactionsStage.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\PipelineStages;
+
+use App\Contracts\PipelineStageContract;
+use App\DTOs\PipelineContext;
+use App\DTOs\StageResult;
+use App\Services\PlannedTransactionMatcher;
+
+final readonly class MatchPlannedTransactionsStage implements PipelineStageContract
+{
+    private const string STAGE_KEY = 'match-planned-transactions';
+
+    public function __construct(private PlannedTransactionMatcher $matcher) {}
+
+    public function key(): string
+    {
+        return self::STAGE_KEY;
+    }
+
+    public function label(): string
+    {
+        return 'Match Planned Transactions';
+    }
+
+    public function shouldRun(PipelineContext $context): bool
+    {
+        return true;
+    }
+
+    public function execute(PipelineContext $context): StageResult
+    {
+        $this->matcher->matchForUser($context->user);
+
+        return new StageResult(success: true, stage: self::STAGE_KEY, suggestionIds: []);
+    }
+}

--- a/app/Services/PlannedTransactionMatcher.php
+++ b/app/Services/PlannedTransactionMatcher.php
@@ -1,0 +1,186 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Models\PlannedTransaction;
+use App\Models\Transaction;
+use App\Models\User;
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Collection;
+
+/**
+ * Matches imported transactions to the active planned items they fulfil, tagging each with
+ * planned_transaction_id. Runs during sync/import so an occurred payment is recognised as
+ * "that planned item" instead of showing as a separate forecast on the calendar.
+ *
+ * A match needs the same account + direction, an EXACT amount, and a post_date within
+ * ReconciliationMatcher::DATE_TOLERANCE_DAYS of a plan occurrence. Matching is one-to-one and
+ * uses the same integer day-diff + greedy-nearest claim as the calendar loader, so a match and
+ * the calendar agree on which occurrence owns which transaction.
+ */
+final readonly class PlannedTransactionMatcher
+{
+    private const int LOOKBACK_DAYS = 45;
+
+    public function matchForUser(User $user): int
+    {
+        $tolerance = ReconciliationMatcher::DATE_TOLERANCE_DAYS;
+        $today = CarbonImmutable::today();
+        $windowStart = $today->subDays(self::LOOKBACK_DAYS);
+        $windowEnd = $today->addDays($tolerance);
+
+        $plans = PlannedTransaction::query()
+            ->where('user_id', $user->id)
+            ->where('is_active', true)
+            ->excludingTransfers()
+            ->orderBy('id')
+            ->get();
+
+        if ($plans->isEmpty()) {
+            return 0;
+        }
+
+        $planIds = $plans->modelKeys();
+        $postDateFrom = $windowStart->subDays($tolerance);
+
+        /** @var Collection<string, Collection<int, Transaction>> $unmatchedByGroup */
+        $unmatchedByGroup = Transaction::query()
+            ->where('user_id', $user->id)
+            ->current()
+            ->excludingTransfers()
+            ->whereNull('planned_transaction_id')
+            ->whereBetween('post_date', [$postDateFrom, $windowEnd])
+            ->get(['id', 'account_id', 'direction', 'amount', 'post_date'])
+            ->groupBy(fn (Transaction $t): string => $t->account_id.'|'.$t->direction->value);
+
+        /** @var Collection<int, Collection<int, Transaction>> $matchedByPlan */
+        $matchedByPlan = Transaction::query()
+            ->where('user_id', $user->id)
+            ->current()
+            ->excludingTransfers()
+            ->whereIn('planned_transaction_id', $planIds)
+            ->whereBetween('post_date', [$postDateFrom, $windowEnd])
+            ->get(['id', 'planned_transaction_id', 'post_date'])
+            ->groupBy('planned_transaction_id');
+
+        /** @var array<int, bool> $consumedIds */
+        $consumedIds = [];
+        $matched = 0;
+
+        foreach ($plans as $plan) {
+            $candidates = ($unmatchedByGroup->get($plan->account_id.'|'.$plan->direction->value) ?? collect())
+                ->filter(fn (Transaction $t): bool => abs((int) $t->amount) === (int) $plan->amount)
+                ->values();
+
+            $existing = ($matchedByPlan->get($plan->id) ?? collect())->values();
+
+            /** @var array<int, bool> $usedExistingIds */
+            $usedExistingIds = [];
+
+            foreach ($plan->occurrencesBetween($windowStart, $windowEnd) as $occurrence) {
+                if ($this->occurrenceAlreadyMatched($existing, $usedExistingIds, $occurrence, $tolerance)) {
+                    continue;
+                }
+
+                $candidate = $this->nearestCandidate($candidates, $consumedIds, $occurrence, $tolerance);
+
+                if ($candidate === null) {
+                    continue;
+                }
+
+                $affected = Transaction::query()
+                    ->whereKey($candidate->id)
+                    ->whereNull('planned_transaction_id')
+                    ->update(['planned_transaction_id' => $plan->id]);
+
+                if ($affected === 1) {
+                    $consumedIds[$candidate->id] = true;
+                    $matched++;
+                }
+            }
+        }
+
+        return $matched;
+    }
+
+    /**
+     * @param  Collection<int, Transaction>  $existing
+     * @param  array<int, bool>  $usedExistingIds
+     */
+    private function occurrenceAlreadyMatched(Collection $existing, array &$usedExistingIds, CarbonImmutable $occurrence, int $tolerance): bool
+    {
+        $nearestId = $this->nearestId($existing, $usedExistingIds, $occurrence, $tolerance);
+
+        if ($nearestId === null) {
+            return false;
+        }
+
+        $usedExistingIds[$nearestId] = true;
+
+        return true;
+    }
+
+    /**
+     * Single nearest unconsumed candidate within tolerance, or null when none match or two tie.
+     *
+     * @param  Collection<int, Transaction>  $candidates
+     * @param  array<int, bool>  $consumedIds
+     */
+    private function nearestCandidate(Collection $candidates, array $consumedIds, CarbonImmutable $occurrence, int $tolerance): ?Transaction
+    {
+        /** @var list<array{tx: Transaction, diff: int}> $inRange */
+        $inRange = [];
+
+        foreach ($candidates as $candidate) {
+            if (isset($consumedIds[$candidate->id])) {
+                continue;
+            }
+
+            $diff = (int) abs($candidate->post_date->diffInDays($occurrence));
+
+            if ($diff <= $tolerance) {
+                $inRange[] = ['tx' => $candidate, 'diff' => $diff];
+            }
+        }
+
+        if ($inRange === []) {
+            return null;
+        }
+
+        $minDiff = min(array_column($inRange, 'diff'));
+        $nearest = array_values(array_filter($inRange, static fn (array $row): bool => $row['diff'] === $minDiff));
+
+        if (count($nearest) > 1) {
+            return null;
+        }
+
+        return $nearest[0]['tx'];
+    }
+
+    /**
+     * @param  Collection<int, Transaction>  $transactions
+     * @param  array<int, bool>  $usedIds
+     */
+    private function nearestId(Collection $transactions, array $usedIds, CarbonImmutable $occurrence, int $tolerance): ?int
+    {
+        $nearestId = null;
+        $nearestDiff = null;
+
+        foreach ($transactions as $transaction) {
+            if (isset($usedIds[$transaction->id])) {
+                continue;
+            }
+
+            $diff = (int) abs($transaction->post_date->diffInDays($occurrence));
+
+            if ($diff <= $tolerance && ($nearestDiff === null || $diff < $nearestDiff)) {
+                $nearestDiff = $diff;
+                $nearestId = $transaction->id;
+            }
+        }
+
+        return $nearestId;
+    }
+}

--- a/app/Support/Calendar/DayActivityLoader.php
+++ b/app/Support/Calendar/DayActivityLoader.php
@@ -8,6 +8,7 @@ use App\Enums\TransactionDirection;
 use App\Livewire\Dashboard\Data\PayCyclePip;
 use App\Models\PlannedTransaction;
 use App\Models\Transaction;
+use App\Services\ReconciliationMatcher;
 use Carbon\CarbonImmutable;
 use Illuminate\Support\Collection;
 
@@ -19,9 +20,20 @@ final readonly class DayActivityLoader
         'category.parent.parent:id,icon,parent_id',
     ];
 
+    private const array LINKED_PLAN_EAGER_LOAD = [
+        'plannedTransaction:id,category_id,description',
+        'plannedTransaction.category:id,name,icon,parent_id',
+        'plannedTransaction.category.parent:id,icon,parent_id',
+        'plannedTransaction.category.parent.parent:id,icon,parent_id',
+    ];
+
     /**
      * Load posted transactions and planned-transaction occurrences for the given date range,
      * grouped by ISO date. Transfers are excluded. Pips per day are sorted by amount desc.
+     *
+     * A planned occurrence that has been reconciled to a posted transaction (matched within
+     * ReconciliationMatcher::DATE_TOLERANCE_DAYS) is suppressed: only the posted pip renders,
+     * relabelled with the reconciled plan's category name and icon.
      *
      * @return array<string, DayActivity>
      */
@@ -32,7 +44,7 @@ final readonly class DayActivityLoader
             ->current()
             ->excludingTransfers()
             ->whereBetween('post_date', [$start, $end])
-            ->with(self::CATEGORY_EAGER_LOAD)
+            ->with([...self::CATEGORY_EAGER_LOAD, ...self::LINKED_PLAN_EAGER_LOAD])
             ->orderBy('post_date')
             ->get();
 
@@ -48,11 +60,29 @@ final readonly class DayActivityLoader
         /** @var Collection<string, Collection<int, Transaction>> $txByDate */
         $txByDate = $transactions->groupBy(static fn (Transaction $t) => $t->post_date->format('Y-m-d'));
 
+        /** @var array<int, list<Transaction>> $reconciledByPlanned */
+        $reconciledByPlanned = [];
+
+        foreach ($transactions as $tx) {
+            if ($tx->planned_transaction_id !== null) {
+                $reconciledByPlanned[$tx->planned_transaction_id][] = $tx;
+            }
+        }
+
+        /** @var array<int, bool> $claimedTransactionIds */
+        $claimedTransactionIds = [];
+
         /** @var array<string, list<PayCyclePip>> $plannedPipsByDate */
         $plannedPipsByDate = [];
 
         foreach ($plannedTransactions as $planned) {
+            $candidates = $reconciledByPlanned[$planned->id] ?? [];
+
             foreach ($planned->occurrencesBetween($start, $end) as $occurrence) {
+                if ($this->claimReconciledTransaction($candidates, $claimedTransactionIds, $occurrence)) {
+                    continue;
+                }
+
                 $key = $occurrence->format('Y-m-d');
                 $plannedPipsByDate[$key] ??= [];
                 $plannedPipsByDate[$key][] = new PayCyclePip(
@@ -95,11 +125,21 @@ final readonly class DayActivityLoader
                     $postedCents += $absAmount;
                 }
 
+                $linkedPlan = $tx->plannedTransaction;
+
+                if ($linkedPlan !== null) {
+                    $name = $linkedPlan->category?->name ?? $linkedPlan->description; // @phpstan-ignore nullsafe.neverNull
+                    $icon = $linkedPlan->category?->resolveIcon();
+                } else {
+                    $name = $tx->category?->name ?? ($tx->description !== '' ? $tx->description : 'Transaction'); // @phpstan-ignore nullsafe.neverNull
+                    $icon = $tx->category?->resolveIcon();
+                }
+
                 $pips[] = new PayCyclePip(
                     kind: $isCredit ? 'inc' : 'out',
-                    name: $tx->category?->name ?? ($tx->description !== '' ? $tx->description : 'Transaction'), // @phpstan-ignore nullsafe.neverNull
+                    name: $name,
                     amount: $absAmount,
-                    icon: $tx->category?->resolveIcon(),
+                    icon: $icon,
                     transactionId: $tx->id,
                     plannedTransactionId: null,
                     occurrenceDate: null,
@@ -125,5 +165,44 @@ final readonly class DayActivityLoader
         }
 
         return $activity;
+    }
+
+    /**
+     * Greedily claim the nearest unclaimed reconciled transaction within the reconciliation
+     * date tolerance for the given occurrence. A claimed transaction is consumed so each
+     * posting suppresses at most one occurrence. Returns true when a claim is made.
+     *
+     * @param  list<Transaction>  $candidates
+     * @param  array<int, bool>  $claimedTransactionIds
+     */
+    private function claimReconciledTransaction(array $candidates, array &$claimedTransactionIds, CarbonImmutable $occurrence): bool
+    {
+        $nearestId = null;
+        $nearestDiff = null;
+
+        foreach ($candidates as $candidate) {
+            if (isset($claimedTransactionIds[$candidate->id])) {
+                continue;
+            }
+
+            $diff = (int) abs($candidate->post_date->diffInDays($occurrence));
+
+            if ($diff > ReconciliationMatcher::DATE_TOLERANCE_DAYS) {
+                continue;
+            }
+
+            if ($nearestDiff === null || $diff < $nearestDiff) {
+                $nearestDiff = $diff;
+                $nearestId = $candidate->id;
+            }
+        }
+
+        if ($nearestId === null) {
+            return false;
+        }
+
+        $claimedTransactionIds[$nearestId] = true;
+
+        return true;
     }
 }

--- a/app/Support/Calendar/DayActivityLoader.php
+++ b/app/Support/Calendar/DayActivityLoader.php
@@ -143,6 +143,7 @@ final readonly class DayActivityLoader
                     transactionId: $tx->id,
                     plannedTransactionId: null,
                     occurrenceDate: null,
+                    matched: $linkedPlan !== null,
                 );
             }
 

--- a/resources/views/components/cib/tx-row.blade.php
+++ b/resources/views/components/cib/tx-row.blade.php
@@ -9,6 +9,7 @@
     'amount',
     'tone' => 'out',
     'icon' => null,
+    'matched' => false,
 ])
 
 @php
@@ -30,7 +31,12 @@
             @endif
         </div>
         <div>
-            <div class="tx-name">{{ $name }}</div>
+            <div class="tx-name">
+                {{ $name }}
+                @if ($matched)
+                    <flux:badge size="sm" color="red" class="ml-1.5 align-middle">Planned</flux:badge>
+                @endif
+            </div>
             @isset($meta)
                 <div class="tx-meta">{{ $meta }}</div>
             @endisset
@@ -55,7 +61,12 @@
             @endif
         </div>
         <div>
-            <div class="tx-name">{{ $name }}</div>
+            <div class="tx-name">
+                {{ $name }}
+                @if ($matched)
+                    <flux:badge size="sm" color="red" class="ml-1.5 align-middle">Planned</flux:badge>
+                @endif
+            </div>
             @isset($meta)
                 <div class="tx-meta">{{ $meta }}</div>
             @endisset

--- a/resources/views/livewire/calendar-view.blade.php
+++ b/resources/views/livewire/calendar-view.blade.php
@@ -129,6 +129,7 @@
                             :amount="$pip->amount"
                             :tone="$rowTone"
                             :icon="$pip->icon"
+                            :matched="$pip->matched"
                     />
                 @empty
                     <p class="cyc-empty">Nothing on this day.</p>

--- a/resources/views/livewire/dashboard/pay-cycle-calendar.blade.php
+++ b/resources/views/livewire/dashboard/pay-cycle-calendar.blade.php
@@ -124,6 +124,7 @@
                                 :amount="$pip->amount"
                                 :tone="$rowTone"
                                 :icon="$pip->icon"
+                                :matched="$pip->matched"
                         />
                     @empty
                         <p class="cyc-empty">Nothing on this day.</p>

--- a/tests/Feature/Console/MatchPlannedTransactionsCommandTest.php
+++ b/tests/Feature/Console/MatchPlannedTransactionsCommandTest.php
@@ -1,0 +1,65 @@
+<?php
+
+/** @noinspection StaticClosureCanBeUsedInspection */
+
+declare(strict_types=1);
+
+use App\Enums\RecurrenceFrequency;
+use App\Enums\TransactionDirection;
+use App\Models\Account;
+use App\Models\PlannedTransaction;
+use App\Models\Transaction;
+use App\Models\User;
+use Carbon\CarbonImmutable;
+
+beforeEach(function () {
+    $this->travelTo(CarbonImmutable::create(2026, 6, 15));
+});
+
+function seedMatchableRent(): Transaction
+{
+    $user = User::factory()->create(['id' => 4242]);
+    $account = Account::factory()->for($user)->create();
+
+    PlannedTransaction::factory()->for($user)->create([
+        'account_id' => $account->id,
+        'amount' => 50000,
+        'direction' => TransactionDirection::Debit,
+        'frequency' => RecurrenceFrequency::DontRepeat,
+        'start_date' => '2026-06-10',
+        'is_active' => true,
+    ]);
+
+    return Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'amount' => -50000,
+        'post_date' => '2026-06-10',
+        'planned_transaction_id' => null,
+    ]);
+}
+
+test('matches a single user by id and reports the count', function () {
+    $tx = seedMatchableRent();
+
+    $this->artisan('app:match-planned-transactions', ['--user' => 4242])
+        ->expectsOutputToContain('Matched 1 transaction(s).')
+        ->assertSuccessful();
+
+    expect($tx->fresh()->planned_transaction_id)->not->toBeNull();
+});
+
+test('fails when the user id does not exist', function () {
+    $this->artisan('app:match-planned-transactions', ['--user' => 999999])
+        ->assertFailed();
+});
+
+test('processes all users with active plans when no id is given and is idempotent', function () {
+    $tx = seedMatchableRent();
+
+    $this->artisan('app:match-planned-transactions')->assertSuccessful();
+    $this->artisan('app:match-planned-transactions')
+        ->expectsOutputToContain('Matched 0 transaction(s).')
+        ->assertSuccessful();
+
+    expect($tx->fresh()->planned_transaction_id)->not->toBeNull();
+});

--- a/tests/Feature/Services/PipelineStages/MatchPlannedTransactionsStageTest.php
+++ b/tests/Feature/Services/PipelineStages/MatchPlannedTransactionsStageTest.php
@@ -1,0 +1,55 @@
+<?php
+
+/** @noinspection StaticClosureCanBeUsedInspection */
+
+declare(strict_types=1);
+
+use App\DTOs\PipelineContext;
+use App\Enums\RecurrenceFrequency;
+use App\Enums\TransactionDirection;
+use App\Models\Account;
+use App\Models\PipelineRun;
+use App\Models\PlannedTransaction;
+use App\Models\Transaction;
+use App\Models\User;
+use App\Services\PipelineStages\MatchPlannedTransactionsStage;
+use Carbon\CarbonImmutable;
+
+beforeEach(function () {
+    $this->travelTo(CarbonImmutable::create(2026, 6, 15));
+    $this->user = User::factory()->create();
+    $this->account = Account::factory()->for($this->user)->create();
+    $this->pipelineRun = PipelineRun::factory()->for($this->user)->create();
+    $this->context = new PipelineContext(user: $this->user, pipelineRun: $this->pipelineRun, isFirstSync: false);
+    $this->stage = app(MatchPlannedTransactionsStage::class);
+});
+
+test('exposes its contract metadata', function () {
+    expect($this->stage->key())->toBe('match-planned-transactions')
+        ->and($this->stage->label())->toBeString()
+        ->and($this->stage->shouldRun($this->context))->toBeTrue();
+});
+
+test('tags a matching transaction and returns a successful result', function () {
+    $plan = PlannedTransaction::factory()->for($this->user)->create([
+        'account_id' => $this->account->id,
+        'amount' => 50000,
+        'direction' => TransactionDirection::Debit,
+        'frequency' => RecurrenceFrequency::DontRepeat,
+        'start_date' => '2026-06-10',
+        'is_active' => true,
+    ]);
+
+    $tx = Transaction::factory()->for($this->user)->debit()->create([
+        'account_id' => $this->account->id,
+        'amount' => -50000,
+        'post_date' => '2026-06-10',
+        'planned_transaction_id' => null,
+    ]);
+
+    $result = $this->stage->execute($this->context);
+
+    expect($result->success)->toBeTrue()
+        ->and($result->stage)->toBe('match-planned-transactions')
+        ->and($tx->fresh()->planned_transaction_id)->toBe($plan->id);
+});

--- a/tests/Feature/Services/PlannedTransactionMatcherTest.php
+++ b/tests/Feature/Services/PlannedTransactionMatcherTest.php
@@ -1,0 +1,235 @@
+<?php
+
+/** @noinspection StaticClosureCanBeUsedInspection */
+
+declare(strict_types=1);
+
+use App\Enums\RecurrenceFrequency;
+use App\Enums\TransactionDirection;
+use App\Models\Account;
+use App\Models\PlannedTransaction;
+use App\Models\Transaction;
+use App\Models\User;
+use App\Services\PlannedTransactionMatcher;
+use App\Services\ReconciliationMatcher;
+use Carbon\CarbonImmutable;
+
+beforeEach(function () {
+    $this->travelTo(CarbonImmutable::create(2026, 6, 15));
+    $this->matcher = app(PlannedTransactionMatcher::class);
+    $this->user = User::factory()->create();
+    $this->account = Account::factory()->for($this->user)->create();
+});
+
+function activeRentPlan(User $user, Account $account, string $startDate = '2026-06-10'): PlannedTransaction
+{
+    return PlannedTransaction::factory()->for($user)->create([
+        'account_id' => $account->id,
+        'amount' => 50000,
+        'direction' => TransactionDirection::Debit,
+        'frequency' => RecurrenceFrequency::DontRepeat,
+        'start_date' => $startDate,
+        'is_active' => true,
+    ]);
+}
+
+test('matches an unmatched transaction on the same day as a plan occurrence', function () {
+    $plan = activeRentPlan($this->user, $this->account);
+
+    $tx = Transaction::factory()->for($this->user)->debit()->create([
+        'account_id' => $this->account->id,
+        'amount' => -50000,
+        'post_date' => '2026-06-10',
+        'planned_transaction_id' => null,
+    ]);
+
+    expect($this->matcher->matchForUser($this->user))->toBe(1)
+        ->and($tx->fresh()->planned_transaction_id)->toBe($plan->id);
+});
+
+test('matches within the date tolerance', function () {
+    $plan = activeRentPlan($this->user, $this->account);
+
+    $tx = Transaction::factory()->for($this->user)->debit()->create([
+        'account_id' => $this->account->id,
+        'amount' => -50000,
+        'post_date' => CarbonImmutable::create(2026, 6, 10)->addDays(ReconciliationMatcher::DATE_TOLERANCE_DAYS)->toDateString(),
+        'planned_transaction_id' => null,
+    ]);
+
+    expect($this->matcher->matchForUser($this->user))->toBe(1)
+        ->and($tx->fresh()->planned_transaction_id)->toBe($plan->id);
+});
+
+test('does not match outside the date tolerance', function () {
+    activeRentPlan($this->user, $this->account);
+
+    $tx = Transaction::factory()->for($this->user)->debit()->create([
+        'account_id' => $this->account->id,
+        'amount' => -50000,
+        'post_date' => CarbonImmutable::create(2026, 6, 10)->addDays(ReconciliationMatcher::DATE_TOLERANCE_DAYS + 1)->toDateString(),
+        'planned_transaction_id' => null,
+    ]);
+
+    expect($this->matcher->matchForUser($this->user))->toBe(0)
+        ->and($tx->fresh()->planned_transaction_id)->toBeNull();
+});
+
+test('requires an exact amount (stricter than the human ±10% matcher)', function () {
+    activeRentPlan($this->user, $this->account);
+
+    $tx = Transaction::factory()->for($this->user)->debit()->create([
+        'account_id' => $this->account->id,
+        'amount' => -47500,
+        'post_date' => '2026-06-10',
+        'planned_transaction_id' => null,
+    ]);
+
+    expect($this->matcher->matchForUser($this->user))->toBe(0)
+        ->and($tx->fresh()->planned_transaction_id)->toBeNull();
+});
+
+test('does not match a transaction on a different account', function () {
+    activeRentPlan($this->user, $this->account);
+    $other = Account::factory()->for($this->user)->create();
+
+    $tx = Transaction::factory()->for($this->user)->debit()->create([
+        'account_id' => $other->id,
+        'amount' => -50000,
+        'post_date' => '2026-06-10',
+        'planned_transaction_id' => null,
+    ]);
+
+    expect($this->matcher->matchForUser($this->user))->toBe(0)
+        ->and($tx->fresh()->planned_transaction_id)->toBeNull();
+});
+
+test('does not match the wrong direction', function () {
+    activeRentPlan($this->user, $this->account);
+
+    $tx = Transaction::factory()->for($this->user)->credit()->create([
+        'account_id' => $this->account->id,
+        'amount' => 50000,
+        'post_date' => '2026-06-10',
+        'planned_transaction_id' => null,
+    ]);
+
+    expect($this->matcher->matchForUser($this->user))->toBe(0)
+        ->and($tx->fresh()->planned_transaction_id)->toBeNull();
+});
+
+test('never matches a transfer leg', function () {
+    activeRentPlan($this->user, $this->account);
+
+    $pair = Transaction::factory()->for($this->user)->debit()->create([
+        'account_id' => $this->account->id,
+        'amount' => -50000,
+        'post_date' => '2026-06-10',
+    ]);
+
+    $transfer = Transaction::factory()->for($this->user)->debit()->create([
+        'account_id' => $this->account->id,
+        'amount' => -50000,
+        'post_date' => '2026-06-10',
+        'transfer_pair_id' => $pair->id,
+        'planned_transaction_id' => null,
+    ]);
+
+    $this->matcher->matchForUser($this->user);
+
+    expect($transfer->fresh()->planned_transaction_id)->toBeNull();
+});
+
+test('does not match an inactive plan', function () {
+    PlannedTransaction::factory()->for($this->user)->inactive()->create([
+        'account_id' => $this->account->id,
+        'amount' => 50000,
+        'direction' => TransactionDirection::Debit,
+        'frequency' => RecurrenceFrequency::DontRepeat,
+        'start_date' => '2026-06-10',
+    ]);
+
+    $tx = Transaction::factory()->for($this->user)->debit()->create([
+        'account_id' => $this->account->id,
+        'amount' => -50000,
+        'post_date' => '2026-06-10',
+        'planned_transaction_id' => null,
+    ]);
+
+    expect($this->matcher->matchForUser($this->user))->toBe(0)
+        ->and($tx->fresh()->planned_transaction_id)->toBeNull();
+});
+
+test('is idempotent: a second run links nothing new and leaves existing links intact', function () {
+    $plan = activeRentPlan($this->user, $this->account, '2026-06-05');
+    $plan->update(['frequency' => RecurrenceFrequency::EveryWeek]);
+
+    $alreadyMatched = Transaction::factory()->for($this->user)->debit()->create([
+        'account_id' => $this->account->id,
+        'amount' => -50000,
+        'post_date' => '2026-06-05',
+        'planned_transaction_id' => $plan->id,
+    ]);
+
+    $fresh = Transaction::factory()->for($this->user)->debit()->create([
+        'account_id' => $this->account->id,
+        'amount' => -50000,
+        'post_date' => '2026-06-12',
+        'planned_transaction_id' => null,
+    ]);
+
+    expect($this->matcher->matchForUser($this->user))->toBe(1)
+        ->and($this->matcher->matchForUser($this->user))->toBe(0)
+        ->and($alreadyMatched->fresh()->planned_transaction_id)->toBe($plan->id)
+        ->and($fresh->fresh()->planned_transaction_id)->toBe($plan->id);
+});
+
+test('skips ambiguous matches when two transactions tie for nearest', function () {
+    activeRentPlan($this->user, $this->account);
+
+    $a = Transaction::factory()->for($this->user)->debit()->create([
+        'account_id' => $this->account->id,
+        'amount' => -50000,
+        'post_date' => '2026-06-09',
+        'planned_transaction_id' => null,
+    ]);
+    $b = Transaction::factory()->for($this->user)->debit()->create([
+        'account_id' => $this->account->id,
+        'amount' => -50000,
+        'post_date' => '2026-06-11',
+        'planned_transaction_id' => null,
+    ]);
+
+    expect($this->matcher->matchForUser($this->user))->toBe(0)
+        ->and($a->fresh()->planned_transaction_id)->toBeNull()
+        ->and($b->fresh()->planned_transaction_id)->toBeNull();
+});
+
+test('never links one transaction to two plans', function () {
+    $planA = activeRentPlan($this->user, $this->account);
+    $planB = activeRentPlan($this->user, $this->account);
+
+    $tx = Transaction::factory()->for($this->user)->debit()->create([
+        'account_id' => $this->account->id,
+        'amount' => -50000,
+        'post_date' => '2026-06-10',
+        'planned_transaction_id' => null,
+    ]);
+
+    expect($this->matcher->matchForUser($this->user))->toBe(1)
+        ->and($tx->fresh()->planned_transaction_id)->toBe(min($planA->id, $planB->id));
+});
+
+test('does not reach back past the lookback window', function () {
+    activeRentPlan($this->user, $this->account, '2026-04-20');
+
+    $tx = Transaction::factory()->for($this->user)->debit()->create([
+        'account_id' => $this->account->id,
+        'amount' => -50000,
+        'post_date' => '2026-04-20',
+        'planned_transaction_id' => null,
+    ]);
+
+    expect($this->matcher->matchForUser($this->user))->toBe(0)
+        ->and($tx->fresh()->planned_transaction_id)->toBeNull();
+});

--- a/tests/Feature/Support/Calendar/DayActivityLoaderTest.php
+++ b/tests/Feature/Support/Calendar/DayActivityLoaderTest.php
@@ -10,6 +10,7 @@ use App\Models\Category;
 use App\Models\PlannedTransaction;
 use App\Models\Transaction;
 use App\Models\User;
+use App\Services\ReconciliationMatcher;
 use App\Support\Calendar\DayActivity;
 use App\Support\Calendar\DayActivityLoader;
 use Carbon\CarbonImmutable;
@@ -277,6 +278,438 @@ test('actual and planned on same day appear together with correct tallies', func
         ->and($day->incomeCents)->toBe(8000)
         ->and($day->postedCents)->toBe(3000)
         ->and($day->plannedCents)->toBe(5000);
+});
+
+// ── reconciled-occurrence suppression ────────────────────────────
+
+test('reconciled debit suppresses the planned pip and relabels the posted pip with the plan category', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $category = Category::factory()->create(['name' => 'Rent', 'icon' => 'home']);
+    $date = CarbonImmutable::create(2026, 6, 14);
+
+    $planned = PlannedTransaction::factory()->for($user)->for($account)->noRepeat()->create([
+        'category_id' => $category->id,
+        'amount' => 77000,
+        'direction' => TransactionDirection::Debit,
+        'start_date' => $date,
+    ]);
+
+    Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'amount' => -77000,
+        'post_date' => $date,
+        'description' => 'Ext Tfr - NET#4789778169 Sekisui House',
+        'planned_transaction_id' => $planned->id,
+    ]);
+
+    $activity = (new DayActivityLoader)->load(
+        CarbonImmutable::create(2026, 6, 1),
+        CarbonImmutable::create(2026, 6, 30),
+        $user->id,
+    );
+    $day = $activity[$date->format('Y-m-d')];
+
+    expect($day->pips)->toHaveCount(1)
+        ->and($day->pips[0]->kind)->toBe('out')
+        ->and($day->pips[0]->transactionId)->not->toBeNull()
+        ->and($day->pips[0]->name)->toBe('Rent')
+        ->and($day->pips[0]->icon)->toBe('home')
+        ->and($day->postedCents)->toBe(77000)
+        ->and($day->plannedCents)->toBe(0);
+});
+
+test('reconciled income credit suppresses the planned income pip', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $category = Category::factory()->create(['name' => 'Salary', 'icon' => 'banknotes']);
+    $date = CarbonImmutable::create(2026, 6, 15);
+
+    $planned = PlannedTransaction::factory()->for($user)->for($account)->noRepeat()->create([
+        'category_id' => $category->id,
+        'amount' => 500000,
+        'direction' => TransactionDirection::Credit,
+        'start_date' => $date,
+    ]);
+
+    Transaction::factory()->for($user)->credit()->create([
+        'account_id' => $account->id,
+        'amount' => 500000,
+        'post_date' => $date,
+        'planned_transaction_id' => $planned->id,
+    ]);
+
+    $day = (new DayActivityLoader)->load(
+        CarbonImmutable::create(2026, 6, 1),
+        CarbonImmutable::create(2026, 6, 30),
+        $user->id,
+    )[$date->format('Y-m-d')];
+
+    expect($day->pips)->toHaveCount(1)
+        ->and($day->pips[0]->kind)->toBe('inc')
+        ->and($day->pips[0]->name)->toBe('Salary')
+        ->and($day->incomeCents)->toBe(500000)
+        ->and($day->plannedCents)->toBe(0);
+});
+
+test('monthly recurring planned keeps unreconciled occurrences when one is reconciled', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $start = CarbonImmutable::create(2026, 6, 5);
+
+    $planned = PlannedTransaction::factory()->for($user)->for($account)->monthly()->create([
+        'amount' => 30000,
+        'direction' => TransactionDirection::Debit,
+        'start_date' => $start,
+    ]);
+
+    Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'amount' => -30000,
+        'post_date' => $start,
+        'planned_transaction_id' => $planned->id,
+    ]);
+
+    $activity = (new DayActivityLoader)->load(
+        CarbonImmutable::create(2026, 6, 1),
+        CarbonImmutable::create(2026, 8, 31),
+        $user->id,
+    );
+
+    expect($activity['2026-06-05']->pips)->toHaveCount(1)
+        ->and($activity['2026-06-05']->pips[0]->kind)->toBe('out')
+        ->and($activity['2026-06-05']->plannedCents)->toBe(0)
+        ->and($activity['2026-07-05']->pips)->toHaveCount(1)
+        ->and($activity['2026-07-05']->pips[0]->kind)->toBe('plan')
+        ->and($activity['2026-07-05']->plannedCents)->toBe(30000)
+        ->and($activity['2026-08-05']->pips[0]->kind)->toBe('plan');
+});
+
+test('reconciled posting outside the date tolerance does not suppress the planned pip', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $category = Category::factory()->create(['name' => 'Rent']);
+    $occurrence = CarbonImmutable::create(2026, 6, 14);
+
+    $planned = PlannedTransaction::factory()->for($user)->for($account)->noRepeat()->create([
+        'category_id' => $category->id,
+        'amount' => 20000,
+        'direction' => TransactionDirection::Debit,
+        'start_date' => $occurrence,
+    ]);
+
+    $postDate = $occurrence->addDays(ReconciliationMatcher::DATE_TOLERANCE_DAYS + 1);
+
+    Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'amount' => -20000,
+        'post_date' => $postDate,
+        'description' => 'Ext Tfr noisy bank text',
+        'planned_transaction_id' => $planned->id,
+    ]);
+
+    $activity = (new DayActivityLoader)->load(
+        CarbonImmutable::create(2026, 6, 1),
+        CarbonImmutable::create(2026, 6, 30),
+        $user->id,
+    );
+
+    expect($activity['2026-06-14']->pips)->toHaveCount(1)
+        ->and($activity['2026-06-14']->pips[0]->kind)->toBe('plan')
+        ->and($activity['2026-06-14']->pips[0]->name)->toBe('Rent')
+        ->and($activity['2026-06-14']->plannedCents)->toBe(20000)
+        ->and($activity[$postDate->format('Y-m-d')]->pips)->toHaveCount(1)
+        ->and($activity[$postDate->format('Y-m-d')]->pips[0]->kind)->toBe('out')
+        ->and($activity[$postDate->format('Y-m-d')]->pips[0]->name)->toBe('Rent');
+});
+
+test('reconciled posting exactly on the tolerance boundary suppresses the planned pip', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $category = Category::factory()->create(['name' => 'Rent', 'icon' => 'home']);
+    $occurrence = CarbonImmutable::create(2026, 6, 14);
+
+    $planned = PlannedTransaction::factory()->for($user)->for($account)->noRepeat()->create([
+        'category_id' => $category->id,
+        'amount' => 20000,
+        'direction' => TransactionDirection::Debit,
+        'start_date' => $occurrence,
+    ]);
+
+    $postDate = $occurrence->addDays(ReconciliationMatcher::DATE_TOLERANCE_DAYS);
+
+    Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'amount' => -20000,
+        'post_date' => $postDate,
+        'description' => 'Ext Tfr noisy bank text',
+        'planned_transaction_id' => $planned->id,
+    ]);
+
+    $activity = (new DayActivityLoader)->load(
+        CarbonImmutable::create(2026, 6, 1),
+        CarbonImmutable::create(2026, 6, 30),
+        $user->id,
+    );
+
+    expect($activity)->not->toHaveKey('2026-06-14')
+        ->and($activity[$postDate->format('Y-m-d')]->pips)->toHaveCount(1)
+        ->and($activity[$postDate->format('Y-m-d')]->pips[0]->kind)->toBe('out')
+        ->and($activity[$postDate->format('Y-m-d')]->pips[0]->name)->toBe('Rent')
+        ->and($activity[$postDate->format('Y-m-d')]->pips[0]->icon)->toBe('home');
+});
+
+test('two close occurrences with one reconciled posting suppress only the nearest occurrence', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+
+    $planned = PlannedTransaction::factory()->for($user)->for($account)->weekly()->create([
+        'amount' => 10000,
+        'direction' => TransactionDirection::Debit,
+        'start_date' => CarbonImmutable::create(2026, 6, 8),
+    ]);
+
+    Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'amount' => -10000,
+        'post_date' => CarbonImmutable::create(2026, 6, 9),
+        'planned_transaction_id' => $planned->id,
+    ]);
+
+    $activity = (new DayActivityLoader)->load(
+        CarbonImmutable::create(2026, 6, 1),
+        CarbonImmutable::create(2026, 6, 20),
+        $user->id,
+    );
+
+    expect($activity)->not->toHaveKey('2026-06-08')
+        ->and($activity['2026-06-09']->pips[0]->kind)->toBe('out')
+        ->and($activity['2026-06-15']->pips)->toHaveCount(1)
+        ->and($activity['2026-06-15']->pips[0]->kind)->toBe('plan')
+        ->and($activity['2026-06-15']->plannedCents)->toBe(10000);
+});
+
+test('superseded child reconciled transaction suppresses the occurrence once', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $date = CarbonImmutable::create(2026, 6, 14);
+
+    $planned = PlannedTransaction::factory()->for($user)->for($account)->noRepeat()->create([
+        'amount' => 45000,
+        'direction' => TransactionDirection::Debit,
+        'start_date' => $date,
+    ]);
+
+    $parent = Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'amount' => -45000,
+        'post_date' => $date,
+        'planned_transaction_id' => $planned->id,
+    ]);
+    $child = $parent->createChild(['amount' => -45000]);
+
+    expect(Transaction::query()->current()->where('planned_transaction_id', $planned->id)->pluck('id')->all())
+        ->toBe([$child->id]);
+
+    $day = (new DayActivityLoader)->load(
+        CarbonImmutable::create(2026, 6, 1),
+        CarbonImmutable::create(2026, 6, 30),
+        $user->id,
+    )[$date->format('Y-m-d')];
+
+    expect($day->pips)->toHaveCount(1)
+        ->and($day->pips[0]->kind)->toBe('out')
+        ->and($day->pips[0]->transactionId)->toBe($child->id)
+        ->and($day->postedCents)->toBe(45000)
+        ->and($day->plannedCents)->toBe(0);
+});
+
+test('un-reconciled child shows both the posted and the planned pip', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $category = Category::factory()->create(['name' => 'Rent']);
+    $date = CarbonImmutable::create(2026, 6, 14);
+
+    $planned = PlannedTransaction::factory()->for($user)->for($account)->noRepeat()->create([
+        'category_id' => $category->id,
+        'amount' => 45000,
+        'direction' => TransactionDirection::Debit,
+        'start_date' => $date,
+    ]);
+
+    $parent = Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'amount' => -45000,
+        'post_date' => $date,
+        'planned_transaction_id' => $planned->id,
+    ]);
+    $parent->createChild(['planned_transaction_id' => null]);
+
+    expect(Transaction::query()->current()->where('user_id', $user->id)->pluck('planned_transaction_id')->all())
+        ->toBe([null]);
+
+    $day = (new DayActivityLoader)->load(
+        CarbonImmutable::create(2026, 6, 1),
+        CarbonImmutable::create(2026, 6, 30),
+        $user->id,
+    )[$date->format('Y-m-d')];
+
+    expect($day->pips)->toHaveCount(2)
+        ->and(collect($day->pips)->pluck('kind')->all())->toContain('plan')
+        ->and(collect($day->pips)->pluck('kind')->all())->toContain('out')
+        ->and($day->plannedCents)->toBe(45000)
+        ->and($day->postedCents)->toBe(45000);
+});
+
+test('planned reconciled then deactivated leaves only the posted pip', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $category = Category::factory()->create(['name' => 'Rent', 'icon' => 'home']);
+    $date = CarbonImmutable::create(2026, 6, 14);
+
+    $planned = PlannedTransaction::factory()->for($user)->for($account)->noRepeat()->create([
+        'category_id' => $category->id,
+        'amount' => 45000,
+        'direction' => TransactionDirection::Debit,
+        'start_date' => $date,
+    ]);
+
+    Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'amount' => -45000,
+        'post_date' => $date,
+        'planned_transaction_id' => $planned->id,
+    ]);
+
+    $planned->update(['is_active' => false]);
+
+    $day = (new DayActivityLoader)->load(
+        CarbonImmutable::create(2026, 6, 1),
+        CarbonImmutable::create(2026, 6, 30),
+        $user->id,
+    )[$date->format('Y-m-d')];
+
+    expect($day->pips)->toHaveCount(1)
+        ->and($day->pips[0]->kind)->toBe('out')
+        ->and($day->pips[0]->name)->toBe('Rent')
+        ->and($day->plannedCents)->toBe(0);
+});
+
+test('two plans on the same day suppress only the reconciled one', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $rent = Category::factory()->create(['name' => 'Rent']);
+    $power = Category::factory()->create(['name' => 'Power']);
+    $date = CarbonImmutable::create(2026, 6, 14);
+
+    $reconciledPlan = PlannedTransaction::factory()->for($user)->for($account)->noRepeat()->create([
+        'category_id' => $rent->id,
+        'amount' => 45000,
+        'direction' => TransactionDirection::Debit,
+        'start_date' => $date,
+    ]);
+    PlannedTransaction::factory()->for($user)->for($account)->noRepeat()->create([
+        'category_id' => $power->id,
+        'amount' => 12000,
+        'direction' => TransactionDirection::Debit,
+        'start_date' => $date,
+    ]);
+
+    Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'amount' => -45000,
+        'post_date' => $date,
+        'planned_transaction_id' => $reconciledPlan->id,
+    ]);
+
+    $day = (new DayActivityLoader)->load(
+        CarbonImmutable::create(2026, 6, 1),
+        CarbonImmutable::create(2026, 6, 30),
+        $user->id,
+    )[$date->format('Y-m-d')];
+
+    $planPips = collect($day->pips)->where('kind', 'plan')->values();
+
+    expect($day->pips)->toHaveCount(2)
+        ->and($planPips)->toHaveCount(1)
+        ->and($planPips[0]->name)->toBe('Power')
+        ->and($day->plannedCents)->toBe(12000)
+        ->and($day->postedCents)->toBe(45000);
+});
+
+test('a posting linked to a different plan does not suppress an unrelated occurrence', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $date = CarbonImmutable::create(2026, 6, 14);
+
+    $visiblePlan = PlannedTransaction::factory()->for($user)->for($account)->noRepeat()->create([
+        'amount' => 30000,
+        'direction' => TransactionDirection::Debit,
+        'start_date' => $date,
+    ]);
+
+    $otherPlan = PlannedTransaction::factory()->for($user)->for($account)->noRepeat()->create([
+        'amount' => 9000,
+        'direction' => TransactionDirection::Debit,
+        'start_date' => $date,
+    ]);
+
+    Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'amount' => -9000,
+        'post_date' => $date,
+        'planned_transaction_id' => $otherPlan->id,
+    ]);
+
+    $day = (new DayActivityLoader)->load(
+        CarbonImmutable::create(2026, 6, 1),
+        CarbonImmutable::create(2026, 6, 30),
+        $user->id,
+    )[$date->format('Y-m-d')];
+
+    $planPips = collect($day->pips)->where('kind', 'plan')->values();
+
+    expect($day->pips)->toHaveCount(2)
+        ->and($planPips)->toHaveCount(1)
+        ->and($planPips[0]->plannedTransactionId)->toBe($visiblePlan->id)
+        ->and($day->plannedCents)->toBe(30000)
+        ->and($day->postedCents)->toBe(9000);
+});
+
+test('plannedCents excludes a suppressed occurrence but keeps unreconciled occurrences', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $reconciledDate = CarbonImmutable::create(2026, 6, 10);
+    $freeDate = CarbonImmutable::create(2026, 6, 20);
+
+    $reconciledPlan = PlannedTransaction::factory()->for($user)->for($account)->noRepeat()->create([
+        'amount' => 60000,
+        'direction' => TransactionDirection::Debit,
+        'start_date' => $reconciledDate,
+    ]);
+    PlannedTransaction::factory()->for($user)->for($account)->noRepeat()->create([
+        'amount' => 15000,
+        'direction' => TransactionDirection::Debit,
+        'start_date' => $freeDate,
+    ]);
+
+    Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'amount' => -60000,
+        'post_date' => $reconciledDate,
+        'planned_transaction_id' => $reconciledPlan->id,
+    ]);
+
+    $activity = (new DayActivityLoader)->load(
+        CarbonImmutable::create(2026, 6, 1),
+        CarbonImmutable::create(2026, 6, 30),
+        $user->id,
+    );
+
+    expect($activity['2026-06-10']->plannedCents)->toBe(0)
+        ->and($activity['2026-06-10']->postedCents)->toBe(60000)
+        ->and($activity['2026-06-20']->plannedCents)->toBe(15000)
+        ->and($activity['2026-06-20']->pips[0]->kind)->toBe('plan');
 });
 
 test('DayActivity::empty returns a zero-state instance', function () {

--- a/tests/Feature/Support/Calendar/DayActivityLoaderTest.php
+++ b/tests/Feature/Support/Calendar/DayActivityLoaderTest.php
@@ -315,8 +315,32 @@ test('reconciled debit suppresses the planned pip and relabels the posted pip wi
         ->and($day->pips[0]->transactionId)->not->toBeNull()
         ->and($day->pips[0]->name)->toBe('Rent')
         ->and($day->pips[0]->icon)->toBe('home')
+        ->and($day->pips[0]->matched)->toBeTrue()
         ->and($day->postedCents)->toBe(77000)
         ->and($day->plannedCents)->toBe(0);
+});
+
+test('an unmatched posted transaction is not flagged as matched', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $date = CarbonImmutable::create(2026, 6, 14);
+
+    Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'amount' => -4200,
+        'post_date' => $date,
+        'planned_transaction_id' => null,
+    ]);
+
+    $day = (new DayActivityLoader)->load(
+        CarbonImmutable::create(2026, 6, 1),
+        CarbonImmutable::create(2026, 6, 30),
+        $user->id,
+    )[$date->format('Y-m-d')];
+
+    expect($day->pips)->toHaveCount(1)
+        ->and($day->pips[0]->kind)->toBe('out')
+        ->and($day->pips[0]->matched)->toBeFalse();
 });
 
 test('reconciled income credit suppresses the planned income pip', function () {


### PR DESCRIPTION
## Summary

Fixes #246 — the calendar showed a planned item **and** its imported transaction as **two
entries on the same day** (e.g. a yellow "Rent" forecast *and* the posted "Ext Tfr … Sekisui
House", both $770).

The root cause was two-fold: (1) nothing **matched** an imported transaction back to the
planned item it fulfilled after the plan already existed, and (2) the calendar rendered the
forecast and the transaction as independent pips.

## What changed

**1. Match at import** — `MatchPlannedTransactionsStage` (new, runs last in the
`TransactionAnalysisPipeline` on every sync/CSV import) tags each transaction to the active
planned item it fulfils, via the new `PlannedTransactionMatcher`. A match needs the **same
account + direction, an EXACT amount, and a post_date within
`ReconciliationMatcher::DATE_TOLERANCE_DAYS` (3)** of a plan occurrence. It reuses the existing
`planned_transaction_id` field, is one-to-one, idempotent, excludes transfers, and skips
ambiguous ties. Tolerances are deliberately tighter than the manual reconcile's ±10% because
these are silent writes with no human confirmation.

**2. Single, tagged calendar entry** — when a transaction is matched, the calendar suppresses
the duplicate forecast pip and renders **one** entry: the transaction with the plan's friendly
category name + icon and a red **"Planned"** tag (`<flux:badge>`). Unmatched planned occurrences
stay highlighted (yellow forecast); standalone transactions are unchanged. Fixes both
`/calendar` and the dashboard `PayCycleCalendar` (shared `DayActivityLoader`).

**3. Backfill command** — `app:match-planned-transactions {--user=}` applies the same matching
to data imported **before** this feature existed (new imports match automatically).

## Display states

| State | Looks like |
|---|---|
| Planned, not yet imported | Yellow highlighted forecast |
| Imported + matched to a plan | Black name + category icon + red **"Planned"** tag (one entry) |
| Standalone transaction | Red (spend) / green (income) |

## Tests

- `PlannedTransactionMatcherTest` — exact-amount, ±3-day boundary, wrong account/direction,
  transfer exclusion, inactive plans, idempotency, ambiguity skip, one-actual-one-plan, window bound (12 cases)
- `MatchPlannedTransactionsStageTest` — contract + delegation (2)
- `MatchPlannedTransactionsCommandTest` — per-user, missing user, all-users idempotent (3)
- `DayActivityLoaderTest` — dedup + relabel + `matched` flag (existing + new)
- Full suite: **1617 passed, 4 skipped**. Pint + PHPStan (`op analyse`) clean.

## Verified on a real account

Reproduced and fixed on the reporter's data: **29 May** went from two rows
(`Ext Tfr … Sekisui House` $770 + `Rent` $770) to a single **`🏠 Rent · Planned · $770.00`**
after running the matcher (`app:match-planned-transactions --user=10` → 12 transactions tagged).

## Notes

- Every auto-match is reversible via the existing Reconciliation modal (unlink).
- `MonthlyProjectionService` (12-month dashboard chart) is a separate forward-only code path; its
  reconciled-occurrence handling is out of scope here and can be a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
