### PR TITLE
fix(#249): detect primary account, pay cycle & recurring items from CSV imports

### DIFF
--- a/app/DTOs/IncomePattern.php
+++ b/app/DTOs/IncomePattern.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTOs;
+
+use App\Enums\PayFrequency;
+use Carbon\CarbonImmutable;
+use Spatie\LaravelData\Dto;
+
+final class IncomePattern extends Dto
+{
+    /**
+     * @param  list<int>  $transactionIds
+     * @param  list<string>  $detectedDates
+     */
+    public function __construct(
+        public readonly PayFrequency $frequency,
+        public readonly int $amount,
+        public readonly string $description,
+        public readonly array $transactionIds,
+        public readonly array $detectedDates,
+        public readonly CarbonImmutable $mostRecentDate,
+        public readonly float $confidence,
+    ) {}
+}

--- a/app/Enums/TransactionSource.php
+++ b/app/Enums/TransactionSource.php
@@ -11,6 +11,18 @@ enum TransactionSource: string
     case Planned = 'planned';
     case Csv = 'csv';
 
+    /**
+     * Bank-statement sources eligible for pattern analysis (primary account,
+     * pay cycle, recurring detection). Excludes Manual (user-entered one-offs)
+     * and Planned (synthetic), which would add noise or be circular.
+     *
+     * @return list<self>
+     */
+    public static function forAnalysis(): array
+    {
+        return [self::Basiq, self::Csv];
+    }
+
     public function label(): string
     {
         return match ($this) {

--- a/app/Livewire/AnalysisSuggestions.php
+++ b/app/Livewire/AnalysisSuggestions.php
@@ -9,12 +9,12 @@ use App\Enums\SuggestionStatus;
 use App\Enums\SuggestionType;
 use App\Models\AnalysisSuggestion;
 use App\Models\Category;
-use App\Models\PlannedTransaction;
 use App\Models\Transaction;
+use App\Models\User;
 use App\Services\RuleActionExecutor;
+use App\Services\SuggestionApplier;
 use Flux\Flux;
 use Illuminate\Contracts\View\View;
-use Illuminate\Support\Facades\DB;
 use Livewire\Component;
 use Throwable;
 
@@ -31,7 +31,7 @@ final class AnalysisSuggestions extends Component
     /** @var array<int, int|string|null> */
     public array $recurringCategories = [];
 
-    public function acceptPrimaryAccount(int $suggestionId): void
+    public function acceptPrimaryAccount(int $suggestionId, SuggestionApplier $applier): void
     {
         $suggestion = $this->findPendingSuggestion($suggestionId, SuggestionType::PrimaryAccount);
 
@@ -39,13 +39,15 @@ final class AnalysisSuggestions extends Component
             return;
         }
 
-        auth()->user()->update(['primary_account_id' => $suggestion->payload['account_id']]);
-        $this->resolveSuggestion($suggestion, SuggestionStatus::Accepted);
+        /** @var User $user */
+        $user = auth()->user();
+
+        $applier->applyPrimaryAccount($suggestion, $user);
 
         Flux::toast(text: 'Primary account set', variant: 'success');
     }
 
-    public function acceptPayCycle(int $suggestionId): void
+    public function acceptPayCycle(int $suggestionId, SuggestionApplier $applier): void
     {
         $this->validate([
             'payAmount' => ['required', 'numeric', 'gt:0'],
@@ -59,15 +61,16 @@ final class AnalysisSuggestions extends Component
             return;
         }
 
-        $cents = (int) round((float) $this->payAmount * 100);
+        /** @var User $user */
+        $user = auth()->user();
 
-        auth()->user()->update([
-            'pay_amount' => $cents,
-            'pay_frequency' => $this->payFrequency,
-            'next_pay_date' => $this->nextPayDate,
-        ]);
-
-        $this->resolveSuggestion($suggestion, SuggestionStatus::Accepted);
+        $applier->applyPayCycle(
+            $suggestion,
+            $user,
+            (int) round((float) $this->payAmount * 100),
+            $this->payFrequency,
+            $this->nextPayDate,
+        );
 
         Flux::toast(text: 'Pay cycle configured', variant: 'success');
     }
@@ -75,7 +78,7 @@ final class AnalysisSuggestions extends Component
     /**
      * @throws Throwable
      */
-    public function acceptRecurringTransaction(int $suggestionId): void
+    public function acceptRecurringTransaction(int $suggestionId, SuggestionApplier $applier): void
     {
         $suggestion = $this->findPendingSuggestion($suggestionId, SuggestionType::RecurringTransaction);
 
@@ -83,44 +86,17 @@ final class AnalysisSuggestions extends Component
             return;
         }
 
-        $payload = $suggestion->payload;
-        $user = auth()->user();
-        $rawCategory = $this->recurringCategories[$suggestionId] ?? $payload['category_id'] ?? null;
+        $rawCategory = $this->recurringCategories[$suggestionId] ?? $suggestion->payload['category_id'] ?? null;
         $categoryId = $rawCategory !== '' && $rawCategory !== null ? (int) $rawCategory : null;
 
         if ($categoryId !== null && ! Category::visible()->where('id', $categoryId)->exists()) {
             $categoryId = null;
         }
 
-        DB::transaction(function () use ($suggestion, $payload, $user, $categoryId): void {
-            $planned = PlannedTransaction::create([
-                'user_id' => $user->id,
-                'account_id' => $payload['account_id'],
-                'amount' => $payload['amount'],
-                'direction' => $payload['direction'],
-                'description' => $payload['clean_description'],
-                'start_date' => $payload['start_date'],
-                'frequency' => $payload['frequency'],
-                'is_active' => true,
-                'category_id' => $categoryId,
-            ]);
+        /** @var User $user */
+        $user = auth()->user();
 
-            $matchedIds = $payload['matched_transaction_ids'] ?? [];
-
-            if ($matchedIds !== []) {
-                $updateData = ['planned_transaction_id' => $planned->id];
-
-                if ($categoryId !== null) {
-                    $updateData['category_id'] = $categoryId;
-                }
-
-                Transaction::whereIn('id', $matchedIds)
-                    ->where('user_id', $user->id)
-                    ->update($updateData);
-            }
-
-            $this->resolveSuggestion($suggestion, SuggestionStatus::Accepted);
-        });
+        $applier->applyRecurringTransaction($suggestion, $user, $categoryId);
 
         Flux::toast(text: 'Recurring transaction created', variant: 'success');
     }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -46,9 +46,9 @@ final class AppServiceProvider extends ServiceProvider
 
         $this->app->singleton(TransactionAnalysisPipeline::class, fn (): TransactionAnalysisPipeline => new TransactionAnalysisPipeline(
             stages: [
-                new IdentifyPrimaryAccountStage,
-                new SetPayCycleStage,
-                new IdentifyRecurringTransactionsStage,
+                $this->app->make(IdentifyPrimaryAccountStage::class),
+                $this->app->make(SetPayCycleStage::class),
+                $this->app->make(IdentifyRecurringTransactionsStage::class),
                 $this->app->make(UserRulesStage::class),
                 $this->app->make(MatchPlannedTransactionsStage::class),
             ],

--- a/app/Services/IncomePatternDetector.php
+++ b/app/Services/IncomePatternDetector.php
@@ -1,0 +1,244 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\DTOs\IncomePattern;
+use App\Enums\PayFrequency;
+use App\Enums\TransactionDirection;
+use App\Enums\TransactionSource;
+use App\Models\Account;
+use App\Models\Transaction;
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Collection;
+
+/**
+ * Detects a regular incoming-money (salary) pattern on a single account by
+ * grouping its credit transactions and scoring each group on interval and
+ * amount consistency. Shared by the primary-account and pay-cycle stages so
+ * that income detection lives in exactly one place.
+ */
+final class IncomePatternDetector
+{
+    /**
+     * Confidence at or above which a detected pattern is trusted enough to
+     * auto-apply (set primary account / pay cycle) without user review.
+     */
+    public const float AUTO_APPLY_CONFIDENCE = 0.80;
+
+    private const int MIN_OCCURRENCES = 2;
+
+    private const float MAX_INTERVAL_CV = 0.30;
+
+    private const int SALARY_THRESHOLD_HIGH = 50_000;
+
+    private const int SALARY_THRESHOLD_LOW = 25_000;
+
+    /** @var array<string, array{min: int, max: int}> */
+    private const array FREQUENCY_RANGES = [
+        'weekly' => ['min' => 5, 'max' => 9],
+        'fortnightly' => ['min' => 12, 'max' => 16],
+        'monthly' => ['min' => 27, 'max' => 35],
+    ];
+
+    private const float WEIGHT_INTERVAL = 0.30;
+
+    private const float WEIGHT_AMOUNT = 0.25;
+
+    private const float WEIGHT_COUNT = 0.25;
+
+    private const float WEIGHT_SALARY = 0.20;
+
+    public function detectForAccount(Account $account): ?IncomePattern
+    {
+        $credits = Transaction::query()
+            ->where('account_id', $account->id)
+            ->where('user_id', $account->user_id)
+            ->where('direction', TransactionDirection::Credit)
+            ->whereIn('source', TransactionSource::forAnalysis())
+            ->whereNull('transfer_pair_id')
+            ->current()
+            ->orderBy('post_date')
+            ->get();
+
+        if ($credits->count() < self::MIN_OCCURRENCES) {
+            return null;
+        }
+
+        $grouped = $credits->groupBy(fn (Transaction $t): string => $this->normalizeDescription($t));
+
+        $best = null;
+
+        foreach ($grouped as $description => $transactions) {
+            if ($transactions->count() < self::MIN_OCCURRENCES) {
+                continue;
+            }
+
+            $candidate = $this->analyzeGroup((string) $description, $transactions);
+
+            if ($candidate === null) {
+                continue;
+            }
+
+            if ($best === null || $candidate->confidence > $best->confidence) {
+                $best = $candidate;
+            }
+        }
+
+        return $best;
+    }
+
+    /**
+     * @param  Collection<int, Transaction>  $transactions
+     */
+    private function analyzeGroup(string $description, Collection $transactions): ?IncomePattern
+    {
+        $sorted = $transactions->sortBy('post_date')->values();
+        $intervals = $this->calculateIntervals($sorted);
+
+        if ($intervals === []) {
+            return null;
+        }
+
+        $frequency = $this->mapFrequency($this->median($intervals));
+
+        if ($frequency === null) {
+            return null;
+        }
+
+        $intervalCV = $this->coefficientOfVariation($intervals);
+
+        if ($intervalCV > self::MAX_INTERVAL_CV) {
+            return null;
+        }
+
+        $amounts = $sorted->pluck('amount')->map(fn ($a): int => abs((int) $a))->all();
+        $latestAmount = abs((int) $sorted->last()->amount);
+        $amountCV = $this->coefficientOfVariation($amounts);
+
+        $intervalScore = max(0.0, 1.0 - $intervalCV * 3.33);
+        $amountScore = max(0.0, 1.0 - $amountCV / 0.10);
+        $countScore = min(1.0, log($sorted->count(), 2) / log(8, 2));
+        $salaryScore = $this->salaryScore($latestAmount);
+
+        $confidence = (self::WEIGHT_INTERVAL * $intervalScore)
+            + (self::WEIGHT_AMOUNT * $amountScore)
+            + (self::WEIGHT_COUNT * $countScore)
+            + (self::WEIGHT_SALARY * $salaryScore);
+
+        return new IncomePattern(
+            frequency: $frequency,
+            amount: $latestAmount,
+            description: $description,
+            transactionIds: $sorted->pluck('id')->all(),
+            detectedDates: $sorted
+                ->pluck('post_date')
+                ->map(fn (CarbonImmutable $date): string => $date->format('Y-m-d'))
+                ->values()
+                ->all(),
+            mostRecentDate: $sorted->last()->post_date,
+            confidence: round($confidence, 4),
+        );
+    }
+
+    /**
+     * @param  Collection<int, Transaction>  $sorted
+     * @return list<float>
+     */
+    private function calculateIntervals(Collection $sorted): array
+    {
+        $intervals = [];
+
+        for ($i = 1; $i < $sorted->count(); $i++) {
+            $intervals[] = (float) $sorted[$i - 1]->post_date->diffInDays($sorted[$i]->post_date);
+        }
+
+        return $intervals;
+    }
+
+    private function mapFrequency(float $medianInterval): ?PayFrequency
+    {
+        foreach (self::FREQUENCY_RANGES as $freq => $range) {
+            if ($medianInterval >= $range['min'] && $medianInterval <= $range['max']) {
+                return PayFrequency::from($freq);
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  list<float|int>  $values
+     */
+    private function coefficientOfVariation(array $values): float
+    {
+        $count = count($values);
+
+        if ($count < 2) {
+            return 0.0;
+        }
+
+        $mean = array_sum($values) / $count;
+
+        if ($mean === 0.0) {
+            return 0.0;
+        }
+
+        $sumSquaredDiffs = 0.0;
+
+        foreach ($values as $v) {
+            $sumSquaredDiffs += ($v - $mean) ** 2;
+        }
+
+        $stdDev = sqrt($sumSquaredDiffs / $count);
+
+        return $stdDev / abs($mean);
+    }
+
+    /**
+     * @param  list<float|int>  $values
+     */
+    private function median(array $values): float
+    {
+        $sorted = $values;
+        sort($sorted);
+
+        $count = count($sorted);
+        $mid = intdiv($count, 2);
+
+        if ($count % 2 === 0) {
+            return ($sorted[$mid - 1] + $sorted[$mid]) / 2.0;
+        }
+
+        return (float) $sorted[$mid];
+    }
+
+    private function salaryScore(float $medianAmount): float
+    {
+        if ($medianAmount >= self::SALARY_THRESHOLD_HIGH) {
+            return 1.0;
+        }
+
+        if ($medianAmount >= self::SALARY_THRESHOLD_LOW) {
+            return 0.5;
+        }
+
+        return 0.0;
+    }
+
+    private function normalizeDescription(Transaction $transaction): string
+    {
+        if ($transaction->merchant_name !== null && $transaction->merchant_name !== '') {
+            return mb_strtoupper(mb_trim($transaction->merchant_name));
+        }
+
+        if ($transaction->clean_description !== null && $transaction->clean_description !== '') {
+            return mb_strtoupper(mb_trim($transaction->clean_description));
+        }
+
+        $normalized = mb_strtoupper(mb_trim($transaction->description));
+
+        return (string) preg_replace('/\s+/', ' ', $normalized);
+    }
+}

--- a/app/Services/PipelineStages/IdentifyPrimaryAccountStage.php
+++ b/app/Services/PipelineStages/IdentifyPrimaryAccountStage.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace App\Services\PipelineStages;
 
 use App\Contracts\PipelineStageContract;
+use App\DTOs\IncomePattern;
 use App\DTOs\PipelineContext;
 use App\DTOs\StageResult;
 use App\Enums\AccountClass;
-use App\Enums\PayFrequency;
 use App\Enums\SuggestionType;
 use App\Enums\TransactionDirection;
 use App\Enums\TransactionSource;
@@ -16,37 +16,22 @@ use App\Models\Account;
 use App\Models\AnalysisSuggestion;
 use App\Models\PipelineAuditEntry;
 use App\Models\Transaction;
+use App\Services\IncomePatternDetector;
+use App\Services\SuggestionApplier;
 use Illuminate\Support\Collection;
 
 final readonly class IdentifyPrimaryAccountStage implements PipelineStageContract
 {
     private const string STAGE_KEY = 'identify-primary-account';
 
-    private const int MIN_OCCURRENCES = 2;
-
-    private const float MAX_INTERVAL_CV = 0.30;
-
-    private const int SALARY_THRESHOLD_HIGH = 50_000;
-
-    private const int SALARY_THRESHOLD_LOW = 25_000;
-
-    private const array FREQUENCY_RANGES = [
-        'weekly' => ['min' => 5, 'max' => 9],
-        'fortnightly' => ['min' => 12, 'max' => 16],
-        'monthly' => ['min' => 27, 'max' => 35],
-    ];
-
-    private const float WEIGHT_INTERVAL = 0.30;
-
-    private const float WEIGHT_AMOUNT = 0.25;
-
-    private const float WEIGHT_COUNT = 0.25;
-
-    private const float WEIGHT_SALARY = 0.20;
-
     private const float TRANSFER_BONUS_MAX = 0.10;
 
     private const float TRANSFER_BONUS_PER = 0.02;
+
+    public function __construct(
+        private IncomePatternDetector $detector,
+        private SuggestionApplier $applier,
+    ) {}
 
     public function key(): string
     {
@@ -74,233 +59,98 @@ final readonly class IdentifyPrimaryAccountStage implements PipelineStageContrac
             return new StageResult(success: true, stage: self::STAGE_KEY);
         }
 
-        $bestOverall = null;
+        $suggestionIds = [];
 
-        foreach ($accounts as $account) {
-            $candidate = $this->analyzeAccount($account, $context);
+        $candidateCount = Transaction::query()
+            ->whereIn('account_id', $accounts->pluck('id'))
+            ->where('direction', TransactionDirection::Credit)
+            ->whereIn('source', TransactionSource::forAnalysis())
+            ->whereNull('transfer_pair_id')
+            ->current()
+            ->count();
 
-            if ($candidate === null) {
-                continue;
-            }
+        if ($candidateCount === 0) {
+            $this->audit($context, 'no_transactions_to_analyze', ['accounts_analyzed' => $accounts->count()]);
+        } else {
+            $best = $this->detectBestAccount($accounts, $context);
 
-            if ($bestOverall === null || $candidate['confidence'] > $bestOverall['confidence']) {
-                $bestOverall = $candidate;
+            if ($best === null) {
+                $this->audit($context, 'no_income_pattern_detected', ['accounts_analyzed' => $accounts->count()]);
+            } else {
+                $suggestion = AnalysisSuggestion::create([
+                    'pipeline_run_id' => $context->pipelineRun->id,
+                    'user_id' => $context->user->id,
+                    'type' => SuggestionType::PrimaryAccount,
+                    'payload' => [
+                        'account_id' => $best['account']->id,
+                        'account_name' => $best['account']->name,
+                        'income_amount' => $best['pattern']->amount,
+                        'income_frequency' => $best['pattern']->frequency->value,
+                        'income_description' => $best['pattern']->description,
+                        'confidence_score' => round($best['confidence'], 4),
+                        'matched_transaction_ids' => $best['pattern']->transactionIds,
+                        'outbound_transfer_count' => $best['transfer_count'],
+                    ],
+                ]);
+
+                $suggestionIds[] = $suggestion->id;
+
+                if ($best['confidence'] >= IncomePatternDetector::AUTO_APPLY_CONFIDENCE) {
+                    $this->applier->applyPrimaryAccount($suggestion, $context->user);
+                    $this->audit($context, 'auto_applied', [
+                        'account_id' => $best['account']->id,
+                        'confidence' => round($best['confidence'], 4),
+                    ]);
+                }
             }
         }
 
-        if ($bestOverall === null) {
-            PipelineAuditEntry::create([
-                'pipeline_run_id' => $context->pipelineRun->id,
-                'stage' => self::STAGE_KEY,
-                'action' => 'no_income_pattern_detected',
-                'metadata' => ['accounts_analyzed' => $accounts->count()],
-            ]);
-
-            return new StageResult(success: true, stage: self::STAGE_KEY);
+        // Guaranteed fallback: if detection set no primary and there is exactly
+        // one eligible account, that account is unambiguously the primary one.
+        // This is the "first import is your primary account" path.
+        if ($accounts->count() === 1 && $context->user->primary_account_id === null) {
+            $singleAccount = $accounts->first();
+            $context->user->update(['primary_account_id' => $singleAccount->id]);
+            $this->audit($context, 'primary_account_fallback_applied', ['account_id' => $singleAccount->id]);
         }
-
-        $transferCount = $this->countOutboundTransfers($bestOverall['account'], $context);
-        $transferBonus = min(self::TRANSFER_BONUS_MAX, $transferCount * self::TRANSFER_BONUS_PER);
-        $finalConfidence = min(1.0, $bestOverall['confidence'] + $transferBonus);
-
-        $suggestion = AnalysisSuggestion::create([
-            'pipeline_run_id' => $context->pipelineRun->id,
-            'user_id' => $context->user->id,
-            'type' => SuggestionType::PrimaryAccount,
-            'payload' => [
-                'account_id' => $bestOverall['account']->id,
-                'account_name' => $bestOverall['account']->name,
-                'income_amount' => $bestOverall['latest_amount'],
-                'income_frequency' => $bestOverall['frequency']->value,
-                'income_description' => $bestOverall['description'],
-                'confidence_score' => round($finalConfidence, 4),
-                'matched_transaction_ids' => $bestOverall['transaction_ids'],
-                'outbound_transfer_count' => $transferCount,
-            ],
-        ]);
 
         return new StageResult(
             success: true,
             stage: self::STAGE_KEY,
-            suggestionIds: [$suggestion->id],
+            suggestionIds: $suggestionIds,
         );
     }
 
     /**
-     * @return array{account: Account, confidence: float, latest_amount: int, frequency: PayFrequency, description: string, transaction_ids: list<int>}|null
+     * @param  Collection<int, Account>  $accounts
+     * @return array{account: Account, pattern: IncomePattern, confidence: float, transfer_count: int}|null
      */
-    private function analyzeAccount(Account $account, PipelineContext $context): ?array
+    private function detectBestAccount(Collection $accounts, PipelineContext $context): ?array
     {
-        $credits = Transaction::query()
-            ->where('account_id', $account->id)
-            ->where('user_id', $context->user->id)
-            ->where('direction', TransactionDirection::Credit)
-            ->where('source', TransactionSource::Basiq)
-            ->whereNull('transfer_pair_id')
-            ->current()
-            ->orderBy('post_date')
-            ->get();
+        $best = null;
 
-        if ($credits->count() < self::MIN_OCCURRENCES) {
-            return null;
-        }
+        foreach ($accounts as $account) {
+            $pattern = $this->detector->detectForAccount($account);
 
-        $grouped = $credits->groupBy(fn (Transaction $t) => $this->normalizeDescription($t));
-
-        $bestCandidate = null;
-
-        foreach ($grouped as $description => $transactions) {
-            if ($transactions->count() < self::MIN_OCCURRENCES) {
+            if ($pattern === null) {
                 continue;
             }
 
-            $result = $this->analyzeGroup($account, (string) $description, $transactions);
+            $transferCount = $this->countOutboundTransfers($account, $context);
+            $transferBonus = min(self::TRANSFER_BONUS_MAX, $transferCount * self::TRANSFER_BONUS_PER);
+            $confidence = min(1.0, $pattern->confidence + $transferBonus);
 
-            if ($result === null) {
-                continue;
-            }
-
-            if ($bestCandidate === null || $result['confidence'] > $bestCandidate['confidence']) {
-                $bestCandidate = $result;
-            }
-        }
-
-        return $bestCandidate;
-    }
-
-    /**
-     * @param  Collection<int, Transaction>  $transactions
-     * @return array{account: Account, confidence: float, latest_amount: int, frequency: PayFrequency, description: string, transaction_ids: list<int>}|null
-     */
-    private function analyzeGroup(Account $account, string $description, Collection $transactions): ?array
-    {
-        $sorted = $transactions->sortBy('post_date')->values();
-        $intervals = $this->calculateIntervals($sorted);
-
-        if ($intervals === []) {
-            return null;
-        }
-
-        $medianInterval = $this->median($intervals);
-        $frequency = $this->mapFrequency($medianInterval);
-
-        if ($frequency === null) {
-            return null;
-        }
-
-        $intervalCV = $this->coefficientOfVariation($intervals);
-
-        if ($intervalCV > self::MAX_INTERVAL_CV) {
-            return null;
-        }
-
-        $amounts = $sorted->pluck('amount')->map(fn ($a) => abs((int) $a))->all();
-        $latestAmount = abs((int) $sorted->last()->amount);
-        $amountCV = $this->coefficientOfVariation($amounts);
-
-        $intervalScore = max(0.0, 1.0 - $intervalCV * 3.33);
-        $amountScore = max(0.0, 1.0 - $amountCV / 0.10);
-        $countScore = min(1.0, log($sorted->count(), 2) / log(8, 2));
-        $salaryScore = $this->salaryScore($latestAmount);
-
-        $confidence = (self::WEIGHT_INTERVAL * $intervalScore)
-            + (self::WEIGHT_AMOUNT * $amountScore)
-            + (self::WEIGHT_COUNT * $countScore)
-            + (self::WEIGHT_SALARY * $salaryScore);
-
-        return [
-            'account' => $account,
-            'confidence' => round($confidence, 4),
-            'latest_amount' => $latestAmount,
-            'frequency' => $frequency,
-            'description' => $description,
-            'transaction_ids' => $sorted->pluck('id')->all(),
-        ];
-    }
-
-    /**
-     * @param  Collection<int, Transaction>  $sorted
-     * @return list<float>
-     */
-    private function calculateIntervals(Collection $sorted): array
-    {
-        $intervals = [];
-
-        for ($i = 1; $i < $sorted->count(); $i++) {
-            $intervals[] = (float) $sorted[$i - 1]->post_date->diffInDays($sorted[$i]->post_date);
-        }
-
-        return $intervals;
-    }
-
-    private function mapFrequency(float $medianInterval): ?PayFrequency
-    {
-        foreach (self::FREQUENCY_RANGES as $freq => $range) {
-            if ($medianInterval >= $range['min'] && $medianInterval <= $range['max']) {
-                return PayFrequency::from($freq);
+            if ($best === null || $confidence > $best['confidence']) {
+                $best = [
+                    'account' => $account,
+                    'pattern' => $pattern,
+                    'confidence' => $confidence,
+                    'transfer_count' => $transferCount,
+                ];
             }
         }
 
-        return null;
-    }
-
-    /**
-     * @param  list<float|int>  $values
-     */
-    private function coefficientOfVariation(array $values): float
-    {
-        $count = count($values);
-
-        if ($count < 2) {
-            return 0.0;
-        }
-
-        $mean = array_sum($values) / $count;
-
-        if ($mean === 0.0) {
-            return 0.0;
-        }
-
-        $sumSquaredDiffs = 0.0;
-
-        foreach ($values as $v) {
-            $sumSquaredDiffs += ($v - $mean) ** 2;
-        }
-
-        $stdDev = sqrt($sumSquaredDiffs / $count);
-
-        return $stdDev / abs($mean);
-    }
-
-    /**
-     * @param  list<float|int>  $values
-     */
-    private function median(array $values): float
-    {
-        $sorted = $values;
-        sort($sorted);
-
-        $count = count($sorted);
-        $mid = intdiv($count, 2);
-
-        if ($count % 2 === 0) {
-            return ($sorted[$mid - 1] + $sorted[$mid]) / 2.0;
-        }
-
-        return (float) $sorted[$mid];
-    }
-
-    private function salaryScore(float $medianAmount): float
-    {
-        if ($medianAmount >= self::SALARY_THRESHOLD_HIGH) {
-            return 1.0;
-        }
-
-        if ($medianAmount >= self::SALARY_THRESHOLD_LOW) {
-            return 0.5;
-        }
-
-        return 0.0;
+        return $best;
     }
 
     private function countOutboundTransfers(Account $account, PipelineContext $context): int
@@ -319,18 +169,16 @@ final readonly class IdentifyPrimaryAccountStage implements PipelineStageContrac
             ->count();
     }
 
-    private function normalizeDescription(Transaction $transaction): string
+    /**
+     * @param  array<string, mixed>  $metadata
+     */
+    private function audit(PipelineContext $context, string $action, array $metadata = []): void
     {
-        if ($transaction->merchant_name !== null && $transaction->merchant_name !== '') {
-            return mb_strtoupper(mb_trim($transaction->merchant_name));
-        }
-
-        if ($transaction->clean_description !== null && $transaction->clean_description !== '') {
-            return mb_strtoupper(mb_trim($transaction->clean_description));
-        }
-
-        $normalized = mb_strtoupper(mb_trim($transaction->description));
-
-        return (string) preg_replace('/\s+/', ' ', $normalized);
+        PipelineAuditEntry::create([
+            'pipeline_run_id' => $context->pipelineRun->id,
+            'stage' => self::STAGE_KEY,
+            'action' => $action,
+            'metadata' => $metadata,
+        ]);
     }
 }

--- a/app/Services/PipelineStages/IdentifyRecurringTransactionsStage.php
+++ b/app/Services/PipelineStages/IdentifyRecurringTransactionsStage.php
@@ -57,6 +57,13 @@ final readonly class IdentifyRecurringTransactionsStage implements PipelineStage
         $transactions = $this->loadUnmatchedTransactions($context->user);
 
         if ($transactions->isEmpty()) {
+            PipelineAuditEntry::create([
+                'pipeline_run_id' => $context->pipelineRun->id,
+                'stage' => self::STAGE_KEY,
+                'action' => 'no_transactions_to_analyze',
+                'metadata' => [],
+            ]);
+
             return new StageResult(success: true, stage: self::STAGE_KEY, suggestionIds: []);
         }
 
@@ -105,7 +112,7 @@ final readonly class IdentifyRecurringTransactionsStage implements PipelineStage
     {
         return Transaction::query()
             ->where('user_id', $user->id)
-            ->where('source', TransactionSource::Basiq)
+            ->whereIn('source', TransactionSource::forAnalysis())
             ->whereNull('planned_transaction_id')
             ->current()
             ->get();

--- a/app/Services/PipelineStages/SetPayCycleStage.php
+++ b/app/Services/PipelineStages/SetPayCycleStage.php
@@ -11,12 +11,18 @@ use App\Enums\PayFrequency;
 use App\Enums\SuggestionType;
 use App\Models\AnalysisSuggestion;
 use App\Models\PipelineAuditEntry;
-use App\Models\Transaction;
+use App\Services\IncomePatternDetector;
+use App\Services\SuggestionApplier;
 use Carbon\CarbonImmutable;
 
 final readonly class SetPayCycleStage implements PipelineStageContract
 {
     private const string STAGE_KEY = 'set-pay-cycle';
+
+    public function __construct(
+        private IncomePatternDetector $detector,
+        private SuggestionApplier $applier,
+    ) {}
 
     public function key(): string
     {
@@ -30,75 +36,77 @@ final readonly class SetPayCycleStage implements PipelineStageContract
 
     public function shouldRun(PipelineContext $context): bool
     {
-        return $context->isFirstSync && ! $context->user->hasPayCycleConfigured();
+        // Requires a primary account to read the salary pattern from. Runs on
+        // every analysis once a primary exists (not just first sync) so a job
+        // change can be re-detected — never overwriting existing settings.
+        return $context->user->primary_account_id !== null;
     }
 
     public function execute(PipelineContext $context): StageResult
     {
-        $primarySuggestion = AnalysisSuggestion::query()
-            ->where('pipeline_run_id', $context->pipelineRun->id)
-            ->ofType(SuggestionType::PrimaryAccount)
-            ->first();
+        $primaryAccount = $context->user->primaryAccount;
 
-        if ($primarySuggestion === null) {
-            PipelineAuditEntry::create([
-                'pipeline_run_id' => $context->pipelineRun->id,
-                'stage' => self::STAGE_KEY,
-                'action' => 'no_primary_account_suggestion',
-                'metadata' => [],
-            ]);
+        if ($primaryAccount === null) {
+            $this->audit($context, 'no_primary_account');
 
             return new StageResult(success: true, stage: self::STAGE_KEY);
         }
 
-        $payload = $primarySuggestion->payload;
-        $incomeAmount = (int) $payload['income_amount'];
-        $incomeFrequency = $payload['income_frequency'];
-        $incomeDescription = (string) $payload['income_description'];
-        $matchedTransactionIds = (array) $payload['matched_transaction_ids'];
-        $accountId = (int) $payload['account_id'];
+        $pattern = $this->detector->detectForAccount($primaryAccount);
 
-        $frequency = PayFrequency::from($incomeFrequency);
-
-        $matchedTransactions = Transaction::query()
-            ->where('user_id', $context->user->id)
-            ->whereIn('id', $matchedTransactionIds)
-            ->orderBy('post_date')
-            ->get();
-
-        if ($matchedTransactions->isEmpty()) {
-            PipelineAuditEntry::create([
-                'pipeline_run_id' => $context->pipelineRun->id,
-                'stage' => self::STAGE_KEY,
-                'action' => 'no_matched_transactions_found',
-                'metadata' => ['expected_ids' => $matchedTransactionIds],
-            ]);
+        if ($pattern === null) {
+            $this->audit($context, 'no_income_pattern_detected', ['account_id' => $primaryAccount->id]);
 
             return new StageResult(success: true, stage: self::STAGE_KEY);
         }
 
-        $detectedDates = $matchedTransactions
-            ->pluck('post_date')
-            ->map(fn (CarbonImmutable $date): string => $date->format('Y-m-d'))
-            ->values()
-            ->all();
+        $alreadyConfigured = $context->user->hasPayCycleConfigured();
 
-        $mostRecentDate = $matchedTransactions->last()->post_date;
-        $nextPayDate = $this->calculateNextPayDate($mostRecentDate, $frequency);
+        // Nothing to do when the detected pattern already matches the user's
+        // current pay cycle — avoids re-suggesting an unchanged value.
+        if ($alreadyConfigured
+            && $context->user->pay_frequency === $pattern->frequency
+            && $context->user->pay_amount === $pattern->amount
+        ) {
+            $this->audit($context, 'pay_cycle_unchanged', ['account_id' => $primaryAccount->id]);
+
+            return new StageResult(success: true, stage: self::STAGE_KEY);
+        }
+
+        $nextPayDate = $this->calculateNextPayDate($pattern->mostRecentDate, $pattern->frequency);
 
         $suggestion = AnalysisSuggestion::create([
             'pipeline_run_id' => $context->pipelineRun->id,
             'user_id' => $context->user->id,
             'type' => SuggestionType::PayCycle,
             'payload' => [
-                'pay_amount' => $incomeAmount,
-                'pay_frequency' => $frequency->value,
+                'pay_amount' => $pattern->amount,
+                'pay_frequency' => $pattern->frequency->value,
                 'next_pay_date' => $nextPayDate->format('Y-m-d'),
-                'source_account_id' => $accountId,
-                'source_description' => $incomeDescription,
-                'detected_dates' => $detectedDates,
+                'source_account_id' => $primaryAccount->id,
+                'source_description' => $pattern->description,
+                'detected_dates' => $pattern->detectedDates,
+                'confidence_score' => $pattern->confidence,
             ],
         ]);
+
+        // Auto-apply only when no pay cycle exists yet. An existing pay cycle is
+        // never overwritten automatically — a changed pattern stays a pending
+        // suggestion for the user to review (protects manual edits / job changes).
+        if (! $alreadyConfigured && $pattern->confidence >= IncomePatternDetector::AUTO_APPLY_CONFIDENCE) {
+            $this->applier->applyPayCycle(
+                $suggestion,
+                $context->user,
+                $pattern->amount,
+                $pattern->frequency->value,
+                $nextPayDate->format('Y-m-d'),
+            );
+
+            $this->audit($context, 'auto_applied', [
+                'account_id' => $primaryAccount->id,
+                'confidence' => $pattern->confidence,
+            ]);
+        }
 
         return new StageResult(
             success: true,
@@ -125,5 +133,18 @@ final readonly class SetPayCycleStage implements PipelineStageContract
             PayFrequency::Fortnightly => $date->addWeeks(2),
             PayFrequency::Monthly => $date->addMonth(),
         };
+    }
+
+    /**
+     * @param  array<string, mixed>  $metadata
+     */
+    private function audit(PipelineContext $context, string $action, array $metadata = []): void
+    {
+        PipelineAuditEntry::create([
+            'pipeline_run_id' => $context->pipelineRun->id,
+            'stage' => self::STAGE_KEY,
+            'action' => $action,
+            'metadata' => $metadata,
+        ]);
     }
 }

--- a/app/Services/SuggestionApplier.php
+++ b/app/Services/SuggestionApplier.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Enums\SuggestionStatus;
+use App\Models\AnalysisSuggestion;
+use App\Models\PlannedTransaction;
+use App\Models\Transaction;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Throwable;
+
+/**
+ * Applies an accepted (or auto-applied) analysis suggestion to the user's data.
+ *
+ * Lives outside the Livewire layer so both the suggestions UI and the queued
+ * analysis pipeline can apply suggestions through the same code path. Each
+ * method takes an explicit User rather than relying on auth() context.
+ */
+final class SuggestionApplier
+{
+    public function applyPrimaryAccount(AnalysisSuggestion $suggestion, User $user): void
+    {
+        $user->update(['primary_account_id' => $suggestion->payload['account_id']]);
+
+        $this->markAccepted($suggestion);
+    }
+
+    public function applyPayCycle(
+        AnalysisSuggestion $suggestion,
+        User $user,
+        int $payAmount,
+        string $payFrequency,
+        string $nextPayDate,
+    ): void {
+        $user->update([
+            'pay_amount' => $payAmount,
+            'pay_frequency' => $payFrequency,
+            'next_pay_date' => $nextPayDate,
+        ]);
+
+        $this->markAccepted($suggestion);
+    }
+
+    /**
+     * @throws Throwable
+     */
+    public function applyRecurringTransaction(
+        AnalysisSuggestion $suggestion,
+        User $user,
+        ?int $categoryId,
+    ): PlannedTransaction {
+        return DB::transaction(function () use ($suggestion, $user, $categoryId): PlannedTransaction {
+            $payload = $suggestion->payload;
+
+            $planned = PlannedTransaction::create([
+                'user_id' => $user->id,
+                'account_id' => $payload['account_id'],
+                'amount' => $payload['amount'],
+                'direction' => $payload['direction'],
+                'description' => $payload['clean_description'],
+                'start_date' => $payload['start_date'],
+                'frequency' => $payload['frequency'],
+                'is_active' => true,
+                'category_id' => $categoryId,
+            ]);
+
+            $matchedIds = $payload['matched_transaction_ids'] ?? [];
+
+            if ($matchedIds !== []) {
+                $updateData = ['planned_transaction_id' => $planned->id];
+
+                if ($categoryId !== null) {
+                    $updateData['category_id'] = $categoryId;
+                }
+
+                Transaction::whereIn('id', $matchedIds)
+                    ->where('user_id', $user->id)
+                    ->update($updateData);
+            }
+
+            $this->markAccepted($suggestion);
+
+            return $planned;
+        });
+    }
+
+    private function markAccepted(AnalysisSuggestion $suggestion): void
+    {
+        $suggestion->update([
+            'status' => SuggestionStatus::Accepted,
+            'resolved_at' => now(),
+        ]);
+    }
+}

--- a/database/factories/TransactionFactory.php
+++ b/database/factories/TransactionFactory.php
@@ -79,6 +79,15 @@ final class TransactionFactory extends Factory
         ]);
     }
 
+    public function fromCsv(): self
+    {
+        return $this->state(fn (array $attributes) => [
+            'source' => TransactionSource::Csv,
+            'merchant_name' => null,
+            'clean_description' => null,
+        ]);
+    }
+
     public function pending(): self
     {
         return $this->state(fn (array $attributes) => [

--- a/tests/Feature/Services/PipelineStages/IdentifyPrimaryAccountStageTest.php
+++ b/tests/Feature/Services/PipelineStages/IdentifyPrimaryAccountStageTest.php
@@ -6,6 +6,7 @@ declare(strict_types=1);
 
 use App\DTOs\PipelineContext;
 use App\Enums\PipelineTrigger;
+use App\Enums\SuggestionStatus;
 use App\Enums\SuggestionType;
 use App\Models\Account;
 use App\Models\AnalysisSuggestion;
@@ -72,7 +73,7 @@ function makeContext(User $user, bool $isFirstSync = true): PipelineContext
 }
 
 beforeEach(function () {
-    $this->stage = new IdentifyPrimaryAccountStage;
+    $this->stage = app(IdentifyPrimaryAccountStage::class);
     $this->user = User::factory()->create(['primary_account_id' => null]);
     $this->account = Account::factory()->for($this->user)->create();
 });
@@ -409,6 +410,10 @@ test('matched_transaction_ids contains all group transaction IDs', function () {
 // ──────────────────────────────────────────────
 
 test('creates audit entry when no income pattern detected', function () {
+    // Two eligible accounts so the single-account fallback does not apply,
+    // isolating the "no income pattern" path.
+    Account::factory()->for($this->user)->create();
+
     createIncomeTransaction($this->user, $this->account, [
         'description' => 'RANDOM THING',
         'amount' => 300_000,
@@ -474,4 +479,104 @@ test('stage is skipped in pipeline when not first sync', function () {
         ->first();
 
     expect($suggestion)->toBeNull();
+});
+
+// ──────────────────────────────────────────────
+// CSV Source (issue #249)
+// ──────────────────────────────────────────────
+
+test('detects primary account from CSV-imported transactions', function () {
+    Account::factory()->savings()->for($this->user)->create();
+
+    for ($i = 0; $i < 4; $i++) {
+        Transaction::factory()
+            ->for($this->user)
+            ->for($this->account)
+            ->credit()
+            ->fromCsv()
+            ->create([
+                'description' => 'SALARY DEPOSIT',
+                'amount' => 300_000,
+                'post_date' => CarbonImmutable::parse('2025-06-01')->addDays($i * 14),
+                'transfer_pair_id' => null,
+            ]);
+    }
+
+    $context = makeContext($this->user);
+    $result = $this->stage->execute($context);
+
+    expect($result->suggestionIds)->toHaveCount(1);
+
+    $suggestion = AnalysisSuggestion::find($result->suggestionIds[0]);
+    expect($suggestion->payload['account_id'])->toBe($this->account->id)
+        ->and($suggestion->payload['income_frequency'])->toBe('fortnightly');
+});
+
+// ──────────────────────────────────────────────
+// Auto-apply (issue #249)
+// ──────────────────────────────────────────────
+
+test('auto-applies primary account and accepts the suggestion when confidence is high', function () {
+    Account::factory()->savings()->for($this->user)->create();
+    createSalaryGroup($this->user, $this->account, 'SALARY DEPOSIT', 300_000, 4, 14);
+
+    $context = makeContext($this->user);
+    $result = $this->stage->execute($context);
+
+    expect($result->suggestionIds)->toHaveCount(1)
+        ->and($this->user->fresh()->primary_account_id)->toBe($this->account->id);
+
+    $suggestion = AnalysisSuggestion::find($result->suggestionIds[0]);
+    expect($suggestion->status)->toBe(SuggestionStatus::Accepted);
+
+    $audit = PipelineAuditEntry::where('pipeline_run_id', $context->pipelineRun->id)
+        ->where('stage', 'identify-primary-account')
+        ->where('action', 'auto_applied')
+        ->first();
+
+    expect($audit)->not->toBeNull();
+});
+
+// ──────────────────────────────────────────────
+// Guaranteed Fallback (issue #249)
+// ──────────────────────────────────────────────
+
+test('falls back to the only eligible account when no income is detected', function () {
+    // Single empty account, no income transactions at all.
+    $context = makeContext($this->user);
+    $result = $this->stage->execute($context);
+
+    expect($result->suggestionIds)->toBeEmpty()
+        ->and($this->user->fresh()->primary_account_id)->toBe($this->account->id);
+
+    $audit = PipelineAuditEntry::where('pipeline_run_id', $context->pipelineRun->id)
+        ->where('stage', 'identify-primary-account')
+        ->where('action', 'primary_account_fallback_applied')
+        ->first();
+
+    expect($audit)->not->toBeNull();
+});
+
+test('does not fall back when multiple eligible accounts exist and no income detected', function () {
+    Account::factory()->for($this->user)->create();
+
+    $context = makeContext($this->user);
+    $result = $this->stage->execute($context);
+
+    expect($result->suggestionIds)->toBeEmpty()
+        ->and($this->user->fresh()->primary_account_id)->toBeNull();
+});
+
+test('records no_transactions_to_analyze when accounts have no analysable credits', function () {
+    Account::factory()->for($this->user)->create();
+
+    $context = makeContext($this->user);
+    $this->stage->execute($context);
+
+    $audit = PipelineAuditEntry::where('pipeline_run_id', $context->pipelineRun->id)
+        ->where('stage', 'identify-primary-account')
+        ->where('action', 'no_transactions_to_analyze')
+        ->first();
+
+    expect($audit)->not->toBeNull();
 });

--- a/tests/Feature/Services/PipelineStages/IdentifyRecurringTransactionsStageTest.php
+++ b/tests/Feature/Services/PipelineStages/IdentifyRecurringTransactionsStageTest.php
@@ -422,7 +422,7 @@ test('PlannedTransaction match uses 5 percent amount tolerance', function () {
 
 // ─── Edge Cases ─────────────────────────────────────────────────────────
 
-test('ignores non-Basiq transactions', function () {
+test('ignores manually-entered transactions', function () {
     $start = CarbonImmutable::parse('2026-01-15');
 
     for ($i = 0; $i < 3; $i++) {
@@ -440,6 +440,43 @@ test('ignores non-Basiq transactions', function () {
 
     expect($result->success)->toBeTrue()
         ->and($result->suggestionIds)->toBeEmpty();
+});
+
+test('detects recurring CSV-imported transactions (issue #249)', function () {
+    $start = CarbonImmutable::parse('2026-01-15');
+
+    for ($i = 0; $i < 3; $i++) {
+        Transaction::factory()
+            ->for($this->user)
+            ->for($this->account)
+            ->fromCsv()
+            ->create([
+                'description' => 'NETFLIX.COM',
+                'amount' => 1699,
+                'direction' => TransactionDirection::Debit,
+                'post_date' => $start->addMonthsNoOverflow($i),
+            ]);
+    }
+
+    $result = $this->stage->execute($this->context);
+
+    expect($result->suggestionIds)->toHaveCount(1);
+
+    $suggestion = AnalysisSuggestion::find($result->suggestionIds[0]);
+    expect($suggestion->payload['description'])->toBe('NETFLIX.COM')
+        ->and($suggestion->payload['frequency'])->toBe(RecurrenceFrequency::EveryMonth->value);
+});
+
+test('audits no_transactions_to_analyze when there is nothing to scan', function () {
+    $this->stage->execute($this->context);
+
+    $audit = PipelineAuditEntry::query()
+        ->where('pipeline_run_id', $this->pipelineRun->id)
+        ->where('stage', 'identify-recurring-transactions')
+        ->where('action', 'no_transactions_to_analyze')
+        ->first();
+
+    expect($audit)->not->toBeNull();
 });
 
 test('ignores transactions already linked to PlannedTransaction', function () {

--- a/tests/Feature/Services/PipelineStages/SetPayCycleStageTest.php
+++ b/tests/Feature/Services/PipelineStages/SetPayCycleStageTest.php
@@ -5,7 +5,9 @@
 declare(strict_types=1);
 
 use App\DTOs\PipelineContext;
+use App\Enums\PayFrequency;
 use App\Enums\PipelineTrigger;
+use App\Enums\SuggestionStatus;
 use App\Enums\SuggestionType;
 use App\Models\Account;
 use App\Models\AnalysisSuggestion;
@@ -21,26 +23,6 @@ use Carbon\CarbonImmutable;
 // Helpers
 // ──────────────────────────────────────────────
 
-function createPrimaryAccountSuggestion(PipelineRun $run, User $user, array $payloadOverrides = []): AnalysisSuggestion
-{
-    return AnalysisSuggestion::factory()
-        ->primaryAccount()
-        ->create([
-            'pipeline_run_id' => $run->id,
-            'user_id' => $user->id,
-            'payload' => array_merge([
-                'account_id' => 1,
-                'account_name' => 'Everyday Account',
-                'income_amount' => 300_000,
-                'income_frequency' => 'monthly',
-                'income_description' => 'SALARY DEPOSIT',
-                'confidence_score' => 0.85,
-                'matched_transaction_ids' => [],
-                'outbound_transfer_count' => 2,
-            ], $payloadOverrides),
-        ]);
-}
-
 function makePayCycleContext(User $user, bool $isFirstSync = true): PipelineContext
 {
     $pipelineRun = PipelineRun::factory()->for($user)->create([
@@ -54,78 +36,71 @@ function makePayCycleContext(User $user, bool $isFirstSync = true): PipelineCont
     );
 }
 
-function createIncomeTransactionForPayCycle(User $user, Account $account, array $overrides = []): Transaction
-{
-    return Transaction::factory()
-        ->for($user)
-        ->for($account)
-        ->credit()
-        ->fromBasiq()
-        ->create(array_merge([
-            'transfer_pair_id' => null,
-            'merchant_name' => null,
-            'clean_description' => null,
-        ], $overrides));
-}
-
-function createSalaryGroupForPayCycle(
+/**
+ * Seed a regular salary on an account: `count` credits spaced `intervalDays`
+ * apart, the most recent landing `lastDaysAgo` days before today.
+ */
+function seedSalary(
     User $user,
     Account $account,
-    string $description,
-    int $amount,
-    int $count,
-    int $intervalDays,
-    ?CarbonImmutable $startDate = null,
-): array {
-    $startDate ??= CarbonImmutable::parse('2025-06-01');
-    $transactions = [];
+    int $amount = 300_000,
+    int $intervalDays = 14,
+    int $count = 4,
+    int $lastDaysAgo = 3,
+    string $description = 'SALARY DEPOSIT',
+): void {
+    $lastDate = CarbonImmutable::today()->subDays($lastDaysAgo);
 
     for ($i = 0; $i < $count; $i++) {
-        $transactions[] = createIncomeTransactionForPayCycle($user, $account, [
-            'description' => $description,
-            'amount' => $amount,
-            'post_date' => $startDate->addDays($i * $intervalDays),
-        ]);
+        Transaction::factory()
+            ->for($user)
+            ->for($account)
+            ->credit()
+            ->fromBasiq()
+            ->create([
+                'description' => $description,
+                'merchant_name' => null,
+                'clean_description' => null,
+                'amount' => $amount,
+                'post_date' => $lastDate->subDays($intervalDays * ($count - 1 - $i)),
+                'transfer_pair_id' => null,
+            ]);
     }
-
-    return $transactions;
 }
 
 beforeEach(function () {
-    $this->stage = new SetPayCycleStage;
+    $this->stage = app(SetPayCycleStage::class);
     $this->user = User::factory()->create([
         'pay_amount' => null,
         'pay_frequency' => null,
         'next_pay_date' => null,
+        'primary_account_id' => null,
     ]);
     $this->account = Account::factory()->for($this->user)->create();
 });
+
+function withPrimaryAccount(User $user, Account $account): User
+{
+    $user->update(['primary_account_id' => $account->id]);
+    $user->refresh();
+
+    return $user;
+}
 
 // ──────────────────────────────────────────────
 // shouldRun Guard
 // ──────────────────────────────────────────────
 
-test('skips when not first sync', function () {
+test('skips when no primary account is set', function () {
+    $context = makePayCycleContext($this->user);
+
+    expect($this->stage->shouldRun($context))->toBeFalse();
+});
+
+test('runs whenever a primary account exists, even when not first sync', function () {
+    withPrimaryAccount($this->user, $this->account);
+
     $context = makePayCycleContext($this->user, isFirstSync: false);
-
-    expect($this->stage->shouldRun($context))->toBeFalse();
-});
-
-test('skips when pay cycle already configured', function () {
-    $this->user->update([
-        'pay_amount' => 300_000,
-        'pay_frequency' => 'monthly',
-        'next_pay_date' => CarbonImmutable::now()->addDays(7),
-    ]);
-    $this->user->refresh();
-
-    $context = makePayCycleContext($this->user);
-
-    expect($this->stage->shouldRun($context))->toBeFalse();
-});
-
-test('runs when first sync and no pay cycle configured', function () {
-    $context = makePayCycleContext($this->user);
 
     expect($this->stage->shouldRun($context))->toBeTrue();
 });
@@ -143,233 +118,158 @@ test('label returns human-readable string', function () {
 });
 
 // ──────────────────────────────────────────────
+// No primary / no income
+// ──────────────────────────────────────────────
+
+test('audits no_primary_account when primary account is missing', function () {
+    $context = makePayCycleContext($this->user);
+
+    $result = $this->stage->execute($context);
+
+    expect($result->success)->toBeTrue()
+        ->and($result->suggestionIds)->toBeEmpty();
+
+    $audit = PipelineAuditEntry::where('pipeline_run_id', $context->pipelineRun->id)
+        ->where('stage', 'set-pay-cycle')
+        ->where('action', 'no_primary_account')
+        ->first();
+
+    expect($audit)->not->toBeNull();
+});
+
+test('audits no_income_pattern_detected when primary account has no salary', function () {
+    withPrimaryAccount($this->user, $this->account);
+
+    $context = makePayCycleContext($this->user);
+    $result = $this->stage->execute($context);
+
+    expect($result->suggestionIds)->toBeEmpty();
+
+    $audit = PipelineAuditEntry::where('pipeline_run_id', $context->pipelineRun->id)
+        ->where('stage', 'set-pay-cycle')
+        ->where('action', 'no_income_pattern_detected')
+        ->first();
+
+    expect($audit)->not->toBeNull();
+});
+
+// ──────────────────────────────────────────────
+// Auto-apply (issue #249)
+// ──────────────────────────────────────────────
+
+test('auto-applies pay cycle when not configured and confidence is high', function () {
+    withPrimaryAccount($this->user, $this->account);
+    seedSalary($this->user, $this->account, amount: 300_000, intervalDays: 14);
+
+    $context = makePayCycleContext($this->user);
+    $result = $this->stage->execute($context);
+
+    expect($result->suggestionIds)->toHaveCount(1);
+
+    $user = $this->user->fresh();
+    expect($user->pay_amount)->toBe(300_000)
+        ->and($user->pay_frequency)->toBe(PayFrequency::Fortnightly)
+        ->and($user->next_pay_date)->not->toBeNull();
+
+    $suggestion = AnalysisSuggestion::find($result->suggestionIds[0]);
+    expect($suggestion->status)->toBe(SuggestionStatus::Accepted);
+
+    $audit = PipelineAuditEntry::where('pipeline_run_id', $context->pipelineRun->id)
+        ->where('stage', 'set-pay-cycle')
+        ->where('action', 'auto_applied')
+        ->first();
+
+    expect($audit)->not->toBeNull();
+});
+
+// ──────────────────────────────────────────────
+// Never overwrite an existing pay cycle (issue #249)
+// ──────────────────────────────────────────────
+
+test('does not overwrite an existing pay cycle, raising a pending suggestion when the pattern changed', function () {
+    $existingNextPay = CarbonImmutable::today()->addDays(5)->format('Y-m-d');
+    $this->user->update([
+        'pay_amount' => 250_000,
+        'pay_frequency' => 'monthly',
+        'next_pay_date' => $existingNextPay,
+    ]);
+    withPrimaryAccount($this->user, $this->account);
+
+    // Detected pattern differs: fortnightly 300k.
+    seedSalary($this->user, $this->account, amount: 300_000, intervalDays: 14);
+
+    $context = makePayCycleContext($this->user, isFirstSync: false);
+    $result = $this->stage->execute($context);
+
+    // A suggestion is raised for review, but the user's values are untouched.
+    expect($result->suggestionIds)->toHaveCount(1);
+
+    $suggestion = AnalysisSuggestion::find($result->suggestionIds[0]);
+    expect($suggestion->status)->toBe(SuggestionStatus::Pending);
+
+    $user = $this->user->fresh();
+    expect($user->pay_amount)->toBe(250_000)
+        ->and($user->pay_frequency)->toBe(PayFrequency::Monthly)
+        ->and($user->next_pay_date->format('Y-m-d'))->toBe($existingNextPay);
+});
+
+test('records pay_cycle_unchanged and raises no suggestion when detection matches the existing cycle', function () {
+    $this->user->update([
+        'pay_amount' => 300_000,
+        'pay_frequency' => 'fortnightly',
+        'next_pay_date' => CarbonImmutable::today()->addDays(5)->format('Y-m-d'),
+    ]);
+    withPrimaryAccount($this->user, $this->account);
+
+    seedSalary($this->user, $this->account, amount: 300_000, intervalDays: 14);
+
+    $context = makePayCycleContext($this->user, isFirstSync: false);
+    $result = $this->stage->execute($context);
+
+    expect($result->suggestionIds)->toBeEmpty();
+
+    $audit = PipelineAuditEntry::where('pipeline_run_id', $context->pipelineRun->id)
+        ->where('stage', 'set-pay-cycle')
+        ->where('action', 'pay_cycle_unchanged')
+        ->first();
+
+    expect($audit)->not->toBeNull();
+});
+
+// ──────────────────────────────────────────────
 // Next Pay Date Calculation
 // ──────────────────────────────────────────────
 
-test('calculates next pay date for weekly frequency', function () {
-    $mostRecentDate = CarbonImmutable::now()->subDays(3);
-    $transactions = [];
-    for ($i = 0; $i < 4; $i++) {
-        $transactions[] = createIncomeTransactionForPayCycle($this->user, $this->account, [
-            'description' => 'WEEKLY PAY',
-            'amount' => 150_000,
-            'post_date' => $mostRecentDate->subWeeks(3 - $i),
-        ]);
-    }
-    $transactionIds = collect($transactions)->pluck('id')->all();
+test('computes a future next pay date for each frequency', function (int $intervalDays, string $expectedFrequency) {
+    withPrimaryAccount($this->user, $this->account);
+    seedSalary($this->user, $this->account, intervalDays: $intervalDays, lastDaysAgo: 2);
 
     $context = makePayCycleContext($this->user);
-    createPrimaryAccountSuggestion($context->pipelineRun, $this->user, [
-        'account_id' => $this->account->id,
-        'income_frequency' => 'weekly',
-        'income_amount' => 150_000,
-        'income_description' => 'WEEKLY PAY',
-        'matched_transaction_ids' => $transactionIds,
-    ]);
-
     $result = $this->stage->execute($context);
 
     $suggestion = AnalysisSuggestion::find($result->suggestionIds[0]);
     $nextPayDate = CarbonImmutable::parse($suggestion->payload['next_pay_date']);
 
-    expect($nextPayDate->greaterThan(CarbonImmutable::today()))->toBeTrue()
-        ->and($nextPayDate->diffInDays($mostRecentDate))->toBeLessThanOrEqual(7);
-});
-
-test('calculates next pay date for fortnightly frequency', function () {
-    $mostRecentDate = CarbonImmutable::now()->subDays(5);
-    $transactions = [];
-    for ($i = 0; $i < 4; $i++) {
-        $transactions[] = createIncomeTransactionForPayCycle($this->user, $this->account, [
-            'description' => 'FORTNIGHTLY PAY',
-            'amount' => 200_000,
-            'post_date' => $mostRecentDate->subWeeks((3 - $i) * 2),
-        ]);
-    }
-    $transactionIds = collect($transactions)->pluck('id')->all();
-
-    $context = makePayCycleContext($this->user);
-    createPrimaryAccountSuggestion($context->pipelineRun, $this->user, [
-        'account_id' => $this->account->id,
-        'income_frequency' => 'fortnightly',
-        'income_amount' => 200_000,
-        'income_description' => 'FORTNIGHTLY PAY',
-        'matched_transaction_ids' => $transactionIds,
-    ]);
-
-    $result = $this->stage->execute($context);
-
-    $suggestion = AnalysisSuggestion::find($result->suggestionIds[0]);
-    $nextPayDate = CarbonImmutable::parse($suggestion->payload['next_pay_date']);
-
-    expect($nextPayDate->greaterThan(CarbonImmutable::today()))->toBeTrue()
-        ->and($nextPayDate->diffInDays($mostRecentDate))->toBeLessThanOrEqual(14);
-});
-
-test('calculates next pay date for monthly frequency', function () {
-    $mostRecentDate = CarbonImmutable::now()->subDays(10);
-    $transactions = [];
-    for ($i = 0; $i < 4; $i++) {
-        $transactions[] = createIncomeTransactionForPayCycle($this->user, $this->account, [
-            'description' => 'SALARY DEPOSIT',
-            'amount' => 300_000,
-            'post_date' => $mostRecentDate->subMonths(3 - $i),
-        ]);
-    }
-    $transactionIds = collect($transactions)->pluck('id')->all();
-
-    $context = makePayCycleContext($this->user);
-    createPrimaryAccountSuggestion($context->pipelineRun, $this->user, [
-        'account_id' => $this->account->id,
-        'income_frequency' => 'monthly',
-        'income_amount' => 300_000,
-        'income_description' => 'SALARY DEPOSIT',
-        'matched_transaction_ids' => $transactionIds,
-    ]);
-
-    $result = $this->stage->execute($context);
-
-    $suggestion = AnalysisSuggestion::find($result->suggestionIds[0]);
-    $nextPayDate = CarbonImmutable::parse($suggestion->payload['next_pay_date']);
-
-    expect($nextPayDate->greaterThan(CarbonImmutable::today()))->toBeTrue();
-});
-
-test('advances next pay date past today when computed date is in the past', function () {
-    $oldDate = CarbonImmutable::now()->subDays(20);
-    $transactions = [];
-    for ($i = 0; $i < 3; $i++) {
-        $transactions[] = createIncomeTransactionForPayCycle($this->user, $this->account, [
-            'description' => 'WEEKLY PAY',
-            'amount' => 150_000,
-            'post_date' => $oldDate->subWeeks(2 - $i),
-        ]);
-    }
-    $transactionIds = collect($transactions)->pluck('id')->all();
-
-    $context = makePayCycleContext($this->user);
-    createPrimaryAccountSuggestion($context->pipelineRun, $this->user, [
-        'account_id' => $this->account->id,
-        'income_frequency' => 'weekly',
-        'income_amount' => 150_000,
-        'income_description' => 'WEEKLY PAY',
-        'matched_transaction_ids' => $transactionIds,
-    ]);
-
-    $result = $this->stage->execute($context);
-
-    $suggestion = AnalysisSuggestion::find($result->suggestionIds[0]);
-    $nextPayDate = CarbonImmutable::parse($suggestion->payload['next_pay_date']);
-
-    expect($nextPayDate->greaterThan(CarbonImmutable::today()))->toBeTrue();
-});
-
-test('advances multiple intervals if needed to reach the future', function () {
-    $veryOldDate = CarbonImmutable::now()->subMonths(3);
-    $transactions = [];
-    for ($i = 0; $i < 3; $i++) {
-        $transactions[] = createIncomeTransactionForPayCycle($this->user, $this->account, [
-            'description' => 'SALARY DEPOSIT',
-            'amount' => 300_000,
-            'post_date' => $veryOldDate->subMonths(2 - $i),
-        ]);
-    }
-    $transactionIds = collect($transactions)->pluck('id')->all();
-
-    $context = makePayCycleContext($this->user);
-    createPrimaryAccountSuggestion($context->pipelineRun, $this->user, [
-        'account_id' => $this->account->id,
-        'income_frequency' => 'monthly',
-        'income_amount' => 300_000,
-        'income_description' => 'SALARY DEPOSIT',
-        'matched_transaction_ids' => $transactionIds,
-    ]);
-
-    $result = $this->stage->execute($context);
-
-    $suggestion = AnalysisSuggestion::find($result->suggestionIds[0]);
-    $nextPayDate = CarbonImmutable::parse($suggestion->payload['next_pay_date']);
-
-    expect($nextPayDate->greaterThan(CarbonImmutable::today()))->toBeTrue();
-});
-
-// ──────────────────────────────────────────────
-// Stage 1 Dependency
-// ──────────────────────────────────────────────
-
-test('returns empty result when no primary account suggestion exists for this run', function () {
-    $context = makePayCycleContext($this->user);
-
-    $result = $this->stage->execute($context);
-
-    expect($result)
-        ->success->toBeTrue()
-        ->suggestionIds->toBeEmpty();
-});
-
-test('creates audit entry when no primary account suggestion found', function () {
-    $context = makePayCycleContext($this->user);
-
-    $this->stage->execute($context);
-
-    $audit = PipelineAuditEntry::where('pipeline_run_id', $context->pipelineRun->id)
-        ->where('stage', 'set-pay-cycle')
-        ->first();
-
-    expect($audit)
-        ->action->toBe('no_primary_account_suggestion');
-});
-
-test('returns empty result with audit entry when matched transactions no longer exist', function () {
-    $context = makePayCycleContext($this->user);
-    createPrimaryAccountSuggestion($context->pipelineRun, $this->user, [
-        'account_id' => $this->account->id,
-        'matched_transaction_ids' => [99999, 99998],
-    ]);
-
-    $result = $this->stage->execute($context);
-
-    expect($result)
-        ->success->toBeTrue()
-        ->suggestionIds->toBeEmpty();
-
-    $audit = PipelineAuditEntry::where('pipeline_run_id', $context->pipelineRun->id)
-        ->where('stage', 'set-pay-cycle')
-        ->where('action', 'no_matched_transactions_found')
-        ->first();
-
-    expect($audit)->not->toBeNull()
-        ->and($audit->metadata['expected_ids'])->toBe([99999, 99998]);
-});
+    expect($suggestion->payload['pay_frequency'])->toBe($expectedFrequency)
+        ->and($nextPayDate->greaterThan(CarbonImmutable::today()))->toBeTrue();
+})->with([
+    'weekly' => [7, 'weekly'],
+    'fortnightly' => [14, 'fortnightly'],
+    'monthly' => [30, 'monthly'],
+]);
 
 // ──────────────────────────────────────────────
 // Payload
 // ──────────────────────────────────────────────
 
 test('payload contains all required fields with correct types', function () {
-    $transactions = [];
-    for ($i = 0; $i < 3; $i++) {
-        $transactions[] = createIncomeTransactionForPayCycle($this->user, $this->account, [
-            'description' => 'SALARY DEPOSIT',
-            'amount' => 300_000,
-            'post_date' => CarbonImmutable::now()->subMonths(3 - $i),
-        ]);
-    }
-    $transactionIds = collect($transactions)->pluck('id')->all();
+    withPrimaryAccount($this->user, $this->account);
+    seedSalary($this->user, $this->account, intervalDays: 30);
 
     $context = makePayCycleContext($this->user);
-    createPrimaryAccountSuggestion($context->pipelineRun, $this->user, [
-        'account_id' => $this->account->id,
-        'income_frequency' => 'monthly',
-        'income_amount' => 300_000,
-        'income_description' => 'SALARY DEPOSIT',
-        'matched_transaction_ids' => $transactionIds,
-    ]);
-
     $result = $this->stage->execute($context);
 
-    $suggestion = AnalysisSuggestion::find($result->suggestionIds[0]);
-    $payload = $suggestion->payload;
+    $payload = AnalysisSuggestion::find($result->suggestionIds[0])->payload;
 
     expect($payload)
         ->toHaveKeys([
@@ -379,40 +279,25 @@ test('payload contains all required fields with correct types', function () {
             'source_account_id',
             'source_description',
             'detected_dates',
+            'confidence_score',
         ])
         ->and($payload['pay_amount'])->toBeInt()
         ->and($payload['pay_frequency'])->toBeString()
         ->and($payload['next_pay_date'])->toBeString()
-        ->and($payload['source_account_id'])->toBeInt()
+        ->and($payload['source_account_id'])->toBe($this->account->id)
         ->and($payload['source_description'])->toBeString()
-        ->and($payload['detected_dates'])->toBeArray();
+        ->and($payload['detected_dates'])->toBeArray()
+        ->and($payload['confidence_score'])->toBeFloat();
 });
 
 test('detected dates are sorted chronologically', function () {
-    $baseDate = CarbonImmutable::now()->subMonths(3);
-    $transactions = [];
-    for ($i = 0; $i < 4; $i++) {
-        $transactions[] = createIncomeTransactionForPayCycle($this->user, $this->account, [
-            'description' => 'SALARY DEPOSIT',
-            'amount' => 300_000,
-            'post_date' => $baseDate->addMonths($i),
-        ]);
-    }
-    $transactionIds = collect($transactions)->pluck('id')->all();
+    withPrimaryAccount($this->user, $this->account);
+    seedSalary($this->user, $this->account, intervalDays: 30, count: 4);
 
     $context = makePayCycleContext($this->user);
-    createPrimaryAccountSuggestion($context->pipelineRun, $this->user, [
-        'account_id' => $this->account->id,
-        'income_frequency' => 'monthly',
-        'income_amount' => 300_000,
-        'income_description' => 'SALARY DEPOSIT',
-        'matched_transaction_ids' => $transactionIds,
-    ]);
-
     $result = $this->stage->execute($context);
 
-    $suggestion = AnalysisSuggestion::find($result->suggestionIds[0]);
-    $detectedDates = $suggestion->payload['detected_dates'];
+    $detectedDates = AnalysisSuggestion::find($result->suggestionIds[0])->payload['detected_dates'];
 
     $sorted = $detectedDates;
     sort($sorted);
@@ -421,42 +306,12 @@ test('detected dates are sorted chronologically', function () {
         ->and($detectedDates)->toHaveCount(4);
 });
 
-test('pay frequency maps correctly from Stage 1 string to PayFrequency enum value', function () {
-    $frequencies = ['weekly', 'fortnightly', 'monthly'];
-
-    foreach ($frequencies as $frequency) {
-        $transactions = [];
-        for ($i = 0; $i < 3; $i++) {
-            $transactions[] = createIncomeTransactionForPayCycle($this->user, $this->account, [
-                'description' => 'PAY '.$frequency,
-                'amount' => 200_000,
-                'post_date' => CarbonImmutable::now()->subDays(($i + 1) * 7),
-            ]);
-        }
-        $transactionIds = collect($transactions)->pluck('id')->all();
-
-        $context = makePayCycleContext($this->user);
-        createPrimaryAccountSuggestion($context->pipelineRun, $this->user, [
-            'account_id' => $this->account->id,
-            'income_frequency' => $frequency,
-            'income_amount' => 200_000,
-            'income_description' => 'PAY '.$frequency,
-            'matched_transaction_ids' => $transactionIds,
-        ]);
-
-        $result = $this->stage->execute($context);
-
-        $suggestion = AnalysisSuggestion::find($result->suggestionIds[0]);
-        expect($suggestion->payload['pay_frequency'])->toBe($frequency);
-    }
-});
-
 // ──────────────────────────────────────────────
 // Integration
 // ──────────────────────────────────────────────
 
-test('stage registered in pipeline and produces PayCycle suggestion on first sync', function () {
-    createSalaryGroupForPayCycle($this->user, $this->account, 'SALARY DEPOSIT', 300_000, 4, 30);
+test('full pipeline auto-applies pay cycle on first sync', function () {
+    seedSalary($this->user, $this->account, amount: 300_000, intervalDays: 30);
 
     $pipeline = app(TransactionAnalysisPipeline::class);
     $run = $pipeline->run($this->user, PipelineTrigger::Sync);
@@ -464,41 +319,36 @@ test('stage registered in pipeline and produces PayCycle suggestion on first syn
     expect($run->stages_completed)->toContain('identify-primary-account')
         ->and($run->stages_completed)->toContain('set-pay-cycle');
 
+    $user = $this->user->fresh();
+    expect($user->primary_account_id)->toBe($this->account->id)
+        ->and($user->pay_amount)->toBe(300_000)
+        ->and($user->pay_frequency)->toBe(PayFrequency::Monthly);
+
     $payCycleSuggestion = AnalysisSuggestion::where('pipeline_run_id', $run->id)
         ->where('type', SuggestionType::PayCycle)
         ->first();
 
     expect($payCycleSuggestion)->not->toBeNull()
-        ->and($payCycleSuggestion->payload['pay_amount'])->toBe(300_000)
-        ->and($payCycleSuggestion->payload['pay_frequency'])->toBe('monthly')
         ->and($payCycleSuggestion->payload['source_account_id'])->toBe($this->account->id);
-
-    $primaryAccountSuggestion = AnalysisSuggestion::where('pipeline_run_id', $run->id)
-        ->where('type', SuggestionType::PrimaryAccount)
-        ->first();
-
-    expect($primaryAccountSuggestion)->not->toBeNull();
 });
 
-test('stage skipped when user already has pay cycle configured', function () {
+test('re-running the pipeline never overwrites a manually-set pay cycle', function () {
+    withPrimaryAccount($this->user, $this->account);
+    $manualNextPay = CarbonImmutable::today()->addDays(6)->format('Y-m-d');
     $this->user->update([
-        'pay_amount' => 300_000,
-        'pay_frequency' => 'monthly',
-        'next_pay_date' => CarbonImmutable::now()->addDays(7),
-        'primary_account_id' => $this->account->id,
+        'pay_amount' => 199_000,
+        'pay_frequency' => 'weekly',
+        'next_pay_date' => $manualNextPay,
     ]);
-    $this->user->refresh();
 
-    createSalaryGroupForPayCycle($this->user, $this->account, 'SALARY DEPOSIT', 300_000, 4, 30);
+    // Detected pattern differs from the manual values.
+    seedSalary($this->user, $this->account, amount: 300_000, intervalDays: 30);
 
     $pipeline = app(TransactionAnalysisPipeline::class);
-    $run = $pipeline->run($this->user, PipelineTrigger::Sync);
+    $pipeline->run($this->user, PipelineTrigger::Sync);
 
-    expect($run->stages_skipped)->toContain('set-pay-cycle');
-
-    $payCycleSuggestion = AnalysisSuggestion::where('pipeline_run_id', $run->id)
-        ->where('type', SuggestionType::PayCycle)
-        ->first();
-
-    expect($payCycleSuggestion)->toBeNull();
+    $user = $this->user->fresh();
+    expect($user->pay_amount)->toBe(199_000)
+        ->and($user->pay_frequency)->toBe(PayFrequency::Weekly)
+        ->and($user->next_pay_date->format('Y-m-d'))->toBe($manualNextPay);
 });

--- a/tests/Feature/Services/PostImportAnalysisCsvTest.php
+++ b/tests/Feature/Services/PostImportAnalysisCsvTest.php
@@ -1,0 +1,86 @@
+<?php
+
+/** @noinspection StaticClosureCanBeUsedInspection */
+
+declare(strict_types=1);
+
+use App\Enums\PayFrequency;
+use App\Enums\PipelineRunStatus;
+use App\Enums\PipelineTrigger;
+use App\Enums\SuggestionType;
+use App\Enums\TransactionDirection;
+use App\Models\Account;
+use App\Models\AnalysisSuggestion;
+use App\Models\Transaction;
+use App\Models\User;
+use App\Services\TransactionAnalysisPipeline;
+use Carbon\CarbonImmutable;
+
+/**
+ * Regression coverage for issue #249: a clean CSV import produced no primary
+ * account, pay cycle, or recurring suggestions because the analysis stages
+ * filtered on source = Basiq and CSV rows were written as source = Csv.
+ *
+ * @param  array<string, mixed>  $overrides
+ */
+function importedCsvTransaction(User $user, Account $account, array $overrides): Transaction
+{
+    return Transaction::factory()
+        ->for($user)
+        ->for($account)
+        ->fromCsv()
+        ->create(array_merge(['transfer_pair_id' => null], $overrides));
+}
+
+test('a clean CSV import auto-sets the primary account and pay cycle and surfaces recurring suggestions', function () {
+    $user = User::factory()->create([
+        'primary_account_id' => null,
+        'pay_amount' => null,
+        'pay_frequency' => null,
+        'next_pay_date' => null,
+    ]);
+    $account = Account::factory()->for($user)->create();
+
+    // Fortnightly salary credits imported from CSV (the primary-account signal).
+    $lastPay = CarbonImmutable::today()->subDays(4);
+    for ($i = 0; $i < 6; $i++) {
+        importedCsvTransaction($user, $account, [
+            'description' => 'ACME PAYROLL',
+            'amount' => 320_000,
+            'direction' => TransactionDirection::Credit,
+            'post_date' => $lastPay->subDays(14 * (5 - $i)),
+        ]);
+    }
+
+    // A recurring monthly debit imported from CSV.
+    $firstDebit = CarbonImmutable::today()->subMonths(3);
+    for ($i = 0; $i < 3; $i++) {
+        importedCsvTransaction($user, $account, [
+            'description' => 'NETFLIX.COM',
+            'amount' => 1699,
+            'direction' => TransactionDirection::Debit,
+            'post_date' => $firstDebit->addMonthsNoOverflow($i),
+        ]);
+    }
+
+    $run = app(TransactionAnalysisPipeline::class)->run($user, PipelineTrigger::Sync);
+
+    expect($run->status)->toBe(PipelineRunStatus::Completed);
+
+    $user->refresh();
+
+    // Primary account and pay cycle were auto-applied from the CSV data.
+    expect($user->primary_account_id)->toBe($account->id)
+        ->and($user->pay_frequency)->toBe(PayFrequency::Fortnightly)
+        ->and($user->pay_amount)->toBe(320_000)
+        ->and($user->next_pay_date)->not->toBeNull();
+
+    // The recurring debit was surfaced as a suggestion for review.
+    $netflix = AnalysisSuggestion::query()
+        ->where('user_id', $user->id)
+        ->where('type', SuggestionType::RecurringTransaction)
+        ->get()
+        ->first(fn (AnalysisSuggestion $s): bool => $s->payload['description'] === 'NETFLIX.COM');
+
+    expect($netflix)->not->toBeNull();
+});


### PR DESCRIPTION
Closes #249.

## The problem

A clean CSV import produced **no** primary account, pay cycle, or recurring
suggestions. This was **not** a missing feature — the full
`TransactionAnalysisPipeline` already runs after every import and reported a green
`Completed` run. It produced nothing because two analysis stages filtered their
candidate queries on `source = Basiq`, while CSV imports write `source = Csv`. The
stages scanned **zero rows** and still returned success; `SetPayCycleStage` then
bailed because the primary-account suggestion it depended on never appeared.

Proven against the reporter's DB: 287 CSV rows, `pipeline_runs` #1 = `completed`,
`analysis_suggestions` empty, `primary_account_id`/`pay_frequency` null, audit
entries `no_income_pattern_detected` + `no_primary_account_suggestion`.

## What changed

- **Source scope (load-bearing fix):** new `TransactionSource::forAnalysis()`
  returns `[Basiq, Csv]`; both detection stages use it.
- **No more "false green":** stages emit a distinct `no_transactions_to_analyze`
  audit when the candidate set is empty.
- **Auto-apply high-confidence:** primary account + pay cycle auto-apply at
  confidence ≥ 0.80 into an empty slot; otherwise they stay pending suggestions.
  Recurring stays suggestion-only.
- **Guaranteed primary fallback:** detection runs first; a single eligible
  account with no detectable income is still set primary.
- **Pay cycle decoupled + always-runs, never overwrites:** detects from the
  primary account directly; unchanged → dropped, changed → pending suggestion; an
  existing cycle is never auto-overwritten.
- **Extractions:** `IncomePatternDetector` (shared salary maths) and
  `SuggestionApplier` (apply logic usable by the queued pipeline). Stages now
  resolve via the container; added a `fromCsv()` factory state.

## Out of scope (follow-ups)

- **Phase 2:** surface the three stages as user-toggleable, reorderable
  "Default Rules" on `/rules` with per-rule run status, plus the visible
  "first import = primary" notice.
- Whether `Manual`-source transactions should feed detection (currently excluded;
  an existing test encodes that decision).

## Verification

- `op lint.check` ✅ · `op analyse` (PHPStan) ✅ · `op test` ✅ **1623 passed, 0 failed**
- New e2e regression `PostImportAnalysisCsvTest` reproduces the reported scenario.

## Applying to an existing import

The reporter's pipeline already ran (and found nothing). Re-importing the same CSV
re-dispatches the analysis and is safe (dedup by `csv_hash`); since nothing was
set, `isFirstSync` is still true, so primary + pay cycle will auto-apply.
