### PR TITLE
feat(#272): keep the source on convert-to-plan and offer a categorisation rule

### DIFF
--- a/app/Livewire/TransactionModal.php
+++ b/app/Livewire/TransactionModal.php
@@ -595,22 +595,25 @@ final class TransactionModal extends Component
 
         [$transaction, $parsed] = $resolved;
 
-        DB::transaction(function () use ($transaction, $parsed): void {
-            $planned = PlannedTransaction::query()->create($this->buildPlannedTransactionData($parsed));
+        // Keep the source transaction. When it is a plain (non-transfer) posting,
+        // reconcile it to the new plan so its occurrence on the start date is not
+        // double-counted on the calendar; its own fields are left untouched.
+        $isPlainSource = $this->transactionType !== 'transfer' && $transaction->transfer_pair_id === null;
 
-            // Keep the source transaction. When it is a plain (non-transfer) posting,
-            // reconcile it to the new plan so its occurrence on the start date is not
-            // double-counted on the calendar; its own fields are left untouched.
-            $isPlainSource = $this->transactionType !== 'transfer' && $transaction->transfer_pair_id === null;
+        DB::transaction(function () use ($transaction, $parsed, $isPlainSource): void {
+            $planned = PlannedTransaction::query()->create($this->buildPlannedTransactionData($parsed));
 
             if ($isPlainSource) {
                 $transaction->update(['planned_transaction_id' => $planned->id]);
             }
-
-            if ($isPlainSource && $this->categoriseMatching && $this->categoryId !== null) {
-                app(CategoryRuleGenerator::class)->generateAndApply($transaction, $this->categoryId);
-            }
         });
+
+        // Generate and apply the categorisation rule after the plan transaction
+        // commits: it can touch many transactions, so keeping it outside avoids
+        // holding row locks for the length of an interactive modal save.
+        if ($isPlainSource && $this->categoriseMatching && $this->categoryId !== null) {
+            app(CategoryRuleGenerator::class)->generateAndApply($transaction, $this->categoryId);
+        }
 
         return true;
     }

--- a/app/Livewire/TransactionModal.php
+++ b/app/Livewire/TransactionModal.php
@@ -12,6 +12,7 @@ use App\Enums\TransactionStatus;
 use App\Models\Category;
 use App\Models\PlannedTransaction;
 use App\Models\Transaction;
+use App\Services\CategoryRuleGenerator;
 use App\Support\AmountParser;
 use App\Support\AmountParseResult;
 use Carbon\CarbonImmutable;
@@ -59,6 +60,8 @@ final class TransactionModal extends Component
     public ?string $untilDate = null;
 
     public ?string $occurrenceDate = null;
+
+    public bool $categoriseMatching = false;
 
     #[Locked]
     public bool $originalWasTransfer = false;
@@ -593,9 +596,20 @@ final class TransactionModal extends Component
         [$transaction, $parsed] = $resolved;
 
         DB::transaction(function () use ($transaction, $parsed): void {
-            PlannedTransaction::query()->create($this->buildPlannedTransactionData($parsed));
+            $planned = PlannedTransaction::query()->create($this->buildPlannedTransactionData($parsed));
 
-            $this->softDeleteWithAncestors($transaction);
+            // Keep the source transaction. When it is a plain (non-transfer) posting,
+            // reconcile it to the new plan so its occurrence on the start date is not
+            // double-counted on the calendar; its own fields are left untouched.
+            $isPlainSource = $this->transactionType !== 'transfer' && $transaction->transfer_pair_id === null;
+
+            if ($isPlainSource) {
+                $transaction->update(['planned_transaction_id' => $planned->id]);
+            }
+
+            if ($isPlainSource && $this->categoriseMatching && $this->categoryId !== null) {
+                app(CategoryRuleGenerator::class)->generateAndApply($transaction, $this->categoryId);
+            }
         });
 
         return true;
@@ -810,34 +824,12 @@ final class TransactionModal extends Component
         return $this->transactionType === 'transfer';
     }
 
-    private function softDeleteWithAncestors(Transaction $transaction): void
-    {
-        $current = $transaction;
-
-        while ($current) {
-            if ($current->transfer_pair_id) {
-                Transaction::query()
-                    ->where('id', $current->transfer_pair_id)
-                    ->where('user_id', auth()->id())
-                    ->delete();
-            }
-
-            $parentId = $current->parent_transaction_id;
-            $current->delete();
-
-            $current = $parentId
-                ? Transaction::withTrashed()
-                    ->where('user_id', auth()->id())
-                    ->find($parentId)
-                : null;
-        }
-    }
-
     private function resetForm(): void
     {
         $this->editingTransactionId = null;
         $this->editingPlannedTransactionId = null;
         $this->occurrenceDate = null;
+        $this->categoriseMatching = false;
         $this->isBasiqTransaction = false;
         $this->transactionType = 'expense';
         $this->descriptionInput = '';

--- a/app/Services/CategoryRuleGenerator.php
+++ b/app/Services/CategoryRuleGenerator.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Enums\RuleActionType;
+use App\Enums\RuleTriggerField;
+use App\Enums\RuleTriggerOperator;
+use App\Models\Transaction;
+use App\Models\UserRule;
+use App\Models\UserRuleGroup;
+use App\Support\Recurring\MerchantSignature;
+
+/**
+ * Builds a "categorise this merchant" rule from a source transaction and a
+ * chosen category, then applies it to the user's existing transactions. The
+ * rule persists and auto-applies, so previous transactions are categorised
+ * immediately and future imports keep being categorised by the normal pipeline.
+ */
+final readonly class CategoryRuleGenerator
+{
+    private const string GROUP_NAME = 'Auto-categorisation';
+
+    public function __construct(
+        private RuleEvaluator $evaluator,
+        private RuleActionExecutor $executor,
+    ) {}
+
+    public function generateAndApply(Transaction $source, int $categoryId): UserRule
+    {
+        $group = $this->group($source->user_id);
+
+        $rule = UserRule::query()->create([
+            'user_id' => $source->user_id,
+            'user_rule_group_id' => $group->id,
+            'name' => $this->ruleName($source),
+            'triggers' => [$this->buildTrigger($source)],
+            'actions' => [[
+                'type' => RuleActionType::SetCategory->value,
+                'value' => (string) $categoryId,
+            ]],
+            'strict_mode' => true,
+            'is_auto_apply' => true,
+            'is_active' => true,
+            'order' => $this->nextRuleOrder($group->id),
+        ]);
+
+        $this->applyToExisting($source->user_id, $rule);
+
+        return $rule;
+    }
+
+    private function applyToExisting(int $userId, UserRule $rule): void
+    {
+        Transaction::query()
+            ->where('user_id', $userId)
+            ->current()
+            ->get()
+            ->each(function (Transaction $transaction) use ($rule): void {
+                if ($this->evaluator->matches($transaction, $rule)) {
+                    $this->executor->execute($transaction, $rule->actions);
+                }
+            });
+    }
+
+    /** @return array<string, string> */
+    private function buildTrigger(Transaction $source): array
+    {
+        if ($source->merchant_name !== null && $source->merchant_name !== '') {
+            return [
+                'field' => RuleTriggerField::MerchantName->value,
+                'operator' => RuleTriggerOperator::Equals->value,
+                'value' => $source->merchant_name,
+            ];
+        }
+
+        if ($source->clean_description !== null && $source->clean_description !== '') {
+            return [
+                'field' => RuleTriggerField::CleanDescription->value,
+                'operator' => RuleTriggerOperator::Contains->value,
+                'value' => $this->merchantToken($source->clean_description),
+            ];
+        }
+
+        return [
+            'field' => RuleTriggerField::Description->value,
+            'operator' => RuleTriggerOperator::Contains->value,
+            'value' => $this->merchantToken($source->description),
+        ];
+    }
+
+    /**
+     * The first stable payee token of the merchant signature. A single token is
+     * a case-insensitive substring of the raw description, so a `contains`
+     * trigger matches the source and its siblings even when reference numbers
+     * vary between them.
+     */
+    private function merchantToken(string $raw): string
+    {
+        $signature = MerchantSignature::for($raw);
+        $first = strtok($signature, ' ');
+
+        return $first === false ? $signature : $first;
+    }
+
+    private function ruleName(Transaction $source): string
+    {
+        $label = $source->merchant_name
+            ?? $source->clean_description
+            ?? $source->description;
+
+        return mb_substr('Categorise '.$label, 0, 255);
+    }
+
+    private function group(int $userId): UserRuleGroup
+    {
+        $existing = UserRuleGroup::query()
+            ->where('user_id', $userId)
+            ->where('name', self::GROUP_NAME)
+            ->first();
+
+        if ($existing !== null) {
+            return $existing;
+        }
+
+        return UserRuleGroup::query()->create([
+            'user_id' => $userId,
+            'name' => self::GROUP_NAME,
+            'order' => (int) UserRuleGroup::query()->where('user_id', $userId)->max('order') + 1,
+            'is_active' => true,
+            'stop_processing' => false,
+        ]);
+    }
+
+    private function nextRuleOrder(int $groupId): int
+    {
+        return (int) UserRule::query()->where('user_rule_group_id', $groupId)->max('order') + 1;
+    }
+}

--- a/app/Services/CategoryRuleGenerator.php
+++ b/app/Services/CategoryRuleGenerator.php
@@ -53,10 +53,12 @@ final readonly class CategoryRuleGenerator
 
     private function applyToExisting(int $userId, UserRule $rule): void
     {
+        // Stream by id rather than loading the whole history into memory. Keying
+        // on the (unchanging) id keeps paging stable even though we mutate rows.
         Transaction::query()
             ->where('user_id', $userId)
             ->current()
-            ->get()
+            ->lazyById()
             ->each(function (Transaction $transaction) use ($rule): void {
                 if ($this->evaluator->matches($transaction, $rule)) {
                     $this->executor->execute($transaction, $rule->actions);

--- a/resources/views/livewire/transaction-modal.blade.php
+++ b/resources/views/livewire/transaction-modal.blade.php
@@ -165,6 +165,14 @@
                 :placeholder="__('No category')"
             />
 
+            @if($editingTransactionId && $mode === 'plan' && $transactionType !== 'transfer')
+                <flux:field variant="inline">
+                    <flux:checkbox wire:model="categoriseMatching"/>
+                    <flux:label>{{ __('Also categorise matching transactions') }}</flux:label>
+                    <flux:description>{{ __('Creates a rule that applies this category to past and future transactions from the same merchant.') }}</flux:description>
+                </flux:field>
+            @endif
+
             {{-- Plan-mode fields --}}
             @if($mode === 'plan')
                 <flux:input

--- a/tests/Feature/Livewire/TransactionModalTest.php
+++ b/tests/Feature/Livewire/TransactionModalTest.php
@@ -15,6 +15,7 @@ use App\Models\Category;
 use App\Models\PlannedTransaction;
 use App\Models\Transaction;
 use App\Models\User;
+use App\Models\UserRule;
 use App\Support\Calendar\DayActivityLoader;
 use Carbon\CarbonImmutable;
 use Livewire\Livewire;
@@ -2301,7 +2302,7 @@ test('basiq transaction cannot be converted to income via tampered transactionTy
 
 // ── Enter/Plan Mode Conversion (#136) ─────────────────────────────
 
-test('converting entered expense to planned expense soft-deletes transaction and creates planned', function () {
+test('converting an entered expense to a plan keeps and reconciles the source', function () {
     $user = User::factory()->create();
     $account = Account::factory()->for($user)->create();
     $category = Category::factory()->create(['is_hidden' => false]);
@@ -2327,10 +2328,6 @@ test('converting entered expense to planned expense soft-deletes transaction and
         ->assertHasNoErrors()
         ->assertDispatched('transaction-saved');
 
-    expect(Transaction::query()->find($transaction->id))
-        ->toBeNull()
-        ->and(Transaction::withTrashed()->find($transaction->id))->not->toBeNull();
-
     $planned = PlannedTransaction::query()->where('user_id', $user->id)->first();
 
     expect($planned)
@@ -2342,6 +2339,10 @@ test('converting entered expense to planned expense soft-deletes transaction and
         ->description->toBe('gym membership')
         ->frequency->toBe(RecurrenceFrequency::EveryMonth)
         ->is_active->toBeTrue();
+
+    // The source transaction is kept and reconciled to the new plan (not deleted).
+    expect(Transaction::query()->find($transaction->id))->not->toBeNull()
+        ->and($transaction->fresh()->planned_transaction_id)->toBe($planned->id);
 });
 
 test('converting entered income to planned income preserves credit direction', function () {
@@ -2374,7 +2375,7 @@ test('converting entered income to planned income preserves credit direction', f
         ->amount->toBe(200000);
 });
 
-test('converting entered transfer to planned transfer soft-deletes both sides', function () {
+test('converting an entered transfer to a plan keeps both sides', function () {
     $user = User::factory()->create();
     $fromAccount = Account::factory()->for($user)->create();
     $toAccount = Account::factory()->for($user)->create();
@@ -2412,12 +2413,10 @@ test('converting entered transfer to planned transfer soft-deletes both sides', 
         ->assertSet('showModal', false)
         ->assertHasNoErrors();
 
-    expect(Transaction::query()->find($debit->id))
-        ->toBeNull()
-        ->and(Transaction::query()->find($credit->id))->toBeNull()
-        ->and(Transaction::withTrashed()->find($debit->id))->not
-        ->toBeNull()
-        ->and(Transaction::withTrashed()->find($credit->id))->not->toBeNull();
+    expect(Transaction::query()->find($debit->id))->not->toBeNull()
+        ->and(Transaction::query()->find($credit->id))->not->toBeNull()
+        ->and($debit->fresh()->planned_transaction_id)->toBeNull()
+        ->and($credit->fresh()->planned_transaction_id)->toBeNull();
 
     $planned = PlannedTransaction::query()->where('user_id', $user->id)->first();
 
@@ -2584,7 +2583,8 @@ test('converting entered expense to planned transfer with mode and type change',
         ->assertSet('showModal', false)
         ->assertHasNoErrors();
 
-    expect(Transaction::query()->find($expense->id))->toBeNull();
+    expect(Transaction::query()->find($expense->id))->not->toBeNull()
+        ->and($expense->fresh()->planned_transaction_id)->toBeNull();
 
     $planned = PlannedTransaction::query()->where('user_id', $user->id)->first();
 
@@ -2632,9 +2632,9 @@ test('converting entered transfer to planned expense with mode and type change',
         ->assertSet('showModal', false)
         ->assertHasNoErrors();
 
-    expect(Transaction::query()->find($debit->id))
-        ->toBeNull()
-        ->and(Transaction::query()->find($credit->id))->toBeNull();
+    expect(Transaction::query()->find($debit->id))->not->toBeNull()
+        ->and(Transaction::query()->find($credit->id))->not->toBeNull()
+        ->and($debit->fresh()->planned_transaction_id)->toBeNull();
 
     $planned = PlannedTransaction::query()->where('user_id', $user->id)->first();
 
@@ -2725,7 +2725,7 @@ test('converting planned transfer to entered expense with mode and type change',
         ->transfer_pair_id->toBeNull();
 });
 
-test('converting edited transaction to planned soft-deletes entire ancestor chain', function () {
+test('converting an edited transaction to a plan keeps and reconciles the current version', function () {
     $user = User::factory()->create();
     $account = Account::factory()->for($user)->create();
     $category = Category::factory()->create(['is_hidden' => false]);
@@ -2753,16 +2753,17 @@ test('converting edited transaction to planned soft-deletes entire ancestor chai
         ->assertSet('showModal', false)
         ->assertHasNoErrors();
 
-    expect(Transaction::withTrashed()->find($child->id)->deleted_at)->not
-        ->toBeNull()
-        ->and(Transaction::withTrashed()->find($parent->id)->deleted_at)->not
-        ->toBeNull()
-        ->and(Transaction::query()->current()->where('user_id', $user->id)->count())->toBe(0);
+    $planned = PlannedTransaction::query()->where('user_id', $user->id)->first();
 
-    expect(PlannedTransaction::query()->where('user_id', $user->id)->first())->not->toBeNull();
+    // The current version is kept and reconciled; the superseded parent stays trashed.
+    expect($planned)->not->toBeNull()
+        ->and(Transaction::query()->find($child->id))->not->toBeNull()
+        ->and($child->fresh()->planned_transaction_id)->toBe($planned->id)
+        ->and(Transaction::withTrashed()->find($parent->id)->deleted_at)->not->toBeNull()
+        ->and(Transaction::query()->current()->where('user_id', $user->id)->count())->toBe(1);
 });
 
-test('converting edited transfer to planned soft-deletes entire ancestor chain including pairs', function () {
+test('converting an edited transfer to a plan keeps the current versions', function () {
     $user = User::factory()->create();
     $fromAccount = Account::factory()->for($user)->create();
     $toAccount = Account::factory()->for($user)->create();
@@ -2809,13 +2810,11 @@ test('converting edited transfer to planned soft-deletes entire ancestor chain i
         ->assertSet('showModal', false)
         ->assertHasNoErrors();
 
-    expect(Transaction::query()->where('user_id', $user->id)->count())->toBe(0);
-
-    $allTrashed = Transaction::withTrashed()->where('user_id', $user->id)->get();
-
-    expect($allTrashed)
-        ->toHaveCount(4)
-        ->each(fn ($t) => $t->deleted_at->not->toBeNull());
+    // The two current transfer legs are kept; only the superseded parents stay trashed.
+    expect(Transaction::query()->current()->where('user_id', $user->id)->count())->toBe(2)
+        ->and(Transaction::onlyTrashed()->where('user_id', $user->id)->count())->toBe(2)
+        ->and($debitChild->fresh()->planned_transaction_id)->toBeNull()
+        ->and($creditChild->fresh()->planned_transaction_id)->toBeNull();
 
     expect(PlannedTransaction::query()->where('user_id', $user->id)->first())->not->toBeNull();
 });
@@ -3032,7 +3031,7 @@ test('copy-transaction prefills a new entry from an existing transaction', funct
         ->assertSet('date', '2026-03-18');
 });
 
-test('converting an entered transaction to planned keeps a planned occurrence on that date', function () {
+test('converting an entered transaction to a plan reconciles the source on that date', function () {
     $user = User::factory()->create();
     $account = Account::factory()->for($user)->create();
     $category = Category::factory()->create(['is_hidden' => false]);
@@ -3065,16 +3064,17 @@ test('converting an entered transaction to planned keeps a planned occurrence on
         ->and($planned->direction)->toBe(TransactionDirection::Debit)
         ->and($planned->frequency)->toBe(RecurrenceFrequency::EveryMonth);
 
-    // The original actual is soft-deleted (recoverable, not hard-deleted), and
-    // the day still surfaces the converted plan as a planned occurrence (so the
-    // date is not left empty).
-    expect(Transaction::query()->find($transaction->id))->toBeNull()
-        ->and(Transaction::withTrashed()->find($transaction->id)?->trashed())->toBeTrue();
+    // The source is kept and reconciled to the plan, so the day surfaces the posted
+    // transaction (matched) rather than double-counting it as a separate plan pip.
+    expect(Transaction::query()->find($transaction->id))->not->toBeNull()
+        ->and($transaction->fresh()->planned_transaction_id)->toBe($planned->id);
 
     $activity = app(DayActivityLoader::class)->load($date->startOfMonth(), $date->endOfMonth(), $user->id);
     $day = $activity[$date->format('Y-m-d')] ?? null;
+    $kinds = collect($day->pips)->pluck('kind')->all();
     expect($day)->not->toBeNull()
-        ->and(collect($day->pips)->pluck('kind')->all())->toContain('plan');
+        ->and($kinds)->toContain('out')
+        ->and($kinds)->not->toContain('plan');
 });
 
 test('opening a past planned occurrence shows the Enter expense action', function () {
@@ -3200,4 +3200,85 @@ test('entering a past planned transfer occurrence links both legs to the plan', 
 
     expect(PlannedTransaction::query()->find($planned->id))->not->toBeNull()
         ->and(Transaction::query()->where('planned_transaction_id', $planned->id)->count())->toBe(2);
+});
+
+test('converting to a plan with categorise-matching ticked creates a rule and categorises matching transactions', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $category = Category::factory()->create(['is_hidden' => false]);
+
+    $source = Transaction::factory()->for($user)->for($account)->manual()->create([
+        'merchant_name' => 'Netflix',
+        'amount' => 1599,
+        'direction' => TransactionDirection::Debit,
+        'description' => 'NETFLIX',
+        'post_date' => '2026-03-15',
+        'category_id' => null,
+    ]);
+    $sibling = Transaction::factory()->for($user)->for($account)->manual()->create([
+        'merchant_name' => 'Netflix',
+        'amount' => 1599,
+        'direction' => TransactionDirection::Debit,
+        'description' => 'NETFLIX',
+        'post_date' => '2026-02-15',
+        'category_id' => null,
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('edit-transaction', id: $source->id)
+        ->set('mode', 'plan')
+        ->set('transactionType', 'expense')
+        ->set('descriptionInput', '15.99 NETFLIX')
+        ->set('categoryId', $category->id)
+        ->set('frequency', RecurrenceFrequency::EveryMonth->value)
+        ->set('categoriseMatching', true)
+        ->call('save')
+        ->assertHasNoErrors()
+        ->assertSet('showModal', false);
+
+    $rule = UserRule::query()->where('user_id', $user->id)->first();
+
+    expect($rule)->not->toBeNull()
+        ->and($rule->is_auto_apply)->toBeTrue()
+        ->and($rule->actions)->toBe([['type' => 'set_category', 'value' => (string) $category->id]]);
+
+    expect($source->fresh()->category_id)->toBe($category->id)
+        ->and($sibling->fresh()->category_id)->toBe($category->id);
+});
+
+test('converting to a plan without ticking categorise-matching creates no rule and leaves siblings untouched', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $category = Category::factory()->create(['is_hidden' => false]);
+
+    $source = Transaction::factory()->for($user)->for($account)->manual()->create([
+        'merchant_name' => 'Netflix',
+        'amount' => 1599,
+        'direction' => TransactionDirection::Debit,
+        'description' => 'NETFLIX',
+        'post_date' => '2026-03-15',
+        'category_id' => null,
+    ]);
+    $sibling = Transaction::factory()->for($user)->for($account)->manual()->create([
+        'merchant_name' => 'Netflix',
+        'amount' => 1599,
+        'direction' => TransactionDirection::Debit,
+        'description' => 'NETFLIX',
+        'category_id' => null,
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('edit-transaction', id: $source->id)
+        ->set('mode', 'plan')
+        ->set('transactionType', 'expense')
+        ->set('descriptionInput', '15.99 NETFLIX')
+        ->set('categoryId', $category->id)
+        ->set('frequency', RecurrenceFrequency::EveryMonth->value)
+        ->call('save')
+        ->assertHasNoErrors();
+
+    expect(UserRule::query()->where('user_id', $user->id)->count())->toBe(0)
+        ->and($sibling->fresh()->category_id)->toBeNull();
 });

--- a/tests/Feature/Services/CategoryRuleGeneratorTest.php
+++ b/tests/Feature/Services/CategoryRuleGeneratorTest.php
@@ -1,0 +1,103 @@
+<?php
+
+/** @noinspection StaticClosureCanBeUsedInspection */
+
+declare(strict_types=1);
+
+use App\Enums\TransactionDirection;
+use App\Models\Account;
+use App\Models\Category;
+use App\Models\Transaction;
+use App\Models\User;
+use App\Models\UserRule;
+use App\Services\CategoryRuleGenerator;
+
+test('it creates an auto-apply set_category rule and categorises existing matches', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $category = Category::factory()->create(['is_hidden' => false]);
+
+    $source = Transaction::factory()->for($user)->for($account)->manual()->create([
+        'merchant_name' => 'Netflix',
+        'description' => 'NETFLIX.COM 1234',
+        'direction' => TransactionDirection::Debit,
+        'category_id' => null,
+    ]);
+    $sibling = Transaction::factory()->for($user)->for($account)->manual()->create([
+        'merchant_name' => 'Netflix',
+        'description' => 'NETFLIX.COM 9999',
+        'direction' => TransactionDirection::Debit,
+        'category_id' => null,
+    ]);
+    $unrelated = Transaction::factory()->for($user)->for($account)->manual()->create([
+        'merchant_name' => 'Spotify',
+        'description' => 'SPOTIFY',
+        'direction' => TransactionDirection::Debit,
+        'category_id' => null,
+    ]);
+
+    $rule = app(CategoryRuleGenerator::class)->generateAndApply($source, $category->id);
+
+    expect($rule->is_auto_apply)->toBeTrue()
+        ->and($rule->is_active)->toBeTrue()
+        ->and($rule->user_id)->toBe($user->id)
+        ->and($rule->actions)->toBe([['type' => 'set_category', 'value' => (string) $category->id]])
+        ->and($rule->triggers[0]['field'])->toBe('merchant_name')
+        ->and($rule->triggers[0]['operator'])->toBe('equals')
+        ->and($rule->triggers[0]['value'])->toBe('Netflix');
+
+    expect($source->fresh()->category_id)->toBe($category->id)
+        ->and($sibling->fresh()->category_id)->toBe($category->id)
+        ->and($unrelated->fresh()->category_id)->toBeNull();
+});
+
+test('it falls back to a description token trigger when there is no merchant name', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $category = Category::factory()->create(['is_hidden' => false]);
+
+    $source = Transaction::factory()->for($user)->for($account)->manual()->create([
+        'merchant_name' => null,
+        'clean_description' => null,
+        'description' => 'WOOLWORTHS 1234 SYDNEY',
+        'direction' => TransactionDirection::Debit,
+        'category_id' => null,
+    ]);
+    $sibling = Transaction::factory()->for($user)->for($account)->manual()->create([
+        'merchant_name' => null,
+        'clean_description' => null,
+        'description' => 'WOOLWORTHS 5678 MELBOURNE',
+        'direction' => TransactionDirection::Debit,
+        'category_id' => null,
+    ]);
+
+    $rule = app(CategoryRuleGenerator::class)->generateAndApply($source, $category->id);
+
+    expect($rule->triggers[0]['field'])->toBe('description')
+        ->and($rule->triggers[0]['operator'])->toBe('contains')
+        ->and(mb_stripos($source->description, $rule->triggers[0]['value']))->not->toBeFalse();
+
+    expect($source->fresh()->category_id)->toBe($category->id)
+        ->and($sibling->fresh()->category_id)->toBe($category->id);
+});
+
+test('it reuses a single auto-categorisation group across generated rules', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $category = Category::factory()->create(['is_hidden' => false]);
+
+    $netflix = Transaction::factory()->for($user)->for($account)->manual()->create([
+        'merchant_name' => 'Netflix',
+        'direction' => TransactionDirection::Debit,
+    ]);
+    $spotify = Transaction::factory()->for($user)->for($account)->manual()->create([
+        'merchant_name' => 'Spotify',
+        'direction' => TransactionDirection::Debit,
+    ]);
+
+    $first = app(CategoryRuleGenerator::class)->generateAndApply($netflix, $category->id);
+    $second = app(CategoryRuleGenerator::class)->generateAndApply($spotify, $category->id);
+
+    expect($second->user_rule_group_id)->toBe($first->user_rule_group_id)
+        ->and(UserRule::query()->where('user_id', $user->id)->count())->toBe(2);
+});


### PR DESCRIPTION
Second slice of the transaction-modal type-by-date work (plan doc `docs/plans/2026-06-02-transaction-modal-type-by-date.md`, PR B). Closes the convert-to-plan asks #3 and #4. Follows #270/#271.

## Ask #3 — "Convert to plan" keeps the source
`TransactionModal::convertEnteredToPlanned()` no longer soft-deletes the source transaction. It creates the plan from the entered date and, for plain (non-transfer) postings, **reconciles the source to the new plan** (`planned_transaction_id`) so the source's occurrence on the start date isn't double-counted on the calendar. The transaction's own fields (amount/description/date/category) are left untouched. The now-unused `softDeleteWithAncestors` helper is removed.

## Ask #4 — user-driven categorisation rule (revised approach)
Instead of silently bulk-recategorising matching transactions, the convert-to-plan modal gains an **"Also categorise matching transactions"** checkbox (shown when converting an existing transaction to a plan, non-transfer). When ticked with a category set, a new `CategoryRuleGenerator`:
- creates a `set_category` `UserRule` keyed to the merchant (trigger: `merchant_name equals` when present, else a `description`/`clean_description` merchant-token `contains`),
- **applies it immediately** to the user's existing matching transactions, and
- persists it as an auto-apply rule, so future imports keep being categorised by the normal `UserRulesStage`.

The user opts in (or not) at conversion time; nothing is changed silently. This reuses the existing rules engine (`RuleEvaluator` + `RuleActionExecutor`) rather than a one-off bulk update.

## Verification
- Convert-to-plan tests rewritten to assert the source is **kept and reconciled** (expense / income / transfer, edited ancestor chains, and the calendar dedupe — the day shows the matched posted pip, not a duplicate plan pip).
- `CategoryRuleGeneratorTest`: rule shape + auto-apply, merchant-name and description-token triggers, immediate application to existing matches, non-matching left untouched, single shared rule group.
- `TransactionModalTest`: checkbox **on** creates the rule and categorises past siblings; checkbox **off** creates no rule and leaves siblings untouched.
- Full Unit+Feature+Arch suite **1654 passed**; Pint + PHPStan clean (GrumPHP). Browser suite not run locally (needs Chromium).

Refs #272