### PR TITLE
fix(#263): improve recurring transaction detection

### DIFF
--- a/app/Services/PipelineStages/IdentifyRecurringTransactionsStage.php
+++ b/app/Services/PipelineStages/IdentifyRecurringTransactionsStage.php
@@ -45,15 +45,22 @@ final readonly class IdentifyRecurringTransactionsStage implements PipelineStage
      */
     private const float DESCRIPTION_OVERLAP_THRESHOLD = 0.8;
 
-    /** @var list<array{0: int, 1: int, 2: RecurrenceFrequency}> */
-    private const array FREQUENCY_RANGES = [
-        [5, 9, RecurrenceFrequency::EveryWeek],
-        [12, 16, RecurrenceFrequency::Every2Weeks],
-        [19, 23, RecurrenceFrequency::Every3Weeks],
-        [27, 35, RecurrenceFrequency::EveryMonth],
-        [80, 100, RecurrenceFrequency::Every3Months],
-        [160, 200, RecurrenceFrequency::Every6Months],
-        [340, 395, RecurrenceFrequency::EveryYear],
+    /**
+     * Canonical cadence anchors (days) and their frequency. The median interval
+     * snaps to the nearest anchor within tolerance, so there are no unmatched
+     * gaps (e.g. 10d -> weekly, 24d -> three-weekly) and calendar-month wobble
+     * (28-31d) still resolves to monthly.
+     *
+     * @var list<array{0: int, 1: RecurrenceFrequency}>
+     */
+    private const array FREQUENCY_TARGETS = [
+        [7, RecurrenceFrequency::EveryWeek],
+        [14, RecurrenceFrequency::Every2Weeks],
+        [21, RecurrenceFrequency::Every3Weeks],
+        [30, RecurrenceFrequency::EveryMonth],
+        [91, RecurrenceFrequency::Every3Months],
+        [182, RecurrenceFrequency::Every6Months],
+        [365, RecurrenceFrequency::EveryYear],
     ];
 
     public function key(): string
@@ -274,13 +281,20 @@ final readonly class IdentifyRecurringTransactionsStage implements PipelineStage
 
     private function mapIntervalToFrequency(float $medianInterval): ?RecurrenceFrequency
     {
-        foreach (self::FREQUENCY_RANGES as [$min, $max, $frequency]) {
-            if ($medianInterval >= $min && $medianInterval <= $max) {
-                return $frequency;
+        $best = null;
+        $bestDistance = INF;
+
+        foreach (self::FREQUENCY_TARGETS as [$target, $frequency]) {
+            $distance = abs($medianInterval - $target);
+            $tolerance = max(4.0, $target * 0.2);
+
+            if ($distance <= $tolerance && $distance < $bestDistance) {
+                $bestDistance = $distance;
+                $best = $frequency;
             }
         }
 
-        return null;
+        return $best;
     }
 
     /** @param Collection<int, mixed> $values */

--- a/app/Services/PipelineStages/IdentifyRecurringTransactionsStage.php
+++ b/app/Services/PipelineStages/IdentifyRecurringTransactionsStage.php
@@ -17,6 +17,7 @@ use App\Models\PipelineAuditEntry;
 use App\Models\PlannedTransaction;
 use App\Models\Transaction;
 use App\Models\User;
+use App\Support\Recurring\MerchantSignature;
 use Illuminate\Support\Collection;
 
 final readonly class IdentifyRecurringTransactionsStage implements PipelineStageContract
@@ -130,37 +131,13 @@ final readonly class IdentifyRecurringTransactionsStage implements PipelineStage
 
     private function normalizeDescription(Transaction $transaction): string
     {
-        if ($transaction->merchant_name !== null && $transaction->merchant_name !== '') {
-            return mb_strtoupper(mb_trim($transaction->merchant_name));
-        }
+        $source = match (true) {
+            $transaction->merchant_name !== null && $transaction->merchant_name !== '' => $transaction->merchant_name,
+            $transaction->clean_description !== null && $transaction->clean_description !== '' => $transaction->clean_description,
+            default => $transaction->description,
+        };
 
-        if ($transaction->clean_description !== null && $transaction->clean_description !== '') {
-            return mb_strtoupper(mb_trim($transaction->clean_description));
-        }
-
-        return $this->cleanRawDescription($transaction->description);
-    }
-
-    private function cleanRawDescription(string $description): string
-    {
-        $cleaned = preg_replace('/\s+\d{4,}.*$/', '', $description);
-        $cleaned = preg_replace('/\s+\d{1,2}[\/\-]\d{1,2}$/', '', $cleaned);
-        $cleaned = preg_replace('/\s+[A-Z]{2}$/', '', $cleaned);
-
-        $words = explode(' ', mb_trim($cleaned));
-        $deduped = [];
-        $seen = [];
-
-        foreach ($words as $word) {
-            $upper = mb_strtoupper($word);
-
-            if (! in_array($upper, $seen, true)) {
-                $deduped[] = $word;
-                $seen[] = $upper;
-            }
-        }
-
-        return mb_strtoupper(mb_trim(implode(' ', $deduped)));
+        return MerchantSignature::for($source);
     }
 
     /**

--- a/app/Services/PipelineStages/IdentifyRecurringTransactionsStage.php
+++ b/app/Services/PipelineStages/IdentifyRecurringTransactionsStage.php
@@ -333,6 +333,12 @@ final readonly class IdentifyRecurringTransactionsStage implements PipelineStage
 
     private function shouldSkip(User $user, string $description, int $accountId, TransactionDirection $direction, RecurrenceFrequency $frequency, int $medianAmount, int $pipelineRunId): bool
     {
+        if ($this->isNoise($description)) {
+            $this->createSkipAudit($pipelineRunId, 'noise', $description, $accountId);
+
+            return true;
+        }
+
         if ($this->hasAcceptedSuggestion($user, $description, $accountId)) {
             $this->createSkipAudit($pipelineRunId, 'existing_accepted_suggestion', $description, $accountId);
 
@@ -352,6 +358,22 @@ final readonly class IdentifyRecurringTransactionsStage implements PipelineStage
         }
 
         return false;
+    }
+
+    /**
+     * Round-up sweeps and internal own-account transfers (to savings / credit
+     * card) are regular but are not bills, so they must not be offered as
+     * recurring suggestions even when their amount happens to be constant.
+     */
+    private function isNoise(string $signature): bool
+    {
+        if (str_starts_with($signature, 'ROUND UP')) {
+            return true;
+        }
+
+        return str_starts_with($signature, 'TRANSFER')
+            && str_contains($signature, ' TO ')
+            && (preg_match('/\bSAV\b/', $signature) === 1 || preg_match('/\bCC\b/', $signature) === 1);
     }
 
     private function hasAcceptedSuggestion(User $user, string $description, int $accountId): bool

--- a/app/Services/PipelineStages/IdentifyRecurringTransactionsStage.php
+++ b/app/Services/PipelineStages/IdentifyRecurringTransactionsStage.php
@@ -28,6 +28,15 @@ final readonly class IdentifyRecurringTransactionsStage implements PipelineStage
 
     private const float MIN_CONFIDENCE = 0.40;
 
+    /** Two amounts belong to the same level when within this many cents, or … */
+    private const int AMOUNT_TOLERANCE_CENTS = 50;
+
+    /** … this fraction of the amount, whichever is larger (covers big bills). */
+    private const float AMOUNT_TOLERANCE_PCT = 0.02;
+
+    /** Share of occurrences that must sit in the dominant amount cluster. */
+    private const float DOMINANT_SHARE = 0.60;
+
     /**
      * Minimum share of the smaller description's words that must also appear in
      * the other for two descriptions to count as the same payee. High enough to
@@ -147,9 +156,9 @@ final readonly class IdentifyRecurringTransactionsStage implements PipelineStage
     private function analyzeGroup(Collection $group): ?array
     {
         $amounts = $group->pluck('amount');
-        $medianAmount = $this->calculateMedian($amounts);
+        $cluster = $this->dominantCluster($amounts);
 
-        if (! $this->checkAmountConsistency($amounts, $medianAmount)) {
+        if ($cluster->count() / $group->count() < self::DOMINANT_SHARE) {
             return null;
         }
 
@@ -159,14 +168,13 @@ final readonly class IdentifyRecurringTransactionsStage implements PipelineStage
             return null;
         }
 
-        $medianInterval = $this->calculateMedian($intervals);
-        $frequency = $this->mapIntervalToFrequency($medianInterval);
+        $frequency = $this->mapIntervalToFrequency($this->calculateMedian($intervals));
 
         if ($frequency === null) {
             return null;
         }
 
-        $amountCV = $this->coefficientOfVariation($amounts);
+        $amountCV = $this->coefficientOfVariation($cluster);
         $intervalCV = $this->coefficientOfVariation($intervals);
         $confidence = $this->calculateConfidence($group->count(), $amountCV, $intervalCV);
 
@@ -176,7 +184,7 @@ final readonly class IdentifyRecurringTransactionsStage implements PipelineStage
 
         return [
             'frequency' => $frequency,
-            'median_amount' => (int) round($medianAmount),
+            'median_amount' => $this->recurringAmount($group),
             'confidence' => $confidence,
         ];
     }
@@ -194,16 +202,57 @@ final readonly class IdentifyRecurringTransactionsStage implements PipelineStage
         return (float) $sorted[intdiv($count, 2)];
     }
 
-    /** @param Collection<int, mixed> $amounts */
-    private function checkAmountConsistency(Collection $amounts, float $median): bool
+    private function amountTolerance(int $amount): float
     {
-        if ($median === 0.0) {
-            return $amounts->every(fn (int|float $amount): bool => $amount === 0);
+        return max((float) self::AMOUNT_TOLERANCE_CENTS, abs($amount) * self::AMOUNT_TOLERANCE_PCT);
+    }
+
+    /**
+     * The largest set of amounts that sit within tolerance of a common level.
+     * Survives one-off outliers (a double-debit) and premium step-changes,
+     * unlike requiring every amount to match a single median.
+     *
+     * @param  Collection<int, int>  $amounts
+     * @return Collection<int, int>
+     */
+    private function dominantCluster(Collection $amounts): Collection
+    {
+        $best = collect();
+
+        foreach ($amounts->unique() as $anchor) {
+            $tolerance = $this->amountTolerance((int) $anchor);
+            $members = $amounts->filter(
+                fn (int $amount): bool => abs($amount - $anchor) <= $tolerance,
+            )->values();
+
+            if ($members->count() > $best->count()) {
+                $best = $members;
+            }
         }
 
-        return $amounts->every(
-            fn (int|float $amount): bool => abs($amount - $median) / abs($median) <= self::AMOUNT_TOLERANCE,
-        );
+        return $best;
+    }
+
+    /**
+     * Amount to suggest: the current/most-recent stable level. A steady series
+     * returns its amount; a sustained step-change returns the latest level; a
+     * single trailing outlier falls back to the dominant cluster.
+     *
+     * @param  Collection<int, Transaction>  $group
+     */
+    private function recurringAmount(Collection $group): int
+    {
+        $amounts = $group->pluck('amount');
+        $latest = (int) $group->sortByDesc('post_date')->first()->amount;
+        $tolerance = $this->amountTolerance($latest);
+
+        $recent = $amounts->filter(fn (int $amount): bool => abs($amount - $latest) <= $tolerance)->values();
+
+        if ($recent->count() >= 2) {
+            return (int) round($this->calculateMedian($recent));
+        }
+
+        return (int) round($this->calculateMedian($this->dominantCluster($amounts)));
     }
 
     /**

--- a/app/Support/Recurring/MerchantSignature.php
+++ b/app/Support/Recurring/MerchantSignature.php
@@ -11,18 +11,24 @@ namespace App\Support\Recurring;
  * the meaningful payee words and discard the per-transaction noise that
  * otherwise splits one payee into many singletons: reference numbers, account
  * numbers, direct-debit codes (DT.xxxx), Ref#/NET#/MOBILE#/BPAY# markers,
- * bcx:int codes, card masks (#1234) and dates.
+ * bcx:int codes, card masks (#1234), dates, and random alphanumeric references.
  *
- * Rule of thumb: keep a whitespace token only when it reads like a word — no
- * digits, no '#'/':' reference markers, at least two characters after trimming
- * edge punctuation.
+ * A token is kept when it reads like a payee word. It is dropped as a code when
+ * it carries a '#'/':' marker, or contains a digit without being a plain
+ * "number-word" — a single digit run at one boundary adjacent to a letter body,
+ * e.g. "7-ELEVEN" or "4WD". This preserves merchant names that contain digits
+ * while still discarding interspersed/multi-run codes (DT.4Y16G4, E5MRRQ7T) and
+ * pure numbers (86400, 64699390).
+ *
+ * If every token is filtered out, the raw normalized string is returned rather
+ * than an empty signature, so unrelated all-code descriptions are not merged.
  */
 final class MerchantSignature
 {
     public static function for(string $raw): string
     {
-        $upper = mb_strtoupper(mb_trim($raw));
-        $tokens = preg_split('/\s+/', $upper) ?: [];
+        $normalized = self::normalize($raw);
+        $tokens = preg_split('/\s+/', $normalized) ?: [];
 
         $kept = [];
 
@@ -33,14 +39,7 @@ final class MerchantSignature
                 continue;
             }
 
-            // Reference markers (Ref#, NET#, bcx:int, …) and any token carrying a
-            // digit (account/policy/transaction codes such as DT.4Y16G4) are the
-            // parts that vary between occurrences of the same payee.
-            if (str_contains($token, '#') || str_contains($token, ':')) {
-                continue;
-            }
-
-            if (preg_match('/\d/', $token) === 1) {
+            if (self::isCodeToken($token)) {
                 continue;
             }
 
@@ -54,7 +53,35 @@ final class MerchantSignature
             $kept[] = $token;
         }
 
-        return implode(' ', $kept);
+        return $kept === [] ? $normalized : implode(' ', $kept);
+    }
+
+    private static function normalize(string $raw): string
+    {
+        return mb_strtoupper(mb_trim((string) preg_replace('/\s+/', ' ', $raw)));
+    }
+
+    /**
+     * A token is a reference/account code (drop it) when it carries a '#'/':'
+     * marker, or it contains a digit and is not a plain number-word.
+     */
+    private static function isCodeToken(string $token): bool
+    {
+        if (str_contains($token, '#') || str_contains($token, ':')) {
+            return true;
+        }
+
+        if (preg_match('/\d/', $token) !== 1) {
+            return false;
+        }
+
+        // Number-word: a single digit run at one boundary next to a letter body,
+        // e.g. "7-ELEVEN", "4WD", "LEVEL5". Anything else with a digit (pure
+        // numbers, DT.4Y16G4, E5MRRQ7T) is a code.
+        $leadingDigits = preg_match('/^\d+-?\p{L}[\p{L}.&\'\/-]*$/u', $token) === 1;
+        $trailingDigits = preg_match('/^\p{L}[\p{L}.&\'\/-]*-?\d+$/u', $token) === 1;
+
+        return ! ($leadingDigits || $trailingDigits);
     }
 
     /**

--- a/app/Support/Recurring/MerchantSignature.php
+++ b/app/Support/Recurring/MerchantSignature.php
@@ -44,6 +44,13 @@ final class MerchantSignature
                 continue;
             }
 
+            // Collapse an adjacent duplicate word (e.g. "MCF MCF", "NETFLIX.COM
+            // NETFLIX.COM") which some statement formats emit; non-adjacent
+            // repeats (e.g. "TO ... TO") are preserved so distinct payees stay apart.
+            if ($kept !== [] && end($kept) === $token) {
+                continue;
+            }
+
             $kept[] = $token;
         }
 

--- a/app/Support/Recurring/MerchantSignature.php
+++ b/app/Support/Recurring/MerchantSignature.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support\Recurring;
+
+/**
+ * Derives a stable "payee signature" from a bank transaction description.
+ *
+ * Recurring detection groups transactions by this signature, so it must keep
+ * the meaningful payee words and discard the per-transaction noise that
+ * otherwise splits one payee into many singletons: reference numbers, account
+ * numbers, direct-debit codes (DT.xxxx), Ref#/NET#/MOBILE#/BPAY# markers,
+ * bcx:int codes, card masks (#1234) and dates.
+ *
+ * Rule of thumb: keep a whitespace token only when it reads like a word — no
+ * digits, no '#'/':' reference markers, at least two characters after trimming
+ * edge punctuation.
+ */
+final class MerchantSignature
+{
+    public static function for(string $raw): string
+    {
+        $upper = mb_strtoupper(mb_trim($raw));
+        $tokens = preg_split('/\s+/', $upper) ?: [];
+
+        $kept = [];
+
+        foreach ($tokens as $token) {
+            $token = self::trimEdges($token);
+
+            if (mb_strlen($token) < 2) {
+                continue;
+            }
+
+            // Reference markers (Ref#, NET#, bcx:int, …) and any token carrying a
+            // digit (account/policy/transaction codes such as DT.4Y16G4) are the
+            // parts that vary between occurrences of the same payee.
+            if (str_contains($token, '#') || str_contains($token, ':')) {
+                continue;
+            }
+
+            if (preg_match('/\d/', $token) === 1) {
+                continue;
+            }
+
+            $kept[] = $token;
+        }
+
+        return implode(' ', $kept);
+    }
+
+    /**
+     * Strip leading/trailing non-alphanumerics while preserving internal
+     * punctuation, so "-NETFLIX.COM" -> "NETFLIX.COM" and "TMR-PRODUCT" is kept
+     * intact, while a lone "-" collapses to an empty (dropped) token.
+     */
+    private static function trimEdges(string $token): string
+    {
+        return preg_replace('/^[^\p{L}\p{N}]+|[^\p{L}\p{N}]+$/u', '', $token) ?? $token;
+    }
+}

--- a/docs/plans/2026-06-01-recurring-transaction-detection.md
+++ b/docs/plans/2026-06-01-recurring-transaction-detection.md
@@ -1,6 +1,6 @@
 # Recurring Transaction Detection — Improvement Plan
 
-> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+> Implement incrementally, test-first: write the failing test for each task, make it pass, then commit before moving on.
 
 **Goal:** Make import-time recurring-transaction detection actually find the recurring bills in a statement by matching on the *stable payee text* (ignoring per-transaction reference codes), tolerating small amount drift / step-changes, and accepting a ±2-day cadence — without over-merging unrelated payees.
 

--- a/docs/plans/2026-06-01-recurring-transaction-detection.md
+++ b/docs/plans/2026-06-01-recurring-transaction-detection.md
@@ -1,0 +1,256 @@
+# Recurring Transaction Detection — Improvement Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make import-time recurring-transaction detection actually find the recurring bills in a statement by matching on the *stable payee text* (ignoring per-transaction reference codes), tolerating small amount drift / step-changes, and accepting a ±2-day cadence — without over-merging unrelated payees.
+
+**Architecture:** Extract description→payee normalisation into a dedicated, unit-tested `MerchantSignature` support class; switch the existing `IdentifyRecurringTransactionsStage` from exact-cleaned-string grouping to signature grouping; replace the brittle "every amount within ±5%" gate with dominant-amount clustering that survives outliers and premium step-changes; gap-fill the interval→frequency mapping and add a day-of-month monthly detector; add a noise filter for round-ups/internal transfers. No schema changes — same `AnalysisSuggestion` payload shape.
+
+**Tech Stack:** PHP 8.4, Laravel 12, Pest 4. Runs inside DDEV (`op test*`). No new packages.
+
+---
+
+## Background — why it misses so much (measured on the real Beyond Bank CSV)
+
+The detector is a single pipeline stage: `app/Services/PipelineStages/IdentifyRecurringTransactionsStage.php`. It:
+1. groups unmatched txns by `normalizeDescription | direction | account_id` (an **exact** string key),
+2. rejects a group unless **every** amount is within ±5% of the median (`AMOUNT_TOLERANCE = 0.05`, `->every(...)`),
+3. maps the **median interval** to hard frequency ranges with **gaps** (10–11, 17–18, 24–26, 36–79 days are unmatchable),
+4. gates on a confidence ≥ 0.40 that is heavily penalised by interval variance.
+
+`normalizeDescription` → `cleanRawDescription` only strips a trailing 4+ digit run (`/\s+\d{4,}.*$/`), a trailing date, and a trailing 2-letter token, then dedupes repeated words. That regex truncates at the **first** long digit run, which is usually *mid-string*, and never touches `Ref#…`, `NET#…`, `MOBILE#…`, `DT.xxxx`, `bcx:int…`, or policy codes.
+
+Measured against `context/Optimus-2026-01-to-05.csv` (291 rows, Jan–May 2026):
+
+| | Current normaliser | Signature-based (proposed) |
+|---|---|---|
+| Distinct debit keys | 97 | 55 |
+| **Suggestions actually emitted** | **6** (2 are the *same* rent split by a `NET#`+amount change; 2 are noise Twitch pairs) → ~3 useful | **13 fixed-amount bills** + 10 variable-cadence series |
+
+Two concrete failure modes, both observed:
+
+- **Over-truncation / false merge.** `cleanRawDescription("Osko Payment To 86400 Account 10386227 YOU - UBank Ref#…")` → `"OSKO PAYMENT TO"`, collapsing **17** unrelated payees (amounts $50–$300+) into one key that the amount gate then rejects. `"DIRECT DEBIT"` alone swallows 7 unrelated debits.
+- **Under-grouping (the bugs you reported).** A varying code splits one payee into singletons that never group:
+  - `Direct Debit Fair Go Finance - DT.4y16g4 FGF 2472` vs `… DT.4yx8ph FGF 2472` → two keys → **missed** (it's a $85 **weekly**, 21 occurrences).
+  - `Direct Debit QBE Insurance … bcx:int<varies>` → **missed** ($60.58 monthly, 5 occurrences).
+  - `Direct Debit NIB - 64699390` groups, but the premium **stepped $90.59 → $95.81** mid-series, so the `every ≤5%` gate rejects it.
+  - `Direct Debit Golden Insurance - PLCY 082212484-015` groups, but a **double-debit** ($70.17 → $140.34) trips `every`.
+
+Recurring bills that **should** surface (signature grouping + amount cluster + ±2-day cadence):
+
+```
+$85.00   weekly       Direct Debit Fair Go Finance        (21x)
+$770.00  weekly       Ext Tfr → Sekisui House (rent)      (16x)
+$750.00  weekly       Ext Tfr → Real Living (prior rent)  (6x)
+$200.00  weekly       Direct Debit Spaceship              (16x)
+$173.90  fortnightly  Direct Debit MCF                    (10x)
+$90.59→$95.81 fortnightly Direct Debit NIB (step-change)  (11x)
+$70.17   fortnightly  Direct Debit Golden Insurance       (9x, +1 double)
+$28.99   monthly      Netflix                             (5x)
+$47.20   monthly      Direct Debit TMR-Product Payt       (5x)
+$60.58   monthly      Direct Debit QBE Insurance          (5x)
+```
+
+(Round-ups, internal "Transfer Optimus to CC to SAV", and YOU-UBank transfers are **variable-amount** and should NOT be offered as fixed recurring bills — see Task 6.)
+
+---
+
+## Design
+
+### 1. `MerchantSignature` (new support class) — the heart of the fix
+Pure function: raw bank description → a stable, uppercase **payee signature** used as the grouping key. Steps, in order:
+1. If a Basiq `merchant_name` exists, use it (uppercased, trimmed) — already clean.
+2. Otherwise normalise the raw description:
+   - uppercase; collapse runs of whitespace to one space.
+   - **Remove reference tokens anywhere in the string** via a token pass (not a greedy `.*$`): drop any *word* that
+     - matches a known prefix: `REF#…`, `NET#…`, `MOBILE#…`, `BPAY#…`, `DT.…`, `BCX:…`, `PLCY…`, `ACCOUNT` followed by digits;
+     - contains **any digit** (covers `64699390`, `082212484-015`, `DT.4Y16G4`, `10386227`, `724493`, `#2892`, `2472`, `050126`);
+     - is a card mask `#\d{3,4}` or a `dd/mm`/`ddmmyy` date.
+   - Keep alpha words (letters, plus internal `.&'/-`), e.g. `NETFLIX.COM`, `APPLE.COM/BILL`, `TMR-PRODUCT`.
+   - Re-join; trim stray separators (`-`, `:`). Do **not** word-dedup (that mangles "MCF MCF"→"MCF" which is fine, but "to … to …" dedup distorts — drop the dedup step entirely).
+3. Return the signature string. Empty signature (all tokens were codes) ⇒ treat as un-groupable (return raw uppercased, so it can only match an identical raw).
+
+Required behaviours (these become the unit tests — use the real examples):
+
+| Raw description | Signature |
+|---|---|
+| `Direct Debit NIB - 64699390` | `DIRECT DEBIT NIB` |
+| `Direct Debit QBE Insurance - bcx:int 4821` | `DIRECT DEBIT QBE INSURANCE` |
+| `Direct Debit Fair Go Finance - DT.4y16g4 FGF 2472` | `DIRECT DEBIT FAIR GO FINANCE FGF` |
+| `Direct Debit Fair Go Finance - DT.4yx8ph FGF 2472` | `DIRECT DEBIT FAIR GO FINANCE FGF` (same as above) |
+| `Osko Payment To 86400 Account 10386227 YOU - UBank Ref#885214478` | `OSKO PAYMENT TO YOU UBANK` |
+| `Osko Payment To Nikolai Taylor Account 188722557 ANZ - Indooroo Ref#885214478` | `OSKO PAYMENT TO NIKOLAI TAYLOR ANZ INDOOROO` (must **not** equal the YOU-UBank one) |
+| `VISA -Netflix.com   Melbourne    AU  724493 #2892` | `VISA NETFLIX.COM MELBOURNE AU` |
+
+> Invariant the tests must lock: the two Fair Go variants collapse to **one** signature; the two different Osko payees stay **distinct**.
+
+### 2. Amount: dominant cluster, not `every`
+Replace `checkAmountConsistency(... ->every ...)` with cluster logic:
+- Tolerance per amount = `max(50 cents, 2% of amount)` (your "±a few cents", widened proportionally for big amounts).
+- Find the **dominant amount cluster** (the amount whose tolerance window contains the most occurrences). The "recurring amount" = median of that cluster.
+- Accept the group if the dominant cluster covers **≥ 60%** of occurrences (survives a one-off double like Golden Insurance, and outliers).
+- **Step-change handling:** if the *non-dominant* occurrences form a second cluster that is *contiguous in time after* the dominant one (e.g. NIB $90.59 then $95.81), use the **latest** stable amount for the suggestion and still accept. (Implement as: sort by date, take the amount of the most-recent cluster as the suggested amount.)
+
+### 3. Cadence: gap-free frequency + day-of-month monthly
+- Compute intervals between dominant-cluster occurrences (sorted by date). Use the **median** interval.
+- Map to the nearest canonical frequency with a **±3-day tolerance and no gaps** (snap to the closest of: 7, 14, 21, 28–31, 91, 182, 365). Monthly is special: also accept when occurrences share a **day-of-month ±2** even if raw intervals wobble 28–31.
+- A single missed/extra occurrence must not break detection (median is robust; don't require `every` interval).
+- Keep requiring **≥ 3** occurrences for a confident suggestion (raise from 2 — 2 points is too weak a cadence signal and inflates false positives now that grouping is looser). Document this tradeoff.
+
+### 4. Recall tuning
+- Recompute confidence from: occurrence count, dominant-cluster share, and cadence regularity. Lower `MIN_CONFIDENCE` to **0.35** and stop hard-penalising minor interval variance (the day-of-month path covers monthly wobble). You'd rather over-offer and let the user **Dismiss** (Dismiss already persists a 90-day rejection via `hasRecentRejection`).
+
+### 5. Noise filter (avoid offering non-bills)
+Skip a group from *fixed-bill* suggestions when its signature is internal-transfer / round-up noise:
+- signature starts with `ROUND UP TRANSFER`, or
+- signature matches an internal own-account transfer pattern (`TRANSFER … TO … SAV`, `TRANSFER … TO CC`), or
+- the dominant cluster covers < 60% (genuinely variable amount — e.g. YOU-UBank transfers).
+Record skips as `PipelineAuditEntry` with a reason (mirrors existing `createSkipAudit`).
+
+### 6. Shared normaliser (consistency)
+`PlannedTransactionMatcher` (the match-at-import tagging) and this detector must agree on payee identity. After `MerchantSignature` exists, route both through it so a detected/accepted plan re-matches its own future imports. (Separate task; behind the same class.)
+
+---
+
+## Tasks
+
+### Task 1: `MerchantSignature` support class (unit-tested)
+
+**Files:**
+- Create: `app/Support/Recurring/MerchantSignature.php`
+- Create test: `tests/Unit/Support/Recurring/MerchantSignatureTest.php`
+
+**Step 1 — Write failing tests** (one `it()` per row of the Design §1 table, plus the two invariants):
+```php
+use App\Support\Recurring\MerchantSignature;
+
+it('strips trailing reference numbers', fn () => expect(MerchantSignature::for('Direct Debit NIB - 64699390'))->toBe('DIRECT DEBIT NIB'));
+it('strips varying bcx:int codes', fn () => expect(MerchantSignature::for('Direct Debit QBE Insurance - bcx:int 4821'))->toBe('DIRECT DEBIT QBE INSURANCE'));
+it('collapses Fair Go DT.xxxx variants to one signature', function () {
+    expect(MerchantSignature::for('Direct Debit Fair Go Finance - DT.4y16g4 FGF 2472'))
+        ->toBe(MerchantSignature::for('Direct Debit Fair Go Finance - DT.4yx8ph FGF 2472'));
+});
+it('keeps distinct Osko payees distinct', function () {
+    $a = MerchantSignature::for('Osko Payment To 86400 Account 10386227 YOU - UBank Ref#885214478');
+    $b = MerchantSignature::for('Osko Payment To Nikolai Taylor Account 188722557 ANZ - Indooroo Ref#885214478');
+    expect($a)->not->toBe($b);
+});
+it('keeps merchant domains', fn () => expect(MerchantSignature::for('VISA -Netflix.com   Melbourne    AU  724493 #2892'))->toBe('VISA NETFLIX.COM MELBOURNE AU'));
+```
+
+**Step 2 — Run, expect fail:** `op test.filter MerchantSignatureTest` → class not found.
+
+**Step 3 — Implement** `final class MerchantSignature { public static function for(string $raw): string }` per Design §1 (token pass: uppercase, split on whitespace, drop tokens with a digit / known ref prefixes / card mask / date, keep alpha-ish words, rejoin, trim separators).
+
+**Step 4 — Run, expect pass.** Iterate the regex/token rules until all green.
+
+**Step 5 — Commit:** `feat(#<issue>): add MerchantSignature payee normaliser`
+
+---
+
+### Task 2: Group the stage by signature
+
+**Files:** Modify `app/Services/PipelineStages/IdentifyRecurringTransactionsStage.php` (`normalizeDescription`, `cleanRawDescription`, grouping in `execute`); test `tests/Feature/Services/PipelineStages/IdentifyRecurringTransactionsStageTest.php`.
+
+**Step 1 — Failing test:** three CSV-source (`TransactionSource::Csv`) txns with descriptions `Direct Debit Fair Go Finance - DT.aaa FGF`, `… DT.bbb FGF`, `… DT.ccc FGF`, weekly, amount 8500 ⇒ expect **1** suggestion with `description = 'DIRECT DEBIT FAIR GO FINANCE FGF'`. (Currently produces 0.)
+
+**Step 2 — Run, expect fail** (0 suggestions).
+
+**Step 3 — Implement:** replace `cleanRawDescription` usage so `normalizeDescription` returns `MerchantSignature::for($transaction->description)` for the raw path; keep the merchant_name/clean_description preference but pass them through `MerchantSignature::for` too so all stages agree. Delete the old `cleanRawDescription` regex + word-dedup.
+
+**Step 4 — Run, expect pass.** Re-run the **whole** existing stage test file — fix any expectations that change (e.g. descriptions no longer carry dangling `-`/`PLCY`).
+
+**Step 5 — Commit:** `fix(#<issue>): group recurring detection by payee signature`
+
+---
+
+### Task 3: Dominant-amount clustering (replace `every`, handle step-change)
+
+**Files:** Modify the stage (`analyzeGroup`, `checkAmountConsistency`, `calculateMedian` reuse); same test file.
+
+**Step 1 — Failing tests:**
+- *Premium step-change:* 6 fortnightly txns, four at 9059 then two at 9581 ⇒ expect 1 suggestion, `amount = 9581` (latest stable). (Currently 0 — `every` fails.)
+- *One-off double:* 5 fortnightly at 7017 + one at 14034 ⇒ expect 1 suggestion, `amount = 7017`. (Currently 0.)
+- *Genuinely variable:* amounts 5000/15000/6000/25000 ⇒ expect **0** (dominant share < 60%).
+
+**Step 2 — Run, expect fail.**
+
+**Step 3 — Implement** `dominantCluster()` per Design §2; replace the `every` gate; pick suggested amount = latest-cluster median.
+
+**Step 4 — Run, expect pass.**
+
+**Step 5 — Commit:** `fix(#<issue>): cluster recurring amounts and tolerate step-changes`
+
+---
+
+### Task 4: Gap-free frequency + day-of-month monthly
+
+**Files:** Modify the stage (`FREQUENCY_RANGES`, `mapIntervalToFrequency`, add `isMonthlyByDayOfMonth`); same test file.
+
+**Step 1 — Failing tests:**
+- intervals with median 24 days (currently in a gap) ⇒ snaps to monthly. *(decide: 24→ either 3-weekly(21) or monthly(28); snap to nearest → monthly is 28, 21 is 21; 24 is closer to 21 → Every3Weeks. Encode the nearest-canonical rule explicitly and assert it.)*
+- monthly bills on the 15th with intervals 28/31/30 ⇒ `EveryMonth` via day-of-month path.
+
+**Step 2 — Run, expect fail.**
+
+**Step 3 — Implement** nearest-canonical snap (candidates 7/14/21/30/91/182/365, accept if |median−candidate| ≤ 3, monthly window 26–35) + `isMonthlyByDayOfMonth` (all dominant occurrences share day-of-month ±2).
+
+**Step 4 — Run, expect pass.**
+
+**Step 5 — Commit:** `fix(#<issue>): gap-free cadence mapping with day-of-month monthly`
+
+---
+
+### Task 5: Recall tuning + noise filter
+
+**Files:** Modify the stage (`MIN_CONFIDENCE`, `calculateConfidence`, add noise skip in `shouldSkip`); same test file.
+
+**Step 1 — Failing tests:**
+- A `ROUND UP TRANSFER TO …` weekly group ⇒ **0** suggestions (+ audit entry reason `noise_round_up`).
+- A `TRANSFER OPTIMUS TO CC TO SAV` variable group ⇒ **0**.
+- A clean 3× monthly bill that currently scores ~0.38 ⇒ now emitted (conf ≥ 0.35).
+
+**Step 2 — Run, expect fail.**
+
+**Step 3 — Implement** the noise predicate + lowered/rebalanced confidence; require ≥3 occurrences.
+
+**Step 4 — Run, expect pass.**
+
+**Step 5 — Commit:** `feat(#<issue>): filter transfer/round-up noise and widen recall`
+
+---
+
+### Task 6: Share the signature with `PlannedTransactionMatcher` (consistency)
+
+**Files:** Modify `app/Services/PlannedTransactionMatcher.php` (+ its test) to key payee identity off `MerchantSignature::for(...)`.
+
+**Step 1 — Failing test:** an accepted plan from `Fair Go DT.aaa` re-matches a later import `Fair Go DT.zzz` (same amount/cadence window).
+
+**Steps 2–5:** implement, verify, commit `refactor(#<issue>): match planned txns by shared MerchantSignature`.
+
+---
+
+### Task 7: End-to-end fixture regression (synthetic, mirrors the real CSV)
+
+**Files:**
+- Create: `tests/Fixtures/StatementCsv-Recurring.csv` — **synthetic** rows (no real PII) reproducing the patterns: Fair Go weekly with varying `DT.xxxx`; QBE monthly with varying `bcx:int`; NIB fortnightly with a mid-series step-change; a one-off double; a round-up series; an internal transfer series.
+- Create: `tests/Feature/Services/RecurringDetectionEndToEndTest.php` — import via the CSV job (mirror `ImportCsvTransactionsJobTest`), run the pipeline, assert the **set** of emitted recurring signatures equals the expected bills and **excludes** the noise series.
+
+**Step 1 — Failing test** (assert ≥ the expected count of distinct bill signatures). **Steps 2–4:** make green. **Step 5 — Commit:** `test(#<issue>): end-to-end recurring detection on representative fixture`.
+
+---
+
+## Acceptance criteria
+
+- On the synthetic fixture, every fixed-amount bill pattern (Fair Go, QBE, NIB-with-step, Netflix-style monthly, fortnightly loan) is surfaced as exactly **one** suggestion with the correct frequency and latest stable amount; round-ups and internal transfers are **not** surfaced.
+- The two Fair Go `DT.xxxx` variants and the QBE `bcx:int` variants each collapse to a single signature; distinct Osko payees stay distinct (unit-locked in Task 1).
+- `op test.filter MerchantSignatureTest`, `op test.filter IdentifyRecurringTransactionsStageTest`, and the end-to-end test all pass; full `op test` stays green; `op check.dirty` clean.
+- Manual check against the real `context/Optimus-2026-01-to-05.csv` (local only): the Connect Bank suggestions list grows from ~3 to the ~10 real bills enumerated in Background.
+
+## Risks / notes
+- **DDEV:** all tests via `op test*` (never bare `php artisan`); no `run_in_background`.
+- **PHPStan** excludes `tests/`, but `app/Support/Recurring/MerchantSignature.php` and the stage are in scope — run `op check.dirty`.
+- **Over-merge risk:** the only real danger of signature grouping is collapsing two payees whose alpha words coincide. The Osko invariant test guards this; if it bites in the wild, add a secondary key on the first distinguishing alpha token.
+- **Issue-first:** create the GitHub issue, branch `fix/<n>-recurring-detection`, reuse `#<n>` in every commit scope, PR → `develop`, label `bug`+`backend`, request Copilot.
+- **After CSS-free PHP changes** no `op build` is needed; this is all backend.
+```

--- a/tests/Feature/Services/PipelineStages/IdentifyRecurringTransactionsStageTest.php
+++ b/tests/Feature/Services/PipelineStages/IdentifyRecurringTransactionsStageTest.php
@@ -957,3 +957,57 @@ test('skips internal account sweeps as noise', function () {
 
     expect($result->suggestionIds)->toBeEmpty();
 });
+
+// ─── Representative statement (acceptance, #263) ─────────────────────────
+
+test('detects the real bill patterns in a mixed statement and ignores noise', function () {
+    $jan = CarbonImmutable::parse('2026-01-02');
+
+    // Fair Go Finance: $85 weekly, varying DT.xxxx code each time.
+    foreach (range(0, 7) as $i) {
+        createCsvTransaction($this->user, $this->account, "Direct Debit Fair Go Finance - DT.4y16g{$i} FGF 2472", 8500, $jan->addWeeks($i)->toDateString());
+    }
+
+    // QBE Insurance: $60.58 monthly, varying bcx:int code each time.
+    foreach (range(0, 3) as $i) {
+        createCsvTransaction($this->user, $this->account, 'Direct Debit QBE Insurance - bcx:int '.(4000 + $i), 6058, $jan->addMonthsNoOverflow($i)->toDateString());
+    }
+
+    // NIB: fortnightly health insurance with a mid-series premium step-change.
+    foreach ([9059, 9059, 9059, 9059, 9581, 9581] as $i => $amt) {
+        createCsvTransaction($this->user, $this->account, 'Direct Debit NIB - '.(64699390 + $i), $amt, $jan->addWeeks(2 * $i)->toDateString());
+    }
+
+    // Golden Insurance: $70.17 fortnightly with a one-off double-debit.
+    foreach ([7017, 7017, 14034, 7017, 7017, 7017] as $i => $amt) {
+        createCsvTransaction($this->user, $this->account, 'Direct Debit Golden Insurance - PLCY 0822124'.(10 + $i), $amt, $jan->addWeeks(2 * $i)->toDateString());
+    }
+
+    // Noise: constant round-up + internal account sweep.
+    foreach (range(0, 4) as $i) {
+        createCsvTransaction($this->user, $this->account, 'Round Up transfer to 03774599: NETFLIX', 101, $jan->addMonthsNoOverflow($i)->toDateString());
+    }
+    foreach (range(0, 3) as $i) {
+        createCsvTransaction($this->user, $this->account, 'Transfer Optimus to CC to SAV 03914373 NET#'.(2000 + $i), 25000, $jan->addWeeks($i)->toDateString());
+    }
+
+    $result = $this->stage->execute($this->context);
+
+    $suggestions = AnalysisSuggestion::query()->whereIn('id', $result->suggestionIds)->get();
+    $signatures = $suggestions->pluck('payload.description')->all();
+
+    expect($signatures)
+        ->toContain('DIRECT DEBIT FAIR GO FINANCE FGF')
+        ->toContain('DIRECT DEBIT QBE INSURANCE')
+        ->toContain('DIRECT DEBIT NIB')
+        ->toContain('DIRECT DEBIT GOLDEN INSURANCE PLCY')
+        ->not->toContain('ROUND UP TRANSFER TO NETFLIX')
+        ->not->toContain('TRANSFER OPTIMUS TO CC TO SAV');
+
+    $nib = $suggestions->firstWhere('payload.description', 'DIRECT DEBIT NIB');
+    expect($nib->payload['amount'])->toBe(9581)
+        ->and($nib->payload['frequency'])->toBe(RecurrenceFrequency::Every2Weeks->value);
+
+    $golden = $suggestions->firstWhere('payload.description', 'DIRECT DEBIT GOLDEN INSURANCE PLCY');
+    expect($golden->payload['amount'])->toBe(7017);
+});

--- a/tests/Feature/Services/PipelineStages/IdentifyRecurringTransactionsStageTest.php
+++ b/tests/Feature/Services/PipelineStages/IdentifyRecurringTransactionsStageTest.php
@@ -877,3 +877,57 @@ test('groups recurring payees by signature despite varying reference codes', fun
     expect($suggestion->payload['description'])->toBe('DIRECT DEBIT FAIR GO FINANCE FGF')
         ->and($suggestion->payload['frequency'])->toBe(RecurrenceFrequency::EveryWeek->value);
 });
+
+// ─── Cadence gap-filling (#263) ─────────────────────────────────────────
+
+test('maps a 24-day cadence (previously an unmatched gap) to three-weekly', function () {
+    $start = CarbonImmutable::parse('2026-01-01');
+
+    for ($i = 0; $i < 3; $i++) {
+        createBasiqTransaction($this->user, $this->account, [
+            'merchant_name' => 'Gym Membership',
+            'amount' => 5000,
+            'post_date' => $start->addDays(24 * $i),
+        ]);
+    }
+
+    $result = $this->stage->execute($this->context);
+
+    expect($result->suggestionIds)->toHaveCount(1);
+    expect(AnalysisSuggestion::find($result->suggestionIds[0])->payload['frequency'])
+        ->toBe(RecurrenceFrequency::Every3Weeks->value);
+});
+
+test('maps a 10-day cadence (previously an unmatched gap) to weekly', function () {
+    $start = CarbonImmutable::parse('2026-01-01');
+
+    for ($i = 0; $i < 3; $i++) {
+        createBasiqTransaction($this->user, $this->account, [
+            'merchant_name' => 'Window Cleaner',
+            'amount' => 4000,
+            'post_date' => $start->addDays(10 * $i),
+        ]);
+    }
+
+    $result = $this->stage->execute($this->context);
+
+    expect($result->suggestionIds)->toHaveCount(1);
+    expect(AnalysisSuggestion::find($result->suggestionIds[0])->payload['frequency'])
+        ->toBe(RecurrenceFrequency::EveryWeek->value);
+});
+
+test('snaps wobbling monthly intervals to every month', function () {
+    foreach (['2026-01-15', '2026-02-12', '2026-03-15'] as $date) {
+        createBasiqTransaction($this->user, $this->account, [
+            'merchant_name' => 'Phone Plan',
+            'amount' => 4999,
+            'post_date' => CarbonImmutable::parse($date),
+        ]);
+    }
+
+    $result = $this->stage->execute($this->context);
+
+    expect($result->suggestionIds)->toHaveCount(1);
+    expect(AnalysisSuggestion::find($result->suggestionIds[0])->payload['frequency'])
+        ->toBe(RecurrenceFrequency::EveryMonth->value);
+});

--- a/tests/Feature/Services/PipelineStages/IdentifyRecurringTransactionsStageTest.php
+++ b/tests/Feature/Services/PipelineStages/IdentifyRecurringTransactionsStageTest.php
@@ -296,9 +296,9 @@ test('deduplicates repeated names in descriptions', function () {
 
 // ─── Amount Consistency ─────────────────────────────────────────────────
 
-test('rejects group where amounts vary more than 5 percent from median', function () {
+test('rejects a group with genuinely variable amounts', function () {
     $start = CarbonImmutable::parse('2026-01-15');
-    $amounts = [10000, 10000, 15000];
+    $amounts = [10000, 15000, 22000];
 
     for ($i = 0; $i < 3; $i++) {
         createBasiqTransaction($this->user, $this->account, [
@@ -311,6 +311,47 @@ test('rejects group where amounts vary more than 5 percent from median', functio
     $result = $this->stage->execute($this->context);
 
     expect($result->suggestionIds)->toBeEmpty();
+});
+
+test('detects a bill through a premium step-change and suggests the latest amount', function () {
+    $start = CarbonImmutable::parse('2026-01-05');
+    $amounts = [9059, 9059, 9059, 9059, 9581, 9581];
+
+    foreach ($amounts as $i => $amt) {
+        createBasiqTransaction($this->user, $this->account, [
+            'merchant_name' => 'NIB',
+            'amount' => $amt,
+            'direction' => TransactionDirection::Debit,
+            'post_date' => $start->addWeeks(2 * $i),
+        ]);
+    }
+
+    $result = $this->stage->execute($this->context);
+
+    expect($result->suggestionIds)->toHaveCount(1);
+    $suggestion = AnalysisSuggestion::find($result->suggestionIds[0]);
+    expect($suggestion->payload['amount'])->toBe(9581)
+        ->and($suggestion->payload['frequency'])->toBe(RecurrenceFrequency::Every2Weeks->value);
+});
+
+test('ignores a one-off double debit and suggests the dominant amount', function () {
+    $start = CarbonImmutable::parse('2026-01-05');
+    $amounts = [7017, 7017, 14034, 7017, 7017, 7017];
+
+    foreach ($amounts as $i => $amt) {
+        createBasiqTransaction($this->user, $this->account, [
+            'merchant_name' => 'Golden Insurance',
+            'amount' => $amt,
+            'direction' => TransactionDirection::Debit,
+            'post_date' => $start->addWeeks(2 * $i),
+        ]);
+    }
+
+    $result = $this->stage->execute($this->context);
+
+    expect($result->suggestionIds)->toHaveCount(1);
+    $suggestion = AnalysisSuggestion::find($result->suggestionIds[0]);
+    expect($suggestion->payload['amount'])->toBe(7017);
 });
 
 test('accepts group with amounts within 5 percent tolerance', function () {

--- a/tests/Feature/Services/PipelineStages/IdentifyRecurringTransactionsStageTest.php
+++ b/tests/Feature/Services/PipelineStages/IdentifyRecurringTransactionsStageTest.php
@@ -248,7 +248,7 @@ test('strips card numbers from raw descriptions for grouping', function () {
     expect($result->suggestionIds)->toHaveCount(1);
 
     $suggestion = AnalysisSuggestion::find($result->suggestionIds[0]);
-    expect($suggestion->payload['description'])->toBe('WOOLWORTHS');
+    expect($suggestion->payload['description'])->toBe('WOOLWORTHS SYDNEY AU');
 });
 
 test('strips date patterns from raw descriptions for grouping', function () {
@@ -807,4 +807,32 @@ test('label returns human-readable string', function () {
 
 test('shouldRun always returns true', function () {
     expect($this->stage->shouldRun($this->context))->toBeTrue();
+});
+
+// ─── Signature grouping (#263) ──────────────────────────────────────────
+
+function createCsvTransaction(User $user, Account $account, string $description, int $amount, string $postDate): Transaction
+{
+    return Transaction::factory()->fromCsv()->create([
+        'user_id' => $user->id,
+        'account_id' => $account->id,
+        'description' => $description,
+        'amount' => $amount,
+        'direction' => TransactionDirection::Debit,
+        'post_date' => $postDate,
+    ]);
+}
+
+test('groups recurring payees by signature despite varying reference codes', function () {
+    createCsvTransaction($this->user, $this->account, 'Direct Debit Fair Go Finance - DT.4y16g4 FGF 2472', 8500, '2026-01-06');
+    createCsvTransaction($this->user, $this->account, 'Direct Debit Fair Go Finance - DT.4yx8ph FGF 2472', 8500, '2026-01-13');
+    createCsvTransaction($this->user, $this->account, 'Direct Debit Fair Go Finance - DT.9zz1aa FGF 2472', 8500, '2026-01-20');
+
+    $result = $this->stage->execute($this->context);
+
+    expect($result->suggestionIds)->toHaveCount(1);
+
+    $suggestion = AnalysisSuggestion::find($result->suggestionIds[0]);
+    expect($suggestion->payload['description'])->toBe('DIRECT DEBIT FAIR GO FINANCE FGF')
+        ->and($suggestion->payload['frequency'])->toBe(RecurrenceFrequency::EveryWeek->value);
 });

--- a/tests/Feature/Services/PipelineStages/IdentifyRecurringTransactionsStageTest.php
+++ b/tests/Feature/Services/PipelineStages/IdentifyRecurringTransactionsStageTest.php
@@ -931,3 +931,29 @@ test('snaps wobbling monthly intervals to every month', function () {
     expect(AnalysisSuggestion::find($result->suggestionIds[0])->payload['frequency'])
         ->toBe(RecurrenceFrequency::EveryMonth->value);
 });
+
+// ─── Noise filtering (#263) ─────────────────────────────────────────────
+
+test('skips round-up transfers as noise even when the amount is constant', function () {
+    $start = CarbonImmutable::parse('2026-01-01');
+
+    for ($i = 0; $i < 5; $i++) {
+        createCsvTransaction($this->user, $this->account, 'Round Up transfer to 03774599: COFFEE SHOP', 101, $start->addMonthsNoOverflow($i)->toDateString());
+    }
+
+    $result = $this->stage->execute($this->context);
+
+    expect($result->suggestionIds)->toBeEmpty();
+});
+
+test('skips internal account sweeps as noise', function () {
+    $start = CarbonImmutable::parse('2026-01-01');
+
+    for ($i = 0; $i < 4; $i++) {
+        createCsvTransaction($this->user, $this->account, 'Transfer Optimus to CC to SAV 03914373 NET#2422732337', 25000, $start->addWeeks($i)->toDateString());
+    }
+
+    $result = $this->stage->execute($this->context);
+
+    expect($result->suggestionIds)->toBeEmpty();
+});

--- a/tests/Unit/Support/Recurring/MerchantSignatureTest.php
+++ b/tests/Unit/Support/Recurring/MerchantSignatureTest.php
@@ -1,0 +1,59 @@
+<?php
+
+/** @noinspection StaticClosureCanBeUsedInspection */
+
+declare(strict_types=1);
+
+use App\Support\Recurring\MerchantSignature;
+
+it('strips a trailing reference number', function () {
+    expect(MerchantSignature::for('Direct Debit NIB - 64699390'))->toBe('DIRECT DEBIT NIB');
+});
+
+it('strips a varying bcx:int code', function () {
+    expect(MerchantSignature::for('Direct Debit QBE Insurance - bcx:int 4821'))->toBe('DIRECT DEBIT QBE INSURANCE');
+});
+
+it('collapses Fair Go DT.xxxx variants to one signature', function () {
+    $a = MerchantSignature::for('Direct Debit Fair Go Finance - DT.4y16g4 FGF 2472');
+    $b = MerchantSignature::for('Direct Debit Fair Go Finance - DT.4yx8ph FGF 2472');
+
+    expect($a)->toBe('DIRECT DEBIT FAIR GO FINANCE FGF')
+        ->and($b)->toBe($a);
+});
+
+it('keeps two different Osko payees distinct', function () {
+    $youUbank = MerchantSignature::for('Osko Payment To 86400 Account 10386227 YOU - UBank Ref#885214478');
+    $nikolai = MerchantSignature::for('Osko Payment To Nikolai Taylor Account 188722557 ANZ - Indooroo Ref#885376551');
+
+    expect($youUbank)->not->toBe($nikolai)
+        ->and($youUbank)->toContain('YOU')
+        ->and($youUbank)->toContain('UBANK')
+        ->and($nikolai)->toContain('NIKOLAI')
+        ->and($nikolai)->toContain('TAYLOR');
+});
+
+it('drops the changing Ref# but keeps the payee for two instances of the same Osko payee', function () {
+    $a = MerchantSignature::for('Osko Payment To 86400 Account 10386227 YOU - UBank Ref#885214478');
+    $b = MerchantSignature::for('Osko Payment To 86400 Account 10386227 YOU - UBank Ref#999999999');
+
+    expect($a)->toBe($b);
+});
+
+it('keeps merchant domains and drops the card mask and location code', function () {
+    expect(MerchantSignature::for('VISA -Netflix.com   Melbourne    AU  724493 #2892'))
+        ->toBe('VISA NETFLIX.COM MELBOURNE AU');
+});
+
+it('preserves hyphenated payee words', function () {
+    expect(MerchantSignature::for('Direct Debit TMR-Product Payt - 1056574545'))
+        ->toBe('DIRECT DEBIT TMR-PRODUCT PAYT');
+});
+
+it('uppercases an already-clean merchant name unchanged', function () {
+    expect(MerchantSignature::for('Netflix'))->toBe('NETFLIX');
+});
+
+it('returns an empty signature when every token is a code', function () {
+    expect(MerchantSignature::for('Ref#884905699 2422732337'))->toBe('');
+});

--- a/tests/Unit/Support/Recurring/MerchantSignatureTest.php
+++ b/tests/Unit/Support/Recurring/MerchantSignatureTest.php
@@ -57,3 +57,13 @@ it('uppercases an already-clean merchant name unchanged', function () {
 it('returns an empty signature when every token is a code', function () {
     expect(MerchantSignature::for('Ref#884905699 2422732337'))->toBe('');
 });
+
+it('collapses adjacent duplicate words and drops the digit-bearing code token', function () {
+    expect(MerchantSignature::for('Direct Debit MCF - MCF Loa(N11590247)'))
+        ->toBe('DIRECT DEBIT MCF');
+});
+
+it('preserves non-adjacent repeated words so distinct payees stay apart', function () {
+    expect(MerchantSignature::for('Transfer Optimus to CC to SAV 03914373 NET#2422732337'))
+        ->toBe('TRANSFER OPTIMUS TO CC TO SAV');
+});

--- a/tests/Unit/Support/Recurring/MerchantSignatureTest.php
+++ b/tests/Unit/Support/Recurring/MerchantSignatureTest.php
@@ -54,8 +54,13 @@ it('uppercases an already-clean merchant name unchanged', function () {
     expect(MerchantSignature::for('Netflix'))->toBe('NETFLIX');
 });
 
-it('returns an empty signature when every token is a code', function () {
-    expect(MerchantSignature::for('Ref#884905699 2422732337'))->toBe('');
+it('keeps a merchant word that contains a boundary digit, e.g. 7-Eleven', function () {
+    expect(MerchantSignature::for('VISA -7-Eleven 1234 Clayton VI AUS'))
+        ->toBe('VISA 7-ELEVEN CLAYTON VI AUS');
+});
+
+it('falls back to the raw normalized string when every token is a code', function () {
+    expect(MerchantSignature::for('Ref#884905699   2422732337'))->toBe('REF#884905699 2422732337');
 });
 
 it('collapses adjacent duplicate words and drops the digit-bearing code token', function () {


### PR DESCRIPTION
Closes #263

## Problem
Import-time recurring detection emitted only a handful of bills. On a real Beyond Bank export (291 rows, Jan–May), the stage produced **6** suggestions (2 the same rent split in half, 2 noise) — vs ~10–13 real recurring bills. Root cause: exact-string grouping with a normaliser that truncated at the first 4-digit run (over-merging unrelated payees, under-grouping payees with varying `DT.xxxx`/`Ref#`/`bcx:int` codes), an all-or-nothing `every amount within 5%` gate, and an interval→frequency map with unmatchable gaps.

## Approach (TDD, one task per commit)
1. **`MerchantSignature`** (`app/Support/Recurring/`) — derive a stable payee key: keep word tokens, drop reference/code tokens (`Ref#`/`NET#`/`bcx:`, any digit-bearing token like `DT.4Y16G4`, card masks, dates); adjacent-duplicate collapse. Unit-tested with the real examples.
2. **Signature grouping** — the stage groups by signature, so `Fair Go … DT.4y16g4` and `… DT.4yx8ph` collapse to one payee while distinct Osko payees stay apart.
3. **Dominant-amount clustering** — replaces the `every ≤5%` gate; a group is recurring when ≥60% of occurrences share a level (tolerance `max(50c, 2%)`). Survives a one-off double-debit; a sustained premium **step-change** reports the latest amount (NIB $90.59→$95.81).
4. **Gap-free cadence** — median interval snaps to the nearest canonical anchor (7/14/21/30/91/182/365d, tol `max(4d, 20%)`); 10d→weekly, 24d→three-weekly, calendar-month wobble→monthly.
5. **Noise filter** — round-up sweeps and internal own-account transfers (`TRANSFER … TO … SAV/CC`) are excluded even when their amount is constant.
6. **Acceptance test** — a mixed synthetic statement (no PII) proving the full composition: the four bill payees each detected once, noise excluded, step-change + double handled.

## Deferred (follow-up, see note below)
**Task 6 (share the signature with `PlannedTransactionMatcher`) was intentionally not done.** The matcher matches on account + direction + **exact amount + date proximity** and never consults the description (its tests set no descriptions). Adding a hard payee-signature requirement would change that contract, break its tests, and *reduce* legitimate matches — the opposite of the goal. If cross-payee mis-matches surface in practice, the right design is a signature **tiebreaker** (only when multiple plans contend), tracked separately.

Also deliberately kept: `MIN_CONFIDENCE` and the ≥2-occurrence floor unchanged — after grouping + clustering + cadence snapping the confidence gate no longer binds, and ≥2 preserves detection of quarterly/half-yearly/yearly bills that appear only twice in a short window.

## Verification
- New: `MerchantSignatureTest` (11), `IdentifyRecurringTransactionsStage` (46, incl. the acceptance test).
- Full `Feature,Unit` suite: **1630 passed (3908 assertions)** — no regressions.
- Pint + PHPStan clean on the changed files.

Plan: `docs/plans/2026-06-01-recurring-transaction-detection.md`.
