### PR TITLE
fix(#265): set app timezone to Australia/Brisbane

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,7 @@ APP_ENV=local
 APP_KEY=
 APP_DEBUG=true
 APP_URL=http://localhost
+APP_TIMEZONE=Australia/Brisbane
 
 APP_LOCALE=en
 APP_FALLBACK_LOCALE=en

--- a/config/app.php
+++ b/config/app.php
@@ -67,7 +67,7 @@ return [
     |
     */
 
-    'timezone' => 'UTC',
+    'timezone' => env('APP_TIMEZONE', 'Australia/Brisbane'),
 
     /*
     |--------------------------------------------------------------------------

--- a/tests/Feature/Livewire/Dashboard/PayCycleCalendarTest.php
+++ b/tests/Feature/Livewire/Dashboard/PayCycleCalendarTest.php
@@ -813,3 +813,24 @@ test('blade renders grid-column-start matching the real weekday for the first da
 
     expect($html)->toMatch($expectedPattern);
 })->with([1, 2, 3, 4, 5, 6, 7]);
+
+test('marks the local Australian day as today across the UTC date boundary', function () {
+    // Mon 1 Jun 23:00 UTC is already Tue 2 Jun 09:00 in QLD (UTC+10). The
+    // dashboard must highlight the local civil day, not the UTC one — guards
+    // against the app reverting to a UTC timezone (issue #265), which made the
+    // calendar show "yesterday" every morning before ~10:00 local.
+    CarbonImmutable::setTestNow(CarbonImmutable::create(2026, 6, 1, 23, 0, 0, 'UTC'));
+
+    [$user] = fortnightlyThursdayPayUser('2026-06-04');
+
+    /** @var list<PayCycleDayData> $days */
+    $days = Livewire::actingAs($user)
+        ->test(PayCycleCalendar::class)
+        ->instance()
+        ->days();
+
+    $byIso = collect($days)->keyBy(fn (PayCycleDayData $day) => $day->iso);
+
+    expect($byIso->get('2026-06-02')?->isToday)->toBeTrue()
+        ->and($byIso->get('2026-06-01')?->isToday)->toBeFalse();
+});


### PR DESCRIPTION
## Summary
Fixes #265. The dashboard showed the **wrong day** for AU users near midnight: logged in on Tue 2 Jun (QLD, UTC+10) and the calendar highlighted Mon 1 Jun as TODAY with a "3d" payday badge instead of "2d".

## Root cause
`config/app.php` hardcoded `'timezone' => 'UTC'`. "Today" is derived from `CarbonImmutable::today()` (`PayCycleCalendar::days()`, `User::daysUntilNextPay()`, payday badge), which returns midnight **in the app timezone**. Before ~10:00 AEST the UTC clock is still on the previous calendar day, so every today-based calculation landed a day behind.

## Change
- `config/app.php`: `'timezone' => env('APP_TIMEZONE', 'Australia/Brisbane')` (env-driven, single-region "AU · Personal" app; QLD = UTC+10, no DST).
- `.env.example`: document `APP_TIMEZONE=Australia/Brisbane`.
- Regression test exercising the real `PayCycleCalendar` component: at 23:00 UTC (== 09:00 next-day Brisbane) the local civil day is marked TODAY, the prior UTC day is not.

## Safety
All budget-relevant date fields (`post_date`, `next_pay_date`, `start_date`, `until_date`, …) are cast `date` (date-only) — **no stored transaction/plan dates shift**. Only `created_at`/`last_synced_at` (datetime) are reinterpreted (cosmetic, ~10h) on pre-existing rows.

## Verification
- New test: RED under UTC → GREEN under Brisbane.
- Full suite: 1674 passed. The 7 `TransactionListBrowserTest` failures are **pre-existing and unrelated** — they fail identically under UTC (verified). Those tests seed data at `now()->subDays(5)` (late May) while the list defaults to a `this-month` filter, so they break for the first ~5 days of any month regardless of timezone.
- Live app post-fix: `config('app.timezone')=Australia/Brisbane`, `today()=2026-06-02 (Tuesday)`.