### PR TITLE
refactor(#277): ReconciliationPolicy + transaction lifecycle events

### DIFF
--- a/app/Events/PlannedTransactionCreated.php
+++ b/app/Events/PlannedTransactionCreated.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Events;
+
+use App\Models\PlannedTransaction;
+
+/**
+ * A planned transaction was created — manually, by promoting an existing transaction,
+ * or from an accepted analysis suggestion. Listeners can react (e.g. reconcile existing
+ * postings to the new plan) without the creation sites needing to know about them.
+ */
+final class PlannedTransactionCreated
+{
+    public function __construct(
+        public PlannedTransaction $plannedTransaction,
+    ) {}
+}

--- a/app/Events/TransactionEntered.php
+++ b/app/Events/TransactionEntered.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Events;
+
+use App\Models\Transaction;
+
+/**
+ * A posted transaction entered the ledger (CSV import, manual entry, or Basiq sync)
+ * without matching an active planned transaction. It stands on its own.
+ */
+final class TransactionEntered
+{
+    public function __construct(
+        public Transaction $transaction,
+    ) {}
+}

--- a/app/Events/TransactionReconciled.php
+++ b/app/Events/TransactionReconciled.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Events;
+
+use App\Models\Transaction;
+
+/**
+ * A posted transaction was reconciled to a planned transaction at ingress — it fulfils
+ * that planned occurrence, so the calendar renders one pip instead of a planned and an
+ * entered pip on the same day.
+ */
+final class TransactionReconciled
+{
+    public function __construct(
+        public Transaction $transaction,
+        public int $plannedTransactionId,
+    ) {}
+}

--- a/app/Models/PlannedTransaction.php
+++ b/app/Models/PlannedTransaction.php
@@ -8,6 +8,7 @@ use App\Casts\MoneyCast;
 use App\Enums\RecurrenceFrequency;
 use App\Enums\TransactionDirection;
 use App\Events\PlannedTransactionCategoryUpdated;
+use App\Events\PlannedTransactionCreated;
 use Carbon\CarbonImmutable;
 use Database\Factories\PlannedTransactionFactory;
 use Illuminate\Database\Eloquent\Builder;
@@ -169,6 +170,10 @@ final class PlannedTransaction extends Model
 
     protected static function booted(): void
     {
+        self::created(static function (PlannedTransaction $plannedTransaction): void {
+            event(new PlannedTransactionCreated($plannedTransaction));
+        });
+
         self::updated(static function (PlannedTransaction $plannedTransaction): void {
             if ($plannedTransaction->wasChanged('category_id')) {
                 event(new PlannedTransactionCategoryUpdated(

--- a/app/Services/PlannedTransactionMatcher.php
+++ b/app/Services/PlannedTransactionMatcher.php
@@ -15,10 +15,11 @@ use Illuminate\Support\Collection;
  * planned_transaction_id. Runs during sync/import so an occurred payment is recognised as
  * "that planned item" instead of showing as a separate forecast on the calendar.
  *
- * A match needs the same account + direction, an EXACT amount, and a post_date within
- * ReconciliationMatcher::DATE_TOLERANCE_DAYS of a plan occurrence. Matching is one-to-one and
- * uses the same integer day-diff + greedy-nearest claim as the calendar loader, so a match and
- * the calendar agree on which occurrence owns which transaction.
+ * A match needs the same account + direction, an amount within ReconciliationPolicy's
+ * tolerance, and a post_date within ReconciliationPolicy::DATE_TOLERANCE_DAYS of a plan
+ * occurrence. Matching is one-to-one and uses the same integer day-diff + greedy-nearest
+ * claim as the calendar loader, so a match and the calendar agree on which occurrence owns
+ * which transaction.
  */
 final readonly class PlannedTransactionMatcher
 {
@@ -26,7 +27,7 @@ final readonly class PlannedTransactionMatcher
 
     public function matchForUser(User $user): int
     {
-        $tolerance = ReconciliationMatcher::DATE_TOLERANCE_DAYS;
+        $tolerance = ReconciliationPolicy::DATE_TOLERANCE_DAYS;
         $today = CarbonImmutable::today();
         $windowStart = $today->subDays(self::LOOKBACK_DAYS);
         $windowEnd = $today->addDays($tolerance);
@@ -71,7 +72,7 @@ final readonly class PlannedTransactionMatcher
 
         foreach ($plans as $plan) {
             $candidates = ($unmatchedByGroup->get($plan->account_id.'|'.$plan->direction->value) ?? collect())
-                ->filter(fn (Transaction $t): bool => abs((int) $t->amount) === (int) $plan->amount)
+                ->filter(fn (Transaction $t): bool => ReconciliationPolicy::amountMatches((int) $t->amount, (int) $plan->amount))
                 ->values();
 
             $existing = ($matchedByPlan->get($plan->id) ?? collect())->values();

--- a/app/Services/ReconciliationMatcher.php
+++ b/app/Services/ReconciliationMatcher.php
@@ -11,9 +11,9 @@ use Illuminate\Support\Collection;
 
 final readonly class ReconciliationMatcher
 {
-    public const float AMOUNT_TOLERANCE = 0.10;
+    public const float AMOUNT_TOLERANCE = ReconciliationPolicy::AMOUNT_TOLERANCE;
 
-    public const int DATE_TOLERANCE_DAYS = 3;
+    public const int DATE_TOLERANCE_DAYS = ReconciliationPolicy::DATE_TOLERANCE_DAYS;
 
     /**
      * @return Collection<int, Transaction>
@@ -22,8 +22,7 @@ final readonly class ReconciliationMatcher
     {
         $dateFrom = $occurrenceDate->subDays(self::DATE_TOLERANCE_DAYS);
         $dateTo = $occurrenceDate->addDays(self::DATE_TOLERANCE_DAYS);
-        $minAmount = (int) floor($planned->amount * (1 - self::AMOUNT_TOLERANCE));
-        $maxAmount = (int) ceil($planned->amount * (1 + self::AMOUNT_TOLERANCE));
+        [$minAmount, $maxAmount] = ReconciliationPolicy::amountRange((int) $planned->amount);
 
         return Transaction::query()
             ->where('user_id', $planned->user_id)
@@ -40,6 +39,51 @@ final readonly class ReconciliationMatcher
                 fn (Transaction $a, Transaction $b) => abs(abs($a->amount) - abs($planned->amount)) <=> abs(abs($b->amount) - abs($planned->amount)),
             ])
             ->values();
+    }
+
+    /**
+     * The active planned transaction this posting fulfils, or null. Mirrors findSuggestions
+     * in reverse: same account + direction, amount within tolerance, and an occurrence within
+     * the date tolerance that no other transaction has already reconciled. When several plans
+     * qualify, the one whose nearest unclaimed occurrence sits closest to the post date wins.
+     */
+    public function findPlanForTransaction(Transaction $transaction): ?PlannedTransaction
+    {
+        $windowStart = $transaction->post_date->subDays(ReconciliationPolicy::DATE_TOLERANCE_DAYS);
+        $windowEnd = $transaction->post_date->addDays(ReconciliationPolicy::DATE_TOLERANCE_DAYS);
+
+        $plans = PlannedTransaction::query()
+            ->where('user_id', $transaction->user_id)
+            ->where('account_id', $transaction->account_id)
+            ->where('direction', $transaction->direction)
+            ->where('is_active', true)
+            ->excludingTransfers()
+            ->get()
+            ->filter(fn (PlannedTransaction $plan): bool => ReconciliationPolicy::amountMatches((int) $transaction->amount, (int) $plan->amount));
+
+        $bestPlan = null;
+        $bestDiff = null;
+
+        foreach ($plans as $plan) {
+            foreach ($plan->occurrencesBetween($windowStart, $windowEnd) as $occurrence) {
+                $diff = ReconciliationPolicy::dayDiff($transaction->post_date, $occurrence);
+
+                if ($diff > ReconciliationPolicy::DATE_TOLERANCE_DAYS) {
+                    continue;
+                }
+
+                if ($this->findLinkedForOccurrence($plan, $occurrence) !== null) {
+                    continue;
+                }
+
+                if ($bestDiff === null || $diff < $bestDiff) {
+                    $bestDiff = $diff;
+                    $bestPlan = $plan;
+                }
+            }
+        }
+
+        return $bestPlan;
     }
 
     public function findLinkedForOccurrence(PlannedTransaction $planned, CarbonImmutable $occurrenceDate): ?Transaction

--- a/app/Services/ReconciliationMatcher.php
+++ b/app/Services/ReconciliationMatcher.php
@@ -63,6 +63,8 @@ final readonly class ReconciliationMatcher
                 $query->whereNull('until_date')->orWhere('until_date', '>=', $windowStart);
             })
             ->excludingTransfers()
+            ->orderBy('start_date')
+            ->orderBy('id')
             ->get()
             ->filter(fn (PlannedTransaction $plan): bool => ReconciliationPolicy::amountMatches((int) $transaction->amount, (int) $plan->amount));
 

--- a/app/Services/ReconciliationMatcher.php
+++ b/app/Services/ReconciliationMatcher.php
@@ -49,30 +49,55 @@ final readonly class ReconciliationMatcher
      */
     public function findPlanForTransaction(Transaction $transaction): ?PlannedTransaction
     {
-        $windowStart = $transaction->post_date->subDays(ReconciliationPolicy::DATE_TOLERANCE_DAYS);
-        $windowEnd = $transaction->post_date->addDays(ReconciliationPolicy::DATE_TOLERANCE_DAYS);
+        $tolerance = ReconciliationPolicy::DATE_TOLERANCE_DAYS;
+        $windowStart = $transaction->post_date->subDays($tolerance);
+        $windowEnd = $transaction->post_date->addDays($tolerance);
 
         $plans = PlannedTransaction::query()
             ->where('user_id', $transaction->user_id)
             ->where('account_id', $transaction->account_id)
             ->where('direction', $transaction->direction)
             ->where('is_active', true)
+            ->where('start_date', '<=', $windowEnd)
+            ->where(static function ($query) use ($windowStart): void {
+                $query->whereNull('until_date')->orWhere('until_date', '>=', $windowStart);
+            })
             ->excludingTransfers()
             ->get()
             ->filter(fn (PlannedTransaction $plan): bool => ReconciliationPolicy::amountMatches((int) $transaction->amount, (int) $plan->amount));
+
+        if ($plans->isEmpty()) {
+            return null;
+        }
+
+        // Occurrences already reconciled by another transaction, fetched once and matched
+        // in-memory so the ingress path doesn't issue a query per candidate occurrence.
+        $claimedByPlan = Transaction::query()
+            ->where('user_id', $transaction->user_id)
+            ->current()
+            ->whereIn('planned_transaction_id', $plans->pluck('id'))
+            ->whereBetween('post_date', [$windowStart->subDays($tolerance), $windowEnd->addDays($tolerance)])
+            ->get(['planned_transaction_id', 'post_date'])
+            ->groupBy('planned_transaction_id');
 
         $bestPlan = null;
         $bestDiff = null;
 
         foreach ($plans as $plan) {
+            $claimed = $claimedByPlan->get($plan->id) ?? collect();
+
             foreach ($plan->occurrencesBetween($windowStart, $windowEnd) as $occurrence) {
                 $diff = ReconciliationPolicy::dayDiff($transaction->post_date, $occurrence);
 
-                if ($diff > ReconciliationPolicy::DATE_TOLERANCE_DAYS) {
+                if ($diff > $tolerance) {
                     continue;
                 }
 
-                if ($this->findLinkedForOccurrence($plan, $occurrence) !== null) {
+                $alreadyClaimed = $claimed->contains(
+                    fn (Transaction $linked): bool => ReconciliationPolicy::dayDiff($linked->post_date, $occurrence) <= $tolerance,
+                );
+
+                if ($alreadyClaimed) {
                     continue;
                 }
 

--- a/app/Services/ReconciliationPolicy.php
+++ b/app/Services/ReconciliationPolicy.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use Carbon\CarbonImmutable;
+
+/**
+ * The single source of truth for deciding whether a posted transaction fulfils a
+ * planned-transaction occurrence. Ingress (TransactionIngestor), the async backstop
+ * (PlannedTransactionMatcher) and the calendar dedup all reconcile through these rules,
+ * so a match made at import time and the pip the calendar renders never disagree.
+ *
+ * A candidate matches when it shares the plan's account and direction, its amount sits
+ * within AMOUNT_TOLERANCE of the plan amount (covering variable bills), and its post date
+ * is within DATE_TOLERANCE_DAYS of an occurrence.
+ */
+final class ReconciliationPolicy
+{
+    /** Fraction the transaction amount may deviate from the plan amount and still match. */
+    public const float AMOUNT_TOLERANCE = 0.10;
+
+    /** Days a transaction's post date may sit either side of a plan occurrence. */
+    public const int DATE_TOLERANCE_DAYS = 3;
+
+    public static function amountMatches(int $transactionAmount, int $planAmount): bool
+    {
+        [$min, $max] = self::amountRange($planAmount);
+
+        $abs = abs($transactionAmount);
+
+        return $abs >= $min && $abs <= $max;
+    }
+
+    /**
+     * Inclusive [min, max] absolute-cent bounds a transaction amount may fall in to match
+     * the given plan amount. Used to build SQL `ABS(amount) BETWEEN ?` constraints.
+     *
+     * @return array{0: int, 1: int}
+     */
+    public static function amountRange(int $planAmount): array
+    {
+        $abs = abs($planAmount);
+        $delta = (int) round($abs * self::AMOUNT_TOLERANCE);
+
+        return [$abs - $delta, $abs + $delta];
+    }
+
+    public static function datesMatch(CarbonImmutable $postDate, CarbonImmutable $occurrence): bool
+    {
+        return self::dayDiff($postDate, $occurrence) <= self::DATE_TOLERANCE_DAYS;
+    }
+
+    public static function dayDiff(CarbonImmutable $postDate, CarbonImmutable $occurrence): int
+    {
+        return (int) abs($postDate->diffInDays($occurrence));
+    }
+}

--- a/app/Services/TransactionIngestor.php
+++ b/app/Services/TransactionIngestor.php
@@ -27,35 +27,23 @@ final readonly class TransactionIngestor
             $transaction->save();
         }
 
-        if ($this->reconcile($transaction)) {
-            event(new TransactionReconciled($transaction, (int) $transaction->planned_transaction_id));
-
-            return $transaction;
-        }
-
-        event(new TransactionEntered($transaction));
-
-        return $transaction;
-    }
-
-    /**
-     * Link the transaction to the planned occurrence it fulfils, if any. Returns true when
-     * a new link was made. Already-linked transactions are left untouched.
-     */
-    private function reconcile(Transaction $transaction): bool
-    {
+        // Already reconciled (e.g. a re-imported or re-processed row): emit nothing so
+        // downstream listeners aren't told it just "entered" or was freshly reconciled.
         if ($transaction->planned_transaction_id !== null) {
-            return false;
+            return $transaction;
         }
 
         $plan = $this->matcher->findPlanForTransaction($transaction);
 
         if ($plan === null) {
-            return false;
+            event(new TransactionEntered($transaction));
+
+            return $transaction;
         }
 
         $this->matcher->link($transaction, $plan);
+        event(new TransactionReconciled($transaction, $plan->id));
 
-        return true;
+        return $transaction;
     }
 }

--- a/app/Services/TransactionIngestor.php
+++ b/app/Services/TransactionIngestor.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Events\TransactionEntered;
+use App\Events\TransactionReconciled;
+use App\Models\Transaction;
+
+/**
+ * The single funnel every ingress path (CSV import, manual entry, Basiq sync) uses to
+ * record a posted transaction. It persists the transaction, reconciles it against the
+ * user's active planned transactions through ReconciliationPolicy, and emits the matching
+ * lifecycle event. Reconciling here — synchronously, before anything renders — is what
+ * stops a planned pip and an entered pip appearing on the same calendar day.
+ */
+final readonly class TransactionIngestor
+{
+    public function __construct(
+        private ReconciliationMatcher $matcher,
+    ) {}
+
+    public function ingest(Transaction $transaction): Transaction
+    {
+        if (! $transaction->exists) {
+            $transaction->save();
+        }
+
+        if ($this->reconcile($transaction)) {
+            event(new TransactionReconciled($transaction, (int) $transaction->planned_transaction_id));
+
+            return $transaction;
+        }
+
+        event(new TransactionEntered($transaction));
+
+        return $transaction;
+    }
+
+    /**
+     * Link the transaction to the planned occurrence it fulfils, if any. Returns true when
+     * a new link was made. Already-linked transactions are left untouched.
+     */
+    private function reconcile(Transaction $transaction): bool
+    {
+        if ($transaction->planned_transaction_id !== null) {
+            return false;
+        }
+
+        $plan = $this->matcher->findPlanForTransaction($transaction);
+
+        if ($plan === null) {
+            return false;
+        }
+
+        $this->matcher->link($transaction, $plan);
+
+        return true;
+    }
+}

--- a/app/Support/Calendar/DayActivityLoader.php
+++ b/app/Support/Calendar/DayActivityLoader.php
@@ -8,7 +8,7 @@ use App\Enums\TransactionDirection;
 use App\Livewire\Dashboard\Data\PayCyclePip;
 use App\Models\PlannedTransaction;
 use App\Models\Transaction;
-use App\Services\ReconciliationMatcher;
+use App\Services\ReconciliationPolicy;
 use Carbon\CarbonImmutable;
 use Illuminate\Support\Collection;
 
@@ -32,7 +32,7 @@ final readonly class DayActivityLoader
      * grouped by ISO date. Transfers are excluded. Pips per day are sorted by amount desc.
      *
      * A planned occurrence that has been reconciled to a posted transaction (matched within
-     * ReconciliationMatcher::DATE_TOLERANCE_DAYS) is suppressed: only the posted pip renders,
+     * ReconciliationPolicy::DATE_TOLERANCE_DAYS) is suppressed: only the posted pip renders,
      * relabelled with the reconciled plan's category name and icon.
      *
      * @return array<string, DayActivity>
@@ -188,7 +188,7 @@ final readonly class DayActivityLoader
 
             $diff = (int) abs($candidate->post_date->diffInDays($occurrence));
 
-            if ($diff > ReconciliationMatcher::DATE_TOLERANCE_DAYS) {
+            if ($diff > ReconciliationPolicy::DATE_TOLERANCE_DAYS) {
                 continue;
             }
 

--- a/tests/Feature/Models/PlannedTransactionTest.php
+++ b/tests/Feature/Models/PlannedTransactionTest.php
@@ -6,12 +6,14 @@ declare(strict_types=1);
 
 use App\Enums\RecurrenceFrequency;
 use App\Enums\TransactionDirection;
+use App\Events\PlannedTransactionCreated;
 use App\Models\Account;
 use App\Models\Category;
 use App\Models\PlannedTransaction;
 use App\Models\Transaction;
 use App\Models\User;
 use Carbon\CarbonImmutable;
+use Illuminate\Support\Facades\Event;
 
 // ── Factory & Basics ──────────────────────────────────────────────
 
@@ -20,6 +22,17 @@ test('factory creates a valid planned transaction', function () {
 
     expect($planned)->toBeInstanceOf(PlannedTransaction::class)
         ->and($planned->exists)->toBeTrue();
+});
+
+test('creating a planned transaction fires PlannedTransactionCreated', function () {
+    Event::fake([PlannedTransactionCreated::class]);
+
+    $planned = PlannedTransaction::factory()->create();
+
+    Event::assertDispatched(
+        PlannedTransactionCreated::class,
+        fn (PlannedTransactionCreated $event): bool => $event->plannedTransaction->is($planned),
+    );
 });
 
 test('default factory creates monthly frequency', function () {

--- a/tests/Feature/Services/PlannedTransactionMatcherTest.php
+++ b/tests/Feature/Services/PlannedTransactionMatcherTest.php
@@ -75,12 +75,26 @@ test('does not match outside the date tolerance', function () {
         ->and($tx->fresh()->planned_transaction_id)->toBeNull();
 });
 
-test('requires an exact amount (stricter than the human ±10% matcher)', function () {
-    activeRentPlan($this->user, $this->account);
+test('matches within the amount tolerance (±10%)', function () {
+    $plan = activeRentPlan($this->user, $this->account);
 
     $tx = Transaction::factory()->for($this->user)->debit()->create([
         'account_id' => $this->account->id,
         'amount' => -47500,
+        'post_date' => '2026-06-10',
+        'planned_transaction_id' => null,
+    ]);
+
+    expect($this->matcher->matchForUser($this->user))->toBe(1)
+        ->and($tx->fresh()->planned_transaction_id)->toBe($plan->id);
+});
+
+test('does not match outside the amount tolerance', function () {
+    activeRentPlan($this->user, $this->account);
+
+    $tx = Transaction::factory()->for($this->user)->debit()->create([
+        'account_id' => $this->account->id,
+        'amount' => -40000,
         'post_date' => '2026-06-10',
         'planned_transaction_id' => null,
     ]);

--- a/tests/Feature/Services/TransactionIngestorTest.php
+++ b/tests/Feature/Services/TransactionIngestorTest.php
@@ -1,0 +1,113 @@
+<?php
+
+/** @noinspection StaticClosureCanBeUsedInspection */
+
+declare(strict_types=1);
+
+use App\Enums\RecurrenceFrequency;
+use App\Enums\TransactionDirection;
+use App\Events\TransactionEntered;
+use App\Events\TransactionReconciled;
+use App\Models\Account;
+use App\Models\PlannedTransaction;
+use App\Models\Transaction;
+use App\Models\User;
+use App\Services\TransactionIngestor;
+use Illuminate\Support\Facades\Event;
+
+beforeEach(function () {
+    $this->ingestor = app(TransactionIngestor::class);
+    $this->user = User::factory()->create();
+    $this->account = Account::factory()->for($this->user)->create();
+});
+
+function ingestorRentPlan(User $user, Account $account, string $startDate = '2026-06-10'): PlannedTransaction
+{
+    return PlannedTransaction::factory()->for($user)->create([
+        'account_id' => $account->id,
+        'amount' => 50000,
+        'direction' => TransactionDirection::Debit,
+        'frequency' => RecurrenceFrequency::DontRepeat,
+        'start_date' => $startDate,
+        'is_active' => true,
+    ]);
+}
+
+test('reconciles a transaction that fulfils an active plan occurrence', function () {
+    Event::fake([TransactionReconciled::class, TransactionEntered::class]);
+    $plan = ingestorRentPlan($this->user, $this->account);
+
+    $tx = Transaction::factory()->for($this->user)->debit()->make([
+        'account_id' => $this->account->id,
+        'amount' => -49000,
+        'post_date' => '2026-06-11',
+        'planned_transaction_id' => null,
+    ]);
+
+    $result = $this->ingestor->ingest($tx);
+
+    expect($result->planned_transaction_id)->toBe($plan->id);
+
+    Event::assertDispatched(
+        TransactionReconciled::class,
+        fn (TransactionReconciled $e): bool => $e->transaction->is($tx) && $e->plannedTransactionId === $plan->id,
+    );
+    Event::assertNotDispatched(TransactionEntered::class);
+});
+
+test('leaves a transaction with no matching plan entered', function () {
+    Event::fake([TransactionReconciled::class, TransactionEntered::class]);
+    ingestorRentPlan($this->user, $this->account);
+
+    $tx = Transaction::factory()->for($this->user)->debit()->make([
+        'account_id' => $this->account->id,
+        'amount' => -49000,
+        'post_date' => '2026-06-30',
+        'planned_transaction_id' => null,
+    ]);
+
+    $result = $this->ingestor->ingest($tx);
+
+    expect($result->planned_transaction_id)->toBeNull();
+
+    Event::assertDispatched(
+        TransactionEntered::class,
+        fn (TransactionEntered $e): bool => $e->transaction->is($tx),
+    );
+    Event::assertNotDispatched(TransactionReconciled::class);
+});
+
+test('persists an unsaved transaction passed to ingest', function () {
+    $tx = Transaction::factory()->for($this->user)->debit()->make([
+        'account_id' => $this->account->id,
+        'amount' => -1200,
+        'post_date' => '2026-06-11',
+        'planned_transaction_id' => null,
+    ]);
+
+    expect($tx->exists)->toBeFalse();
+
+    $this->ingestor->ingest($tx);
+
+    expect($tx->exists)->toBeTrue()
+        ->and(Transaction::query()->whereKey($tx->id)->exists())->toBeTrue();
+});
+
+test('does not relink a transaction already reconciled to a plan', function () {
+    Event::fake([TransactionReconciled::class, TransactionEntered::class]);
+    $plan = ingestorRentPlan($this->user, $this->account);
+
+    $tx = Transaction::factory()->for($this->user)->debit()->create([
+        'account_id' => $this->account->id,
+        'amount' => -50000,
+        'post_date' => '2026-06-10',
+        'planned_transaction_id' => $plan->id,
+    ]);
+
+    $this->ingestor->ingest($tx);
+
+    expect($tx->fresh()->planned_transaction_id)->toBe($plan->id);
+
+    Event::assertNotDispatched(TransactionReconciled::class);
+    Event::assertDispatched(TransactionEntered::class);
+});

--- a/tests/Feature/Services/TransactionIngestorTest.php
+++ b/tests/Feature/Services/TransactionIngestorTest.php
@@ -23,8 +23,7 @@ beforeEach(function () {
 
 function ingestorRentPlan(User $user, Account $account, string $startDate = '2026-06-10'): PlannedTransaction
 {
-    return PlannedTransaction::factory()->for($user)->create([
-        'account_id' => $account->id,
+    return PlannedTransaction::factory()->for($user)->for($account)->create([
         'amount' => 50000,
         'direction' => TransactionDirection::Debit,
         'frequency' => RecurrenceFrequency::DontRepeat,
@@ -37,8 +36,7 @@ test('reconciles a transaction that fulfils an active plan occurrence', function
     Event::fake([TransactionReconciled::class, TransactionEntered::class]);
     $plan = ingestorRentPlan($this->user, $this->account);
 
-    $tx = Transaction::factory()->for($this->user)->debit()->make([
-        'account_id' => $this->account->id,
+    $tx = Transaction::factory()->for($this->user)->for($this->account)->debit()->make([
         'amount' => -49000,
         'post_date' => '2026-06-11',
         'planned_transaction_id' => null,
@@ -59,8 +57,7 @@ test('leaves a transaction with no matching plan entered', function () {
     Event::fake([TransactionReconciled::class, TransactionEntered::class]);
     ingestorRentPlan($this->user, $this->account);
 
-    $tx = Transaction::factory()->for($this->user)->debit()->make([
-        'account_id' => $this->account->id,
+    $tx = Transaction::factory()->for($this->user)->for($this->account)->debit()->make([
         'amount' => -49000,
         'post_date' => '2026-06-30',
         'planned_transaction_id' => null,
@@ -78,8 +75,7 @@ test('leaves a transaction with no matching plan entered', function () {
 });
 
 test('persists an unsaved transaction passed to ingest', function () {
-    $tx = Transaction::factory()->for($this->user)->debit()->make([
-        'account_id' => $this->account->id,
+    $tx = Transaction::factory()->for($this->user)->for($this->account)->debit()->make([
         'amount' => -1200,
         'post_date' => '2026-06-11',
         'planned_transaction_id' => null,
@@ -97,8 +93,7 @@ test('does not relink or emit lifecycle events for a transaction already reconci
     Event::fake([TransactionReconciled::class, TransactionEntered::class]);
     $plan = ingestorRentPlan($this->user, $this->account);
 
-    $tx = Transaction::factory()->for($this->user)->debit()->create([
-        'account_id' => $this->account->id,
+    $tx = Transaction::factory()->for($this->user)->for($this->account)->debit()->create([
         'amount' => -50000,
         'post_date' => '2026-06-10',
         'planned_transaction_id' => $plan->id,

--- a/tests/Feature/Services/TransactionIngestorTest.php
+++ b/tests/Feature/Services/TransactionIngestorTest.php
@@ -93,7 +93,7 @@ test('persists an unsaved transaction passed to ingest', function () {
         ->and(Transaction::query()->whereKey($tx->id)->exists())->toBeTrue();
 });
 
-test('does not relink a transaction already reconciled to a plan', function () {
+test('does not relink or emit lifecycle events for a transaction already reconciled to a plan', function () {
     Event::fake([TransactionReconciled::class, TransactionEntered::class]);
     $plan = ingestorRentPlan($this->user, $this->account);
 
@@ -109,5 +109,5 @@ test('does not relink a transaction already reconciled to a plan', function () {
     expect($tx->fresh()->planned_transaction_id)->toBe($plan->id);
 
     Event::assertNotDispatched(TransactionReconciled::class);
-    Event::assertDispatched(TransactionEntered::class);
+    Event::assertNotDispatched(TransactionEntered::class);
 });

--- a/tests/Unit/Services/ReconciliationPolicyTest.php
+++ b/tests/Unit/Services/ReconciliationPolicyTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Services\ReconciliationPolicy;
+use Carbon\CarbonImmutable;
+
+test('amountMatches accepts amounts within ±10% of the plan amount', function () {
+    expect(ReconciliationPolicy::amountMatches(-50000, 50000))->toBeTrue()
+        ->and(ReconciliationPolicy::amountMatches(-47500, 50000))->toBeTrue()
+        ->and(ReconciliationPolicy::amountMatches(-45000, 50000))->toBeTrue()
+        ->and(ReconciliationPolicy::amountMatches(-55000, 50000))->toBeTrue();
+});
+
+test('amountMatches rejects amounts outside ±10% of the plan amount', function () {
+    expect(ReconciliationPolicy::amountMatches(-44999, 50000))->toBeFalse()
+        ->and(ReconciliationPolicy::amountMatches(-55001, 50000))->toBeFalse()
+        ->and(ReconciliationPolicy::amountMatches(-40000, 50000))->toBeFalse();
+});
+
+test('amountMatches compares absolute values regardless of sign', function () {
+    expect(ReconciliationPolicy::amountMatches(50000, 50000))->toBeTrue()
+        ->and(ReconciliationPolicy::amountMatches(-50000, 50000))->toBeTrue();
+});
+
+test('amountRange returns inclusive ±10% cent bounds', function () {
+    expect(ReconciliationPolicy::amountRange(50000))->toBe([45000, 55000])
+        ->and(ReconciliationPolicy::amountRange(1699))->toBe([1529, 1869]);
+});
+
+test('datesMatch is true within the date tolerance and false beyond it', function () {
+    $occurrence = CarbonImmutable::create(2026, 6, 10);
+
+    expect(ReconciliationPolicy::datesMatch($occurrence, $occurrence))->toBeTrue()
+        ->and(ReconciliationPolicy::datesMatch($occurrence->addDays(3), $occurrence))->toBeTrue()
+        ->and(ReconciliationPolicy::datesMatch($occurrence->addDays(4), $occurrence))->toBeFalse()
+        ->and(ReconciliationPolicy::datesMatch($occurrence->subDays(3), $occurrence))->toBeTrue();
+});

--- a/tests/Unit/Services/ReconciliationPolicyTest.php
+++ b/tests/Unit/Services/ReconciliationPolicyTest.php
@@ -1,5 +1,7 @@
 <?php
 
+/** @noinspection StaticClosureCanBeUsedInspection */
+
 declare(strict_types=1);
 
 use App\Services\ReconciliationPolicy;


### PR DESCRIPTION
## What
Introduce a single matching rule (`ReconciliationPolicy`) and a small set of domain events as the foundation for reconciling transactions at ingress. **No ingress path is wired yet** — that follows in #278 (CSV) and #280 (manual + Basiq).

## Why
Three components matched postings to plans with different rules — `PlannedTransactionMatcher` (exact amount), `ReconciliationMatcher` (±10%), `DayActivityLoader` (date-only). That divergence is the structural cause of the planned + entered calendar duplicates (the 5 Jun issue).

## Changes
- **`ReconciliationPolicy`** — single source of truth: same `account_id` + `direction`, amount within ±10% (`AMOUNT_TOLERANCE`), `post_date` within ±3 days (`DATE_TOLERANCE_DAYS`). `amountRange()` uses an integer-cent delta (`round`) to avoid float-boundary drift (e.g. `ceil(50000 * 1.1) = 55001`).
- **`PlannedTransactionMatcher`** — retires the exact-amount rule; now uses `ReconciliationPolicy::amountMatches` (±10%), so variable bills reconcile.
- **`ReconciliationMatcher`** — tolerances now alias the policy; `findSuggestions` uses `amountRange`; adds `findPlanForTransaction()` (the transaction→plan lookup the ingestor needs, respecting already-claimed occurrences).
- **`DayActivityLoader`** — references `ReconciliationPolicy::DATE_TOLERANCE_DAYS`.
- **`TransactionIngestor`** — the funnel: persist → reconcile-or-enter → emit event.
- **Events** — `TransactionEntered`, `TransactionReconciled`, `PlannedTransactionCreated` (the last fires from the model's `created` hook).

## Tests
- New: `ReconciliationPolicyTest` (5, unit — amount/date boundaries), `TransactionIngestorTest` (4 — reconcile / enter / persist / no-relink).
- Updated: `PlannedTransactionMatcherTest` exact-amount case → within/outside ±10%; `PlannedTransactionTest` gains a `PlannedTransactionCreated` event assertion.
- Green via `op test.filter`: ReconciliationPolicyTest (5), TransactionIngestorTest (4), PlannedTransactionMatcherTest (13), MatchPlannedTransactionsStageTest (2), ReconciliationMatcherTest (17), DayActivityLoaderTest (25), PlannedTransactionTest (46). GrumPHP (Pint + PHPStan + mago) passed.

Design: `docs/plans/2026-06-05-transaction-reconciliation-lifecycle-design.md` (sections A, B, C).

Closes #277