### PR TITLE
chore(#276): feature-flag off recurring auto-detection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,6 +68,9 @@ BASIQ_CONSENT_URL=
 BASIQ_WEBHOOK_SECRET=
 BASIQ_SEED_USER_ID=
 
+# Recurring transaction auto-detection (off while the import/reconcile flow is stabilised)
+BUDGET_RECURRING_DETECTION=false
+
 # Fine-grained PAT: "Contents: read and write" for screenshot uploads via release assets
 # Classic PAT: "repo" scope
 # Without these permissions, issues are still created but screenshots are skipped

--- a/app/Livewire/AnalysisSuggestions.php
+++ b/app/Livewire/AnalysisSuggestions.php
@@ -171,6 +171,7 @@ final class AnalysisSuggestions extends Component
         $suggestions = AnalysisSuggestion::query()
             ->where('user_id', auth()->id())
             ->pending()
+            ->unless((bool) config('budget.recurring_detection'), fn ($q) => $q->whereNot('type', SuggestionType::RecurringTransaction))
             ->get()
             ->groupBy(fn (AnalysisSuggestion $s) => $s->type->value);
 

--- a/app/Livewire/AnalysisSuggestions.php
+++ b/app/Livewire/AnalysisSuggestions.php
@@ -171,7 +171,7 @@ final class AnalysisSuggestions extends Component
         $suggestions = AnalysisSuggestion::query()
             ->where('user_id', auth()->id())
             ->pending()
-            ->unless((bool) config('budget.recurring_detection'), fn ($q) => $q->whereNot('type', SuggestionType::RecurringTransaction))
+            ->unless((bool) config('budget.recurring_detection'), fn ($q) => $q->where('type', '!=', SuggestionType::RecurringTransaction))
             ->get()
             ->groupBy(fn (AnalysisSuggestion $s) => $s->type->value);
 

--- a/app/Services/PipelineStages/IdentifyRecurringTransactionsStage.php
+++ b/app/Services/PipelineStages/IdentifyRecurringTransactionsStage.php
@@ -75,7 +75,7 @@ final readonly class IdentifyRecurringTransactionsStage implements PipelineStage
 
     public function shouldRun(PipelineContext $context): bool
     {
-        return true;
+        return (bool) config('budget.recurring_detection');
     }
 
     public function execute(PipelineContext $context): StageResult

--- a/config/budget.php
+++ b/config/budget.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Recurring Transaction Auto-Detection
+    |--------------------------------------------------------------------------
+    |
+    | When enabled, the analysis pipeline scans imported transactions for
+    | recurring patterns and surfaces them as suggestions that can be turned
+    | into planned transactions. Disabled by default while the core
+    | import/reconcile flow is stabilised; it will be rewired into the user
+    | rule system before being re-enabled.
+    |
+    */
+
+    'recurring_detection' => env('BUDGET_RECURRING_DETECTION', false),
+
+];

--- a/tests/Feature/Livewire/AnalysisSuggestionsTest.php
+++ b/tests/Feature/Livewire/AnalysisSuggestionsTest.php
@@ -24,6 +24,7 @@ beforeEach(function () {
     $this->user = User::factory()->create();
     $this->account = Account::factory()->for($this->user)->create();
     $this->pipelineRun = PipelineRun::factory()->for($this->user)->create();
+    config(['budget.recurring_detection' => true]);
 });
 
 function primaryAccountPayload(int $accountId, string $accountName = 'Everyday Account'): array
@@ -204,6 +205,15 @@ test('recurring-transaction accept button uses yellow-pill markup, not flux prim
         ->assertSee('Accept');
 
     expect($component->html())->toMatch('/wire:click="acceptRecurringTransaction\(\d+\)"[^>]*?bg-cib-yellow-400/s');
+});
+test('recurring-transaction suggestions are hidden when auto-detection is disabled', function () {
+    config(['budget.recurring_detection' => false]);
+
+    $suggestion = createSuggestion($this, 'recurring', recurringPayload($this->account->id));
+
+    Livewire::actingAs($this->user)
+        ->test(AnalysisSuggestions::class)
+        ->assertDontSeeHtml('wire:click="acceptRecurringTransaction('.$suggestion->id.')"');
 });
 
 test('user-rule accept button uses yellow-pill markup, not flux primary', function () {

--- a/tests/Feature/Services/PipelineStages/IdentifyRecurringTransactionsStageTest.php
+++ b/tests/Feature/Services/PipelineStages/IdentifyRecurringTransactionsStageTest.php
@@ -821,6 +821,8 @@ test('creates audit entries for skipped candidates with reason in metadata', fun
 // ─── Integration ────────────────────────────────────────────────────────
 
 test('stage is registered in pipeline and full run produces suggestions', function () {
+    config(['budget.recurring_detection' => true]);
+
     createMonthlyGroup($this->user, $this->account, 'Netflix', 1699, 3);
 
     $pipeline = app(App\Services\TransactionAnalysisPipeline::class);
@@ -846,7 +848,11 @@ test('label returns human-readable string', function () {
     expect($this->stage->label())->toBe('Identify Recurring Transactions');
 });
 
-test('shouldRun always returns true', function () {
+test('shouldRun reflects the recurring detection config flag', function () {
+    config(['budget.recurring_detection' => false]);
+    expect($this->stage->shouldRun($this->context))->toBeFalse();
+
+    config(['budget.recurring_detection' => true]);
     expect($this->stage->shouldRun($this->context))->toBeTrue();
 });
 

--- a/tests/Feature/Services/PipelineStages/IdentifyRecurringTransactionsStageTest.php
+++ b/tests/Feature/Services/PipelineStages/IdentifyRecurringTransactionsStageTest.php
@@ -838,6 +838,25 @@ test('stage is registered in pipeline and full run produces suggestions', functi
     expect($suggestions)->toHaveCount(1);
 });
 
+test('stage is skipped in a full run when recurring detection is disabled', function () {
+    config(['budget.recurring_detection' => false]);
+
+    createMonthlyGroup($this->user, $this->account, 'Netflix', 1699, 3);
+
+    $pipeline = app(App\Services\TransactionAnalysisPipeline::class);
+    $run = $pipeline->run($this->user, App\Enums\PipelineTrigger::Sync);
+
+    expect($run->stages_skipped)->toContain('identify-recurring-transactions')
+        ->and($run->stages_completed)->not->toContain('identify-recurring-transactions');
+
+    $suggestions = AnalysisSuggestion::query()
+        ->where('pipeline_run_id', $run->id)
+        ->where('type', SuggestionType::RecurringTransaction)
+        ->get();
+
+    expect($suggestions)->toBeEmpty();
+});
+
 // ─── Contract ───────────────────────────────────────────────────────────
 
 test('key returns expected string', function () {

--- a/tests/Feature/Services/PostImportAnalysisCsvTest.php
+++ b/tests/Feature/Services/PostImportAnalysisCsvTest.php
@@ -33,6 +33,8 @@ function importedCsvTransaction(User $user, Account $account, array $overrides):
 }
 
 test('a clean CSV import auto-sets the primary account and pay cycle and surfaces recurring suggestions', function () {
+    config(['budget.recurring_detection' => true]);
+
     $user = User::factory()->create([
         'primary_account_id' => null,
         'pay_amount' => null,


### PR DESCRIPTION
## What
Gate the recurring-transaction auto-detection behind a config flag, defaulting **off**, while the import/reconcile flow is stabilised.

## Why
`IdentifyRecurringTransactionsStage` surfaced `RecurringTransaction` suggestions that become planned transactions, adding noise and contributing to the planned/entered calendar duplicates (the 5 Jun issue). Pausing it isolates the core flow work. The code is retained for the planned rule-system integration.

## Changes
- New `config/budget.php` → `recurring_detection` from `BUDGET_RECURRING_DETECTION` (default `false`); added to `.env.example`.
- `IdentifyRecurringTransactionsStage::shouldRun()` now returns the flag (pipeline records the stage as skipped when off).
- `AnalysisSuggestions` hides `RecurringTransaction` suggestions when the flag is off.

## Tests
- New: `shouldRun reflects the recurring detection config flag` (both states); `recurring-transaction suggestions are hidden when auto-detection is disabled`.
- Recurring-feature tests opt into the flag (`AnalysisSuggestionsTest` beforeEach, `PostImportAnalysisCsvTest`, the recurring stage integration test).
- Verified green via `op test.filter`: IdentifyRecurringTransactionsStageTest (46), AnalysisSuggestionsTest (34), PostImportAnalysisCsvTest (1), SetPayCycleStageTest (17), IdentifyPrimaryAccountStageTest (29). Pint + PHPStan (app/config) clean; GrumPHP pre-commit passed.

Design: `docs/plans/2026-06-05-transaction-reconciliation-lifecycle-design.md` (section E).

Closes #276