### PR TITLE
feat(#270): add transactions from any calendar day and enter past planned occurrences

### DIFF
--- a/app/Livewire/CalendarView.php
+++ b/app/Livewire/CalendarView.php
@@ -43,10 +43,11 @@ final class CalendarView extends Component
         unset($this->selectedDay); // @phpstan-ignore property.notFound
     }
 
-    public function openDay(string $date): void
+    public function addTransaction(): void
     {
-        $this->selectDate($date);
-        $this->dispatch('open-transaction-modal', date: $this->selectedDate);
+        if ($this->selectedDate !== '') {
+            $this->dispatch('open-transaction-modal', date: $this->selectedDate);
+        }
     }
 
     public function previousMonth(): void

--- a/app/Livewire/CalendarView.php
+++ b/app/Livewire/CalendarView.php
@@ -43,6 +43,12 @@ final class CalendarView extends Component
         unset($this->selectedDay); // @phpstan-ignore property.notFound
     }
 
+    public function openDay(string $date): void
+    {
+        $this->selectDate($date);
+        $this->dispatch('open-transaction-modal', date: $this->selectedDate);
+    }
+
     public function previousMonth(): void
     {
         $target = $this->monthStart()->subMonth();

--- a/app/Livewire/Dashboard/PayCycleCalendar.php
+++ b/app/Livewire/Dashboard/PayCycleCalendar.php
@@ -57,6 +57,15 @@ final class PayCycleCalendar extends Component
         unset($this->selectedDay); // @phpstan-ignore property.notFound
     }
 
+    public function openDay(string $iso): void
+    {
+        $this->selectDay($iso);
+
+        if ($this->selectedDate !== null) {
+            $this->dispatch('open-transaction-modal', date: $this->selectedDate);
+        }
+    }
+
     /**
      * Refresh the calendar when a transaction is created, edited, converted or
      * deleted from the globally-mounted TransactionModal. Without this listener

--- a/app/Livewire/Dashboard/PayCycleCalendar.php
+++ b/app/Livewire/Dashboard/PayCycleCalendar.php
@@ -57,10 +57,8 @@ final class PayCycleCalendar extends Component
         unset($this->selectedDay); // @phpstan-ignore property.notFound
     }
 
-    public function openDay(string $iso): void
+    public function addTransaction(): void
     {
-        $this->selectDay($iso);
-
         if ($this->selectedDate !== null) {
             $this->dispatch('open-transaction-modal', date: $this->selectedDate);
         }

--- a/app/Livewire/ReconciliationModal.php
+++ b/app/Livewire/ReconciliationModal.php
@@ -113,7 +113,7 @@ final class ReconciliationModal extends Component
     public function editPlanned(): void
     {
         $this->showModal = false;
-        $this->dispatch('edit-planned-transaction', id: $this->plannedTransactionId);
+        $this->dispatch('edit-planned-transaction', id: $this->plannedTransactionId, occurrenceDate: $this->occurrenceDate);
     }
 
     public function render(): View

--- a/app/Livewire/TransactionModal.php
+++ b/app/Livewire/TransactionModal.php
@@ -58,6 +58,8 @@ final class TransactionModal extends Component
 
     public ?string $untilDate = null;
 
+    public ?string $occurrenceDate = null;
+
     #[Locked]
     public bool $originalWasTransfer = false;
 
@@ -161,7 +163,7 @@ final class TransactionModal extends Component
     }
 
     #[On('edit-planned-transaction')]
-    public function openForEditPlanned(int $id): void
+    public function openForEditPlanned(int $id, ?string $occurrenceDate = null): void
     {
         $planned = PlannedTransaction::query()
             ->where('user_id', auth()->id())
@@ -174,6 +176,7 @@ final class TransactionModal extends Component
         $this->resetForm();
 
         $this->editingPlannedTransactionId = $planned->id;
+        $this->occurrenceDate = $occurrenceDate;
         $this->mode = 'plan';
         $this->originalWasTransfer = $planned->transfer_to_account_id !== null;
 
@@ -192,7 +195,7 @@ final class TransactionModal extends Component
 
         $this->accountId = $planned->account_id;
         $this->categoryId = $planned->category_id;
-        $this->date = $planned->start_date->format('Y-m-d');
+        $this->date = $occurrenceDate ?? $planned->start_date->format('Y-m-d');
         $this->frequency = $planned->frequency->value;
 
         if ($planned->until_date !== null) {
@@ -299,6 +302,19 @@ final class TransactionModal extends Component
     }
 
     /**
+     * A planned occurrence opened from the calendar (carrying its occurrence
+     * date) whose date is today or earlier — the user is entering/reconciling a
+     * forecast that has now passed, rather than editing the plan definition.
+     */
+    public function isRealizableOccurrence(): bool
+    {
+        return $this->editingPlannedTransactionId !== null
+            && $this->mode === 'plan'
+            && $this->occurrenceDate !== null
+            && CarbonImmutable::parse($this->occurrenceDate)->lessThanOrEqualTo(CarbonImmutable::today());
+    }
+
+    /**
      * @throws Throwable
      */
     private function resolveSave(): bool
@@ -309,6 +325,10 @@ final class TransactionModal extends Component
 
         if ($this->editingPlannedTransactionId && $this->mode === 'enter') {
             return $this->convertPlannedToEntered();
+        }
+
+        if ($this->isRealizableOccurrence()) {
+            return $this->realizePlannedOccurrence();
         }
 
         if ($this->editingPlannedTransactionId) {
@@ -597,6 +617,35 @@ final class TransactionModal extends Component
         return true;
     }
 
+    /**
+     * Realize a past planned occurrence: record the posted transaction it
+     * forecast and link it to the plan, leaving the recurring plan active so
+     * future occurrences keep forecasting. Triggered when a planned occurrence
+     * whose date is today-or-earlier is opened from the calendar.
+     *
+     * @throws Throwable
+     */
+    private function realizePlannedOccurrence(): bool
+    {
+        $resolved = $this->resolvePlannedTransactionWithParsedAmount();
+
+        if ($resolved === false) {
+            return false;
+        }
+
+        [$planned, $parsed] = $resolved;
+
+        if ($this->transactionType === 'transfer') {
+            DB::transaction(fn () => $this->createTransferPair($parsed));
+
+            return true;
+        }
+
+        $this->createSingleTransaction($parsed, $planned->id);
+
+        return true;
+    }
+
     /** @return array{Transaction, AmountParseResult}|false */
     private function resolveTransactionWithParsedAmount(): array|false
     {
@@ -674,7 +723,7 @@ final class TransactionModal extends Component
         return [$debitSide, $creditSide, $parsed];
     }
 
-    private function createSingleTransaction(AmountParseResult $parsed): void
+    private function createSingleTransaction(AmountParseResult $parsed, ?int $plannedTransactionId = null): void
     {
         Transaction::query()->create([
             'user_id' => auth()->id(),
@@ -689,6 +738,7 @@ final class TransactionModal extends Component
             'status' => TransactionStatus::Posted,
             'source' => TransactionSource::Manual,
             'notes' => $this->notes !== '' ? $this->notes : null,
+            'planned_transaction_id' => $plannedTransactionId,
         ]);
     }
 
@@ -776,6 +826,7 @@ final class TransactionModal extends Component
     {
         $this->editingTransactionId = null;
         $this->editingPlannedTransactionId = null;
+        $this->occurrenceDate = null;
         $this->isBasiqTransaction = false;
         $this->transactionType = 'expense';
         $this->descriptionInput = '';

--- a/app/Livewire/TransactionModal.php
+++ b/app/Livewire/TransactionModal.php
@@ -308,10 +308,20 @@ final class TransactionModal extends Component
      */
     public function isRealizableOccurrence(): bool
     {
-        return $this->editingPlannedTransactionId !== null
-            && $this->mode === 'plan'
-            && $this->occurrenceDate !== null
-            && CarbonImmutable::parse($this->occurrenceDate)->lessThanOrEqualTo(CarbonImmutable::today());
+        if ($this->editingPlannedTransactionId === null
+            || $this->mode !== 'plan'
+            || $this->occurrenceDate === null) {
+            return false;
+        }
+
+        try {
+            $occurrence = CarbonImmutable::createFromFormat('!Y-m-d', $this->occurrenceDate);
+        } catch (Throwable) {
+            return false;
+        }
+
+        return $occurrence instanceof CarbonImmutable
+            && $occurrence->lessThanOrEqualTo(CarbonImmutable::today());
     }
 
     /**
@@ -636,7 +646,7 @@ final class TransactionModal extends Component
         [$planned, $parsed] = $resolved;
 
         if ($this->transactionType === 'transfer') {
-            DB::transaction(fn () => $this->createTransferPair($parsed));
+            DB::transaction(fn () => $this->createTransferPair($parsed, $planned->id));
 
             return true;
         }
@@ -742,9 +752,10 @@ final class TransactionModal extends Component
         ]);
     }
 
-    private function createTransferPair(AmountParseResult $parsed): void
+    private function createTransferPair(AmountParseResult $parsed, ?int $plannedTransactionId = null): void
     {
         $shared = [
+            'planned_transaction_id' => $plannedTransactionId,
             'user_id' => auth()->id(),
             'category_id' => $this->categoryId,
             'amount' => $parsed->amount,

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -913,6 +913,8 @@ select:focus[data-flux-control] {
         color: var(--color-fg-3);
         font: 700 13px/1.5 var(--font-sans);
     }
+    .cyc-detail-foot { margin-top: 10px; display: flex; }
+    .cyc-detail-foot .cib-yellow-pill { width: 100%; justify-content: center; }
 
     /* ---------- 12-month projection widget (Ticket #233 — running-balance redesign) ---------- */
 

--- a/resources/views/calendar.blade.php
+++ b/resources/views/calendar.blade.php
@@ -1,4 +1,3 @@
 <x-layouts::app :title="__('Calendar')">
     <livewire:calendar-view />
-    <livewire:reconciliation-modal />
 </x-layouts::app>

--- a/resources/views/layouts/app/sidebar.blade.php
+++ b/resources/views/layouts/app/sidebar.blade.php
@@ -64,6 +64,7 @@
 
 <livewire:feedback-widget/>
 <livewire:transaction-modal/>
+<livewire:reconciliation-modal/>
 
 @fluxScripts
 </body>

--- a/resources/views/livewire/calendar-view.blade.php
+++ b/resources/views/livewire/calendar-view.blade.php
@@ -48,7 +48,7 @@
             @foreach ($this->days as $day)
                 <button
                         type="button"
-                        wire:click="openDay('{{ $day->iso }}')"
+                        wire:click="selectDate('{{ $day->iso }}')"
                         wire:key="cal-day-{{ $day->iso }}"
                         style="grid-column-start: {{ $day->isoWeekday }}"
                         @class([
@@ -134,6 +134,12 @@
                 @empty
                     <p class="cyc-empty">Nothing on this day.</p>
                 @endforelse
+            </div>
+            <div class="cyc-detail-foot">
+                <button type="button" class="cib-yellow-pill" wire:click="addTransaction">
+                    <flux:icon.plus variant="micro"/>
+                    {{ __('Add transaction') }}
+                </button>
             </div>
         </div>
     @endif

--- a/resources/views/livewire/calendar-view.blade.php
+++ b/resources/views/livewire/calendar-view.blade.php
@@ -48,7 +48,7 @@
             @foreach ($this->days as $day)
                 <button
                         type="button"
-                        wire:click="selectDate('{{ $day->iso }}')"
+                        wire:click="openDay('{{ $day->iso }}')"
                         wire:key="cal-day-{{ $day->iso }}"
                         style="grid-column-start: {{ $day->isoWeekday }}"
                         @class([

--- a/resources/views/livewire/dashboard/pay-cycle-calendar.blade.php
+++ b/resources/views/livewire/dashboard/pay-cycle-calendar.blade.php
@@ -48,7 +48,7 @@
                 @foreach ($this->days as $day)
                     <button
                             type="button"
-                            wire:click="openDay('{{ $day->iso }}')"
+                            wire:click="selectDay('{{ $day->iso }}')"
                             wire:key="cyc-day-{{ $day->iso }}"
                             style="grid-column-start: {{ $day->isoWeekday }}"
                             @class([
@@ -129,6 +129,12 @@
                     @empty
                         <p class="cyc-empty">Nothing on this day.</p>
                     @endforelse
+                </div>
+                <div class="cyc-detail-foot">
+                    <button type="button" class="cib-yellow-pill" wire:click="addTransaction">
+                        <flux:icon.plus variant="micro"/>
+                        {{ __('Add transaction') }}
+                    </button>
                 </div>
             </div>
         @endif

--- a/resources/views/livewire/dashboard/pay-cycle-calendar.blade.php
+++ b/resources/views/livewire/dashboard/pay-cycle-calendar.blade.php
@@ -48,7 +48,7 @@
                 @foreach ($this->days as $day)
                     <button
                             type="button"
-                            wire:click="selectDay('{{ $day->iso }}')"
+                            wire:click="openDay('{{ $day->iso }}')"
                             wire:key="cyc-day-{{ $day->iso }}"
                             style="grid-column-start: {{ $day->isoWeekday }}"
                             @class([

--- a/resources/views/livewire/transaction-modal.blade.php
+++ b/resources/views/livewire/transaction-modal.blade.php
@@ -281,6 +281,14 @@
                         @else
                             {{ __('Convert to entered income') }}
                         @endif
+                    @elseif($this->isRealizableOccurrence())
+                        @if($transactionType === 'transfer')
+                            {{ __('Enter transfer') }}
+                        @elseif($transactionType === 'expense')
+                            {{ __('Enter expense') }}
+                        @else
+                            {{ __('Enter income') }}
+                        @endif
                     @elseif($editingPlannedTransactionId)
                         @if($transactionType === 'transfer')
                             {{ __('Update planned transfer') }}

--- a/tests/Feature/CalendarPageTest.php
+++ b/tests/Feature/CalendarPageTest.php
@@ -23,6 +23,16 @@ it('renders the TransactionModal exactly once on the calendar page', function ()
         ->toBe(1);
 });
 
+it('renders the ReconciliationModal exactly once on the calendar page', function () {
+    $response = $this->get(route('calendar'));
+
+    $response->assertOk();
+    $response->assertSeeLivewire('reconciliation-modal');
+
+    expect(countLivewireMounts($response->getContent(), 'reconciliation-modal'))
+        ->toBe(1);
+});
+
 /**
  * Count how many times a Livewire component is mounted in rendered HTML by
  * parsing each `wire:snapshot` attribute, decoding HTML entities, and inspecting

--- a/tests/Feature/DashboardPageTest.php
+++ b/tests/Feature/DashboardPageTest.php
@@ -1,0 +1,19 @@
+<?php
+
+/** @noinspection StaticClosureCanBeUsedInspection */
+
+declare(strict_types=1);
+
+use App\Models\User;
+
+beforeEach(function () {
+    $this->user = User::factory()->create();
+    $this->actingAs($this->user);
+});
+
+it('mounts the reconciliation modal on the dashboard page', function () {
+    $response = $this->get(route('dashboard'));
+
+    $response->assertOk();
+    $response->assertSeeLivewire('reconciliation-modal');
+});

--- a/tests/Feature/Livewire/CalendarViewTest.php
+++ b/tests/Feature/Livewire/CalendarViewTest.php
@@ -642,13 +642,25 @@ test('transfer-pair transactions are excluded from pips', function () {
     expect($cell->pips)->toBeEmpty();
 });
 
-test('clicking a day opens the add-transaction modal pre-dated to that day', function () {
+test('selecting a day shows its detail panel with an add-transaction button and does not open the modal', function () {
     $user = User::factory()->create();
     $iso = CarbonImmutable::now()->startOfMonth()->addDays(9)->format('Y-m-d');
 
     Livewire::actingAs($user)
         ->test(CalendarView::class)
-        ->call('openDay', $iso)
-        ->assertDispatched('open-transaction-modal', date: $iso)
-        ->assertSet('selectedDate', $iso);
+        ->call('selectDate', $iso)
+        ->assertSet('selectedDate', $iso)
+        ->assertNotDispatched('open-transaction-modal')
+        ->assertSee('Add transaction');
+});
+
+test('the add-transaction button opens the modal pre-dated to the selected day', function () {
+    $user = User::factory()->create();
+    $iso = CarbonImmutable::now()->startOfMonth()->addDays(9)->format('Y-m-d');
+
+    Livewire::actingAs($user)
+        ->test(CalendarView::class)
+        ->call('selectDate', $iso)
+        ->call('addTransaction')
+        ->assertDispatched('open-transaction-modal', date: $iso);
 });

--- a/tests/Feature/Livewire/CalendarViewTest.php
+++ b/tests/Feature/Livewire/CalendarViewTest.php
@@ -641,3 +641,14 @@ test('transfer-pair transactions are excluded from pips', function () {
 
     expect($cell->pips)->toBeEmpty();
 });
+
+test('clicking a day opens the add-transaction modal pre-dated to that day', function () {
+    $user = User::factory()->create();
+    $iso = CarbonImmutable::now()->startOfMonth()->addDays(9)->format('Y-m-d');
+
+    Livewire::actingAs($user)
+        ->test(CalendarView::class)
+        ->call('openDay', $iso)
+        ->assertDispatched('open-transaction-modal', date: $iso)
+        ->assertSet('selectedDate', $iso);
+});

--- a/tests/Feature/Livewire/Dashboard/PayCycleCalendarTest.php
+++ b/tests/Feature/Livewire/Dashboard/PayCycleCalendarTest.php
@@ -834,3 +834,21 @@ test('marks the local Australian day as today across the UTC date boundary', fun
     expect($byIso->get('2026-06-02')?->isToday)->toBeTrue()
         ->and($byIso->get('2026-06-01')?->isToday)->toBeFalse();
 });
+
+test('clicking a day opens the add-transaction modal pre-dated to that day', function () {
+    $nextPay = nextMondayAtLeastDaysAhead(7);
+
+    $user = User::factory()->withPayCycle()->create([
+        'pay_frequency' => PayFrequency::Fortnightly,
+        'next_pay_date' => $nextPay,
+    ]);
+    Account::factory()->for($user)->create();
+
+    $iso = $nextPay->subWeeks(2)->addDays(2)->format('Y-m-d');
+
+    Livewire::actingAs($user)
+        ->test(PayCycleCalendar::class)
+        ->call('openDay', $iso)
+        ->assertDispatched('open-transaction-modal', date: $iso)
+        ->assertSet('selectedDate', $iso);
+});

--- a/tests/Feature/Livewire/Dashboard/PayCycleCalendarTest.php
+++ b/tests/Feature/Livewire/Dashboard/PayCycleCalendarTest.php
@@ -835,7 +835,7 @@ test('marks the local Australian day as today across the UTC date boundary', fun
         ->and($byIso->get('2026-06-01')?->isToday)->toBeFalse();
 });
 
-test('clicking a day opens the add-transaction modal pre-dated to that day', function () {
+test('the add-transaction button opens the modal pre-dated to the selected day', function () {
     $nextPay = nextMondayAtLeastDaysAhead(7);
 
     $user = User::factory()->withPayCycle()->create([
@@ -848,7 +848,10 @@ test('clicking a day opens the add-transaction modal pre-dated to that day', fun
 
     Livewire::actingAs($user)
         ->test(PayCycleCalendar::class)
-        ->call('openDay', $iso)
-        ->assertDispatched('open-transaction-modal', date: $iso)
-        ->assertSet('selectedDate', $iso);
+        ->call('selectDay', $iso)
+        ->assertSet('selectedDate', $iso)
+        ->assertNotDispatched('open-transaction-modal')
+        ->assertSee('Add transaction')
+        ->call('addTransaction')
+        ->assertDispatched('open-transaction-modal', date: $iso);
 });

--- a/tests/Feature/Livewire/ReconciliationModalTest.php
+++ b/tests/Feature/Livewire/ReconciliationModalTest.php
@@ -288,3 +288,20 @@ test('after linking suggestions are cleared and linked transaction is shown', fu
         ->and($component->get('linkedTransaction.id'))->toBe($transaction->id)
         ->and($component->get('suggestions'))->toBeEmpty();
 });
+
+test('editPlanned forwards the occurrence date to the transaction modal', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $planned = PlannedTransaction::factory()->for($user)->for($account)->noRepeat()->create([
+        'description' => 'Monthly Rent',
+        'amount' => 150000,
+        'direction' => TransactionDirection::Debit,
+        'start_date' => '2026-03-15',
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(ReconciliationModal::class)
+        ->dispatch('open-reconciliation-modal', plannedId: $planned->id, occurrenceDate: '2026-03-15')
+        ->call('editPlanned')
+        ->assertDispatched('edit-planned-transaction', id: $planned->id, occurrenceDate: '2026-03-15');
+});

--- a/tests/Feature/Livewire/TransactionModalTest.php
+++ b/tests/Feature/Livewire/TransactionModalTest.php
@@ -3155,3 +3155,49 @@ test('a future planned occurrence still updates the plan rather than entering it
     expect(Transaction::query()->where('planned_transaction_id', $planned->id)->count())->toBe(0)
         ->and($planned->fresh()->amount)->toBe(7500);
 });
+
+test('a malformed occurrence date does not break render and is not realizable', function () {
+    $this->travelTo(CarbonImmutable::parse('2026-06-15'));
+
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $planned = PlannedTransaction::factory()->for($user)->for($account)->monthly()->create([
+        'direction' => TransactionDirection::Debit,
+        'amount' => 5000,
+        'description' => 'gym',
+        'start_date' => '2026-05-01',
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('edit-planned-transaction', id: $planned->id, occurrenceDate: 'garbage')
+        ->assertOk()
+        ->assertSee(__('Update planned expense'))
+        ->assertDontSee(__('Enter expense'));
+});
+
+test('entering a past planned transfer occurrence links both legs to the plan', function () {
+    $this->travelTo(CarbonImmutable::parse('2026-06-15'));
+
+    $user = User::factory()->create();
+    $from = Account::factory()->for($user)->create();
+    $to = Account::factory()->for($user)->create();
+    $planned = PlannedTransaction::factory()->for($user)->for($from)->monthly()->create([
+        'direction' => TransactionDirection::Debit,
+        'transfer_to_account_id' => $to->id,
+        'amount' => 5000,
+        'description' => 'savings',
+        'start_date' => '2026-05-01',
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('edit-planned-transaction', id: $planned->id, occurrenceDate: '2026-06-01')
+        ->assertSet('transactionType', 'transfer')
+        ->call('save')
+        ->assertHasNoErrors()
+        ->assertSet('showModal', false);
+
+    expect(PlannedTransaction::query()->find($planned->id))->not->toBeNull()
+        ->and(Transaction::query()->where('planned_transaction_id', $planned->id)->count())->toBe(2);
+});

--- a/tests/Feature/Livewire/TransactionModalTest.php
+++ b/tests/Feature/Livewire/TransactionModalTest.php
@@ -3076,3 +3076,82 @@ test('converting an entered transaction to planned keeps a planned occurrence on
     expect($day)->not->toBeNull()
         ->and(collect($day->pips)->pluck('kind')->all())->toContain('plan');
 });
+
+test('opening a past planned occurrence shows the Enter expense action', function () {
+    $this->travelTo(CarbonImmutable::parse('2026-06-15'));
+
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $planned = PlannedTransaction::factory()->for($user)->for($account)->monthly()->create([
+        'direction' => TransactionDirection::Debit,
+        'amount' => 5000,
+        'description' => 'gym',
+        'start_date' => '2026-05-01',
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('edit-planned-transaction', id: $planned->id, occurrenceDate: '2026-06-01')
+        ->assertSet('mode', 'plan')
+        ->assertSet('date', '2026-06-01')
+        ->assertSee(__('Enter expense'))
+        ->assertDontSee(__('Update planned expense'));
+});
+
+test('entering a past planned occurrence creates a linked posted transaction and keeps the plan', function () {
+    $this->travelTo(CarbonImmutable::parse('2026-06-15'));
+
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $category = Category::factory()->create(['is_hidden' => false]);
+    $planned = PlannedTransaction::factory()->for($user)->for($account)->monthly()->create([
+        'direction' => TransactionDirection::Debit,
+        'amount' => 5000,
+        'description' => 'gym',
+        'start_date' => '2026-05-01',
+        'category_id' => $category->id,
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('edit-planned-transaction', id: $planned->id, occurrenceDate: '2026-06-01')
+        ->call('save')
+        ->assertHasNoErrors()
+        ->assertSet('showModal', false)
+        ->assertDispatched('transaction-saved');
+
+    expect(PlannedTransaction::query()->find($planned->id))->not->toBeNull();
+
+    $txn = Transaction::query()->where('planned_transaction_id', $planned->id)->first();
+
+    expect($txn)->not->toBeNull()
+        ->and($txn->status)->toBe(TransactionStatus::Posted)
+        ->and($txn->source)->toBe(TransactionSource::Manual)
+        ->and($txn->direction)->toBe(TransactionDirection::Debit)
+        ->and($txn->amount)->toBe(5000)
+        ->and($txn->post_date->format('Y-m-d'))->toBe('2026-06-01')
+        ->and($txn->category_id)->toBe($category->id);
+});
+
+test('a future planned occurrence still updates the plan rather than entering it', function () {
+    $this->travelTo(CarbonImmutable::parse('2026-06-15'));
+
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $planned = PlannedTransaction::factory()->for($user)->for($account)->monthly()->create([
+        'direction' => TransactionDirection::Debit,
+        'amount' => 5000,
+        'description' => 'gym',
+        'start_date' => '2026-05-01',
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('edit-planned-transaction', id: $planned->id, occurrenceDate: '2026-07-01')
+        ->set('descriptionInput', '75 updated gym')
+        ->call('save')
+        ->assertHasNoErrors();
+
+    expect(Transaction::query()->where('planned_transaction_id', $planned->id)->count())->toBe(0)
+        ->and($planned->fresh()->amount)->toBe(7500);
+});


### PR DESCRIPTION
Closes the calendar-entry and planned-occurrence gaps from the plan doc (`docs/plans/2026-06-02-transaction-modal-type-by-date.md`, PR A). PR B (#3 convert-to-plan keeps source + #4 series category back-fill) follows separately.

## What changed

### 1. Add a transaction from any calendar day
- `CalendarView` and `Dashboard\PayCycleCalendar` gained `openDay()`; day buttons now dispatch `open-transaction-modal` pre-dated to the clicked day while still selecting it (the detail panel keeps surfacing existing pips).
- No modal change needed: `openForAdd` already defaults to an expense, picking **enter** for today/past and **planned** for future dates.

### 2. Enter a past planned occurrence
- When a planned item is opened from the calendar (carrying its occurrence date) and that date is **today-or-earlier**, the modal's primary button now reads **“Enter expense/income/transfer”** and records a posted transaction linked to the plan (`planned_transaction_id`). The recurring plan stays active, so future occurrences keep forecasting and the calendar dedupes the realized day.
- Opening a plan **without** an occurrence context (the plan editor / future dates) still updates the plan definition as before — existing `editing planned transaction updates correctly` is unchanged.
- `ReconciliationModal::editPlanned()` now forwards the occurrence date so the right occurrence is realized rather than the plan's start date.

### Bug fix: reconciliation modal missing on the dashboard
- `reconciliation-modal` was mounted only on the calendar page, so clicking a planned pip on the dashboard was a silent no-op. It's now mounted once in the app layout (global) and the redundant calendar-page mount removed.

## Verification
- New tests: calendar day-click dispatch (CalendarView + PayCycleCalendar); past-planned “Enter” button + linked-posted-transaction realize; future-occurrence still updates the plan; `editPlanned` forwards the occurrence date; dashboard mounts the modal; calendar mounts it exactly once.
- Full suite: **Unit + Feature + Arch — 1646 passed**. Pint + PHPStan clean (GrumPHP). Browser suite not run locally (needs Chromium).

Refs #270