### PR TITLE
fix(#249): prevent the salary being re-suggested as a duplicate recurring transaction

### DIFF
--- a/app/Services/PayCycleConfigurator.php
+++ b/app/Services/PayCycleConfigurator.php
@@ -8,6 +8,7 @@ use App\Enums\PayFrequency;
 use App\Enums\TransactionDirection;
 use App\Models\Category;
 use App\Models\PlannedTransaction;
+use App\Models\Transaction;
 use App\Models\User;
 use Carbon\CarbonImmutable;
 use Illuminate\Database\Eloquent\Builder;
@@ -34,6 +35,13 @@ final class PayCycleConfigurator
      * transaction is skipped because `planned_transactions.account_id` is NOT
      * NULL.
      *
+     * The detected source transactions are tagged with the income row's
+     * `planned_transaction_id` so the recurring-transaction detector excludes
+     * them and cannot re-suggest the salary as a second income planned
+     * transaction (which would double-count income in the projection).
+     *
+     * @param  list<int>  $sourceTransactionIds
+     *
      * @throws Throwable
      */
     public function apply(
@@ -42,8 +50,9 @@ final class PayCycleConfigurator
         PayFrequency $frequency,
         CarbonImmutable|string $nextPayDate,
         ?string $description = null,
+        array $sourceTransactionIds = [],
     ): void {
-        DB::transaction(function () use ($user, $payAmountCents, $frequency, $nextPayDate, $description): void {
+        DB::transaction(function () use ($user, $payAmountCents, $frequency, $nextPayDate, $description, $sourceTransactionIds): void {
             $user->update([
                 'pay_amount' => $payAmountCents,
                 'pay_frequency' => $frequency,
@@ -54,7 +63,7 @@ final class PayCycleConfigurator
                 return;
             }
 
-            PlannedTransaction::updateOrCreate(
+            $income = PlannedTransaction::updateOrCreate(
                 ['user_id' => $user->id, 'is_pay_cycle_income' => true],
                 [
                     'account_id' => $user->primary_account_id,
@@ -68,7 +77,29 @@ final class PayCycleConfigurator
                     'is_active' => true,
                 ],
             );
+
+            $this->linkSourceTransactions($user, $income, $sourceTransactionIds);
         });
+    }
+
+    /**
+     * Tag the detected salary transactions with the income row so the recurring
+     * detector's `planned_transaction_id IS NULL` filter excludes them. Only
+     * claims transactions not already linked to another planned item.
+     *
+     * @param  list<int>  $sourceTransactionIds
+     */
+    private function linkSourceTransactions(User $user, PlannedTransaction $income, array $sourceTransactionIds): void
+    {
+        if ($sourceTransactionIds === []) {
+            return;
+        }
+
+        Transaction::query()
+            ->where('user_id', $user->id)
+            ->whereIn('id', $sourceTransactionIds)
+            ->whereNull('planned_transaction_id')
+            ->update(['planned_transaction_id' => $income->id]);
     }
 
     /**

--- a/app/Services/PipelineStages/IdentifyRecurringTransactionsStage.php
+++ b/app/Services/PipelineStages/IdentifyRecurringTransactionsStage.php
@@ -10,6 +10,7 @@ use App\DTOs\StageResult;
 use App\Enums\RecurrenceFrequency;
 use App\Enums\SuggestionStatus;
 use App\Enums\SuggestionType;
+use App\Enums\TransactionDirection;
 use App\Enums\TransactionSource;
 use App\Models\AnalysisSuggestion;
 use App\Models\PipelineAuditEntry;
@@ -25,6 +26,14 @@ final readonly class IdentifyRecurringTransactionsStage implements PipelineStage
     private const float AMOUNT_TOLERANCE = 0.05;
 
     private const float MIN_CONFIDENCE = 0.40;
+
+    /**
+     * Minimum share of the smaller description's words that must also appear in
+     * the other for two descriptions to count as the same payee. High enough to
+     * separate unrelated merchants, but tolerant of the different normalisers
+     * used across stages (e.g. a deduped vs non-deduped salary description).
+     */
+    private const float DESCRIPTION_OVERLAP_THRESHOLD = 0.8;
 
     /** @var list<array{0: int, 1: int, 2: RecurrenceFrequency}> */
     private const array FREQUENCY_RANGES = [
@@ -86,8 +95,9 @@ final readonly class IdentifyRecurringTransactionsStage implements PipelineStage
 
             $normalizedDescription = $this->normalizeDescription($group->first());
             $accountId = $group->first()->account_id;
+            $direction = $group->first()->direction;
 
-            if ($this->shouldSkip($context->user, $normalizedDescription, $accountId, $analysis['frequency'], $analysis['median_amount'], $context->pipelineRun->id)) {
+            if ($this->shouldSkip($context->user, $normalizedDescription, $accountId, $direction, $analysis['frequency'], $analysis['median_amount'], $context->pipelineRun->id)) {
                 continue;
             }
 
@@ -281,7 +291,7 @@ final readonly class IdentifyRecurringTransactionsStage implements PipelineStage
         return round($confidence, 2);
     }
 
-    private function shouldSkip(User $user, string $description, int $accountId, RecurrenceFrequency $frequency, int $medianAmount, int $pipelineRunId): bool
+    private function shouldSkip(User $user, string $description, int $accountId, TransactionDirection $direction, RecurrenceFrequency $frequency, int $medianAmount, int $pipelineRunId): bool
     {
         if ($this->hasAcceptedSuggestion($user, $description, $accountId)) {
             $this->createSkipAudit($pipelineRunId, 'existing_accepted_suggestion', $description, $accountId);
@@ -289,7 +299,7 @@ final readonly class IdentifyRecurringTransactionsStage implements PipelineStage
             return true;
         }
 
-        if ($this->hasMatchingPlannedTransaction($user, $description, $accountId, $frequency, $medianAmount)) {
+        if ($this->hasMatchingPlannedTransaction($user, $description, $accountId, $direction, $frequency, $medianAmount)) {
             $this->createSkipAudit($pipelineRunId, 'existing_planned_transaction', $description, $accountId);
 
             return true;
@@ -315,22 +325,55 @@ final readonly class IdentifyRecurringTransactionsStage implements PipelineStage
             ->exists();
     }
 
-    private function hasMatchingPlannedTransaction(User $user, string $description, int $accountId, RecurrenceFrequency $frequency, int $medianAmount): bool
+    private function hasMatchingPlannedTransaction(User $user, string $description, int $accountId, TransactionDirection $direction, RecurrenceFrequency $frequency, int $medianAmount): bool
     {
         return PlannedTransaction::query()
             ->where('user_id', $user->id)
             ->where('account_id', $accountId)
+            ->where('direction', $direction)
             ->where('frequency', $frequency)
             ->where('is_active', true)
-            ->whereRaw('UPPER(description) = ?', [$description])
             ->get()
-            ->contains(function (PlannedTransaction $planned) use ($medianAmount): bool {
-                if ($medianAmount === 0) {
-                    return $planned->amount === 0;
-                }
+            ->contains(fn (PlannedTransaction $planned): bool => $this->amountsMatch($planned->amount, $medianAmount)
+                && $this->descriptionsRelated($planned->description, $description));
+    }
 
-                return abs($planned->amount - $medianAmount) / abs($medianAmount) <= self::AMOUNT_TOLERANCE;
-            });
+    private function amountsMatch(int $plannedAmount, int $medianAmount): bool
+    {
+        if ($medianAmount === 0) {
+            return $plannedAmount === 0;
+        }
+
+        return abs($plannedAmount - $medianAmount) / abs($medianAmount) <= self::AMOUNT_TOLERANCE;
+    }
+
+    /**
+     * Two descriptions count as the same payee when most of the smaller one's
+     * words also appear in the other. Tolerant of the different per-stage
+     * normalisers (the pay-cycle income description is not word-deduped, the
+     * recurring detector's is) while still separating unrelated merchants.
+     */
+    private function descriptionsRelated(string $a, string $b): bool
+    {
+        $tokensA = $this->descriptionTokens($a);
+        $tokensB = $this->descriptionTokens($b);
+
+        if ($tokensA === [] || $tokensB === []) {
+            return $tokensA === $tokensB;
+        }
+
+        $shared = count(array_intersect($tokensA, $tokensB));
+        $smaller = min(count($tokensA), count($tokensB));
+
+        return $shared / $smaller >= self::DESCRIPTION_OVERLAP_THRESHOLD;
+    }
+
+    /** @return list<string> */
+    private function descriptionTokens(string $description): array
+    {
+        preg_match_all('/[\p{L}\p{N}]+/u', mb_strtoupper($description), $matches);
+
+        return array_values(array_unique($matches[0]));
     }
 
     private function hasRecentRejection(User $user, string $description, int $accountId): bool

--- a/app/Services/PipelineStages/SetPayCycleStage.php
+++ b/app/Services/PipelineStages/SetPayCycleStage.php
@@ -85,6 +85,7 @@ final readonly class SetPayCycleStage implements PipelineStageContract
                 'next_pay_date' => $nextPayDate->format('Y-m-d'),
                 'source_account_id' => $primaryAccount->id,
                 'source_description' => $pattern->description,
+                'source_transaction_ids' => $pattern->transactionIds,
                 'detected_dates' => $pattern->detectedDates,
                 'confidence_score' => $pattern->confidence,
             ],

--- a/app/Services/SuggestionApplier.php
+++ b/app/Services/SuggestionApplier.php
@@ -43,12 +43,16 @@ final readonly class SuggestionApplier
         string $payFrequency,
         string $nextPayDate,
     ): void {
+        /** @var list<int> $sourceTransactionIds */
+        $sourceTransactionIds = $suggestion->payload['source_transaction_ids'] ?? [];
+
         $this->payCycleConfigurator->apply(
             $user,
             $payAmount,
             PayFrequency::from($payFrequency),
             $nextPayDate,
             $suggestion->payload['source_description'] ?? null,
+            $sourceTransactionIds,
         );
 
         $this->markAccepted($suggestion);

--- a/tests/Feature/Livewire/Dashboard/PayCycleCalendarTest.php
+++ b/tests/Feature/Livewire/Dashboard/PayCycleCalendarTest.php
@@ -228,6 +228,31 @@ test('matches the income deposit by description, not just amount', function () {
     expect($days[0]->iso)->toBe('2026-05-21');
 });
 
+test('anchors on the same-account amount match when the salary description has drifted', function () {
+    $this->travelTo('2026-05-31');
+    [$user, $account] = fortnightlyThursdayPayUser();
+
+    // The salary landed late (Friday 8 May) but the bank description has drifted
+    // and no longer contains the configured "WINABLE PAYROLL". The same-account,
+    // exact-amount, credit transaction is the only candidate, so the window must
+    // anchor on it (deliberate amount-only fallback) rather than silently
+    // reverting to schedule-only bounds (which would start 21 May, end 4 Jun).
+    Transaction::factory()->credit()->for($user)->for($account)->create([
+        'amount' => 570660,
+        'description' => 'ACME PTY LTD 0042',
+        'post_date' => '2026-05-08',
+    ]);
+
+    /** @var list<PayCycleDayData> $days */
+    $days = Livewire::actingAs($user)
+        ->test(PayCycleCalendar::class)
+        ->instance()
+        ->days();
+
+    expect($days[0]->iso)->toBe('2026-05-08')
+        ->and(end($days)->iso)->toBe('2026-05-21');
+});
+
 test('falls back to schedule bounds when the income has no matching deposit yet', function () {
     $this->travelTo('2026-05-31');
     [$user] = fortnightlyThursdayPayUser();

--- a/tests/Feature/Livewire/TransactionListTest.php
+++ b/tests/Feature/Livewire/TransactionListTest.php
@@ -14,6 +14,14 @@ use App\Models\User;
 use Carbon\CarbonImmutable;
 use Livewire\Livewire;
 
+beforeEach(function (): void {
+    // Pin the clock to a stable mid-month date. Several tests below create
+    // transactions at now()->subDays(N) and assert against the default
+    // "this-month" filter; without a fixed clock they break on month
+    // boundaries (e.g. a CI run on the 1st pushes subDays(5) into last month).
+    $this->travelTo(CarbonImmutable::parse('2026-06-15'));
+});
+
 test('component renders for authenticated user', function () {
     $user = User::factory()->create();
 

--- a/tests/Feature/Services/PayCycleConfiguratorTest.php
+++ b/tests/Feature/Services/PayCycleConfiguratorTest.php
@@ -10,6 +10,7 @@ use App\Enums\TransactionDirection;
 use App\Models\Account;
 use App\Models\Category;
 use App\Models\PlannedTransaction;
+use App\Models\Transaction;
 use App\Models\User;
 use App\Services\PayCycleConfigurator;
 use Carbon\CarbonImmutable;
@@ -162,4 +163,44 @@ test('the database enforces at most one pay-cycle income row per user', function
     expect(fn () => PlannedTransaction::factory()->for($this->user)->for($this->account)->create([
         'is_pay_cycle_income' => true,
     ]))->toThrow(QueryException::class);
+});
+
+test('links the provided source transactions to the income planned transaction', function () {
+    $salary = Transaction::factory()->credit()->for($this->user)->for($this->account)->count(2)->create([
+        'amount' => 300_000,
+    ]);
+
+    $this->configurator->apply(
+        $this->user,
+        300_000,
+        PayFrequency::Fortnightly,
+        CarbonImmutable::today()->addDays(7)->format('Y-m-d'),
+        'Salary',
+        $salary->pluck('id')->all(),
+    );
+
+    $income = incomePlannedTransactions($this->user)->first();
+
+    $salary->each(function (Transaction $transaction) use ($income): void {
+        expect($transaction->fresh()->planned_transaction_id)->toBe($income->id);
+    });
+});
+
+test('does not steal source transactions already linked to another planned transaction', function () {
+    $other = PlannedTransaction::factory()->for($this->user)->for($this->account)->create();
+    $already = Transaction::factory()->credit()->for($this->user)->for($this->account)->create([
+        'amount' => 300_000,
+        'planned_transaction_id' => $other->id,
+    ]);
+
+    $this->configurator->apply(
+        $this->user,
+        300_000,
+        PayFrequency::Fortnightly,
+        CarbonImmutable::today()->addDays(7)->format('Y-m-d'),
+        'Salary',
+        [$already->id],
+    );
+
+    expect($already->fresh()->planned_transaction_id)->toBe($other->id);
 });

--- a/tests/Feature/Services/PipelineStages/IdentifyRecurringTransactionsStageTest.php
+++ b/tests/Feature/Services/PipelineStages/IdentifyRecurringTransactionsStageTest.php
@@ -420,6 +420,71 @@ test('PlannedTransaction match uses 5 percent amount tolerance', function () {
     expect($result->suggestionIds)->toBeEmpty();
 });
 
+test('skips a credit already configured as pay-cycle income despite a differently-normalised description', function () {
+    // The income planned transaction stores the non-deduped description as
+    // IncomePatternDetector produces it; the recurring detector word-dedups the
+    // raw CSV description. The guard must still treat them as the same payee.
+    PlannedTransaction::factory()->for($this->user)->create([
+        'account_id' => $this->account->id,
+        'description' => 'DIRECT CREDIT WINABLE PAYROLL - WINABLE PAYROLL',
+        'direction' => TransactionDirection::Credit,
+        'frequency' => RecurrenceFrequency::Every2Weeks,
+        'amount' => 570660,
+        'is_active' => true,
+        'is_pay_cycle_income' => true,
+    ]);
+
+    $start = CarbonImmutable::parse('2026-01-15');
+
+    for ($i = 0; $i < 3; $i++) {
+        Transaction::factory()->for($this->user)->for($this->account)->fromCsv()->create([
+            'description' => 'DIRECT CREDIT WINABLE PAYROLL - WINABLE PAYROLL',
+            'amount' => 570660,
+            'direction' => TransactionDirection::Credit,
+            'post_date' => $start->addWeeks($i * 2),
+        ]);
+    }
+
+    $result = $this->stage->execute($this->context);
+
+    expect($result->suggestionIds)->toBeEmpty();
+
+    $audit = PipelineAuditEntry::query()
+        ->where('pipeline_run_id', $this->pipelineRun->id)
+        ->where('stage', 'identify-recurring-transactions')
+        ->where('action', 'skipped')
+        ->first();
+
+    expect($audit?->metadata['reason'])->toBe('existing_planned_transaction');
+});
+
+test('still suggests a different credit that only shares amount and frequency with an existing plan', function () {
+    PlannedTransaction::factory()->for($this->user)->create([
+        'account_id' => $this->account->id,
+        'description' => 'WINABLE PAYROLL',
+        'direction' => TransactionDirection::Credit,
+        'frequency' => RecurrenceFrequency::Every2Weeks,
+        'amount' => 570660,
+        'is_active' => true,
+        'is_pay_cycle_income' => true,
+    ]);
+
+    $start = CarbonImmutable::parse('2026-01-15');
+
+    for ($i = 0; $i < 3; $i++) {
+        createBasiqTransaction($this->user, $this->account, [
+            'merchant_name' => 'ACME REFUND CENTRE',
+            'amount' => 570660,
+            'direction' => TransactionDirection::Credit,
+            'post_date' => $start->addWeeks($i * 2),
+        ]);
+    }
+
+    $result = $this->stage->execute($this->context);
+
+    expect($result->suggestionIds)->toHaveCount(1);
+});
+
 // ─── Edge Cases ─────────────────────────────────────────────────────────
 
 test('ignores manually-entered transactions', function () {

--- a/tests/Feature/Services/PipelineStages/SetPayCycleStageTest.php
+++ b/tests/Feature/Services/PipelineStages/SetPayCycleStageTest.php
@@ -295,6 +295,7 @@ test('payload contains all required fields with correct types', function () {
             'next_pay_date',
             'source_account_id',
             'source_description',
+            'source_transaction_ids',
             'detected_dates',
             'confidence_score',
         ])
@@ -303,8 +304,33 @@ test('payload contains all required fields with correct types', function () {
         ->and($payload['next_pay_date'])->toBeString()
         ->and($payload['source_account_id'])->toBe($this->account->id)
         ->and($payload['source_description'])->toBeString()
+        ->and($payload['source_transaction_ids'])->toBeArray()
         ->and($payload['detected_dates'])->toBeArray()
         ->and($payload['confidence_score'])->toBeFloat();
+});
+
+test('auto-applying the pay cycle links the detected salary transactions to the income planned transaction', function () {
+    withPrimaryAccount($this->user, $this->account);
+    seedSalary($this->user, $this->account, amount: 300_000, intervalDays: 14);
+
+    $context = makePayCycleContext($this->user);
+    $this->stage->execute($context);
+
+    $income = PlannedTransaction::query()
+        ->where('user_id', $this->user->id)
+        ->where('is_pay_cycle_income', true)
+        ->firstOrFail();
+
+    $salaryCredits = Transaction::query()
+        ->where('user_id', $this->user->id)
+        ->where('direction', TransactionDirection::Credit)
+        ->get();
+
+    expect($salaryCredits)->not->toBeEmpty();
+
+    $salaryCredits->each(
+        fn (Transaction $transaction) => expect($transaction->planned_transaction_id)->toBe($income->id),
+    );
 });
 
 test('detected dates are sorted chronologically', function () {

--- a/tests/Feature/Services/PostImportAnalysisCsvTest.php
+++ b/tests/Feature/Services/PostImportAnalysisCsvTest.php
@@ -76,11 +76,17 @@ test('a clean CSV import auto-sets the primary account and pay cycle and surface
         ->and($user->next_pay_date)->not->toBeNull();
 
     // The recurring debit was surfaced as a suggestion for review.
-    $netflix = AnalysisSuggestion::query()
+    $recurring = AnalysisSuggestion::query()
         ->where('user_id', $user->id)
         ->where('type', SuggestionType::RecurringTransaction)
-        ->get()
-        ->first(fn (AnalysisSuggestion $s): bool => $s->payload['description'] === 'NETFLIX.COM');
+        ->get();
 
-    expect($netflix)->not->toBeNull();
+    expect($recurring->first(fn (AnalysisSuggestion $s): bool => $s->payload['description'] === 'NETFLIX.COM'))
+        ->not->toBeNull();
+
+    // The salary is NOT also surfaced as a recurring credit — it is already the
+    // pay-cycle income planned transaction, so re-suggesting it would create a
+    // duplicate income row and double-count income in the projection.
+    expect($recurring->first(fn (AnalysisSuggestion $s): bool => str_contains((string) $s->payload['description'], 'ACME PAYROLL')))
+        ->toBeNull();
 });


### PR DESCRIPTION
## Summary

Follow-up to #251. Closes the double-count gap flagged there: after a CSV import
auto-applies the pay cycle, the recurring-transaction detector could *also*
suggest the salary as a recurring credit. Accepting it would create a second
income planned transaction alongside the `is_pay_cycle_income` one and
double-count income in the projection.

> **Stacked on #251.** This branch builds on `fix/249-post-import-csv-analysis`,
> so the diff against `develop` currently includes #251's commits too. The
> changes unique to this PR are its two commits:
> - `fix(#249): match the recurring-transaction guard on financial fingerprint`
> - `fix(#249): link salary transactions to the income row so they are not re-detected`
>
> Merge #251 first; this PR's diff then collapses to just those two.

## The two gaps (two-layer fix)

The recurring detector already skips patterns already configured as planned
transactions, but the salary slipped through two cracks:

**A - brittle description match.** The skip guard required `UPPER(description)` to
be *exactly* equal, but the income planned transaction's description (from
`IncomePatternDetector`) and the recurring detector's `cleanRawDescription()`
differ by word-dedup for a CSV salary. The guard now matches on the **financial
fingerprint - account + direction + frequency + amount-within-tolerance** - with a
token-set description check (>= 80% word overlap) instead of exact equality. This
is the general "don't duplicate any planned transaction" guard, and it adds the
previously-missing `direction` filter.

**B - sources never linked.** Accepted recurring suggestions tag their source
transactions with `planned_transaction_id` (so they are excluded next run); the
pay-cycle income transaction did not. `PayCycleConfigurator` now tags the detected
salary transactions (threaded from `SetPayCycleStage`'s payload) with the income
row's `planned_transaction_id`, reusing the existing `planned_transaction_id IS
NULL` exclusion. Defense in depth with A.

## Testing

- `op test`: **1646 passed, 4 skipped, 0 failures**. Pint clean, PHPStan no errors.
- New: fingerprint guard skips a differently-normalised salary description but not
  an unrelated same-amount credit; `PayCycleConfigurator` links sources and will
  not steal already-linked ones; auto-apply links the salary; and **end-to-end - a
  clean CSV import no longer surfaces the salary as a recurring suggestion.**

## Known limitation (flagged, not fixed)

If the pay cycle is only a *pending* suggestion (not auto-applied), the income
transaction does not exist yet, so neither layer excludes the salary from
recurring detection in that same run. Accepting both the recurring salary and the
pay cycle could then still create two income rows. Rare (high-confidence imports
auto-apply); can be closed later by also skipping recurring groups that match a
pending pay-cycle suggestion.

Relates to #249.
