### PR TITLE
fix(#278): reconcile CSV imports at ingress (no planned/entered duplicate)

### DIFF
--- a/app/Jobs/ImportCsvTransactionsJob.php
+++ b/app/Jobs/ImportCsvTransactionsJob.php
@@ -10,6 +10,7 @@ use App\Enums\TransactionStatus;
 use App\Models\BankImport;
 use App\Models\Transaction;
 use App\Services\CsvImport\CsvParserService;
+use App\Services\TransactionIngestor;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Database\QueryException;
@@ -50,7 +51,7 @@ final class ImportCsvTransactionsJob implements ShouldBeUnique, ShouldQueue
     /**
      * @throws Throwable
      */
-    public function handle(CsvParserService $parser): void
+    public function handle(CsvParserService $parser, TransactionIngestor $ingestor): void
     {
         $bankImport = $this->bankImport->fresh();
 
@@ -94,11 +95,11 @@ final class ImportCsvTransactionsJob implements ShouldBeUnique, ShouldQueue
                     ];
 
                     if ($existing === null) {
-                        Transaction::query()->create([
+                        $ingestor->ingest(new Transaction([
                             'account_id' => $bankImport->account_id,
                             'csv_hash' => $row->csvHash,
                             ...$values,
-                        ]);
+                        ]));
                         $imported++;
 
                         continue;

--- a/tests/Feature/Jobs/ImportCsvTransactionsJobTest.php
+++ b/tests/Feature/Jobs/ImportCsvTransactionsJobTest.php
@@ -7,16 +7,22 @@
 declare(strict_types=1);
 
 use App\Enums\BankImportStatus;
+use App\Enums\RecurrenceFrequency;
+use App\Enums\TransactionDirection;
 use App\Enums\TransactionSource;
 use App\Jobs\ImportCsvTransactionsJob;
 use App\Jobs\RunTransactionAnalysisJob;
 use App\Models\Account;
 use App\Models\BankImport;
 use App\Models\Category;
+use App\Models\PlannedTransaction;
 use App\Models\Transaction;
 use App\Models\User;
 use App\Services\CsvImport\CsvColumnMapper;
 use App\Services\CsvImport\CsvParserService;
+use App\Services\TransactionIngestor;
+use App\Support\Calendar\DayActivityLoader;
+use Carbon\CarbonImmutable;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Facades\Storage;
@@ -58,7 +64,7 @@ test('imports rows into transactions with source=csv', function () {
 
     $bankImport = makeBankImportFromFixture();
 
-    new ImportCsvTransactionsJob($bankImport)->handle(new CsvParserService());
+    new ImportCsvTransactionsJob($bankImport)->handle(new CsvParserService(), app(TransactionIngestor::class));
 
     $bankImport->refresh();
     expect($bankImport->status)->toBe(BankImportStatus::Completed)
@@ -79,7 +85,7 @@ test('re-running the same import is idempotent (dedupe via csv_hash)', function 
 
     $bankImport = makeBankImportFromFixture();
 
-    new ImportCsvTransactionsJob($bankImport)->handle(new CsvParserService());
+    new ImportCsvTransactionsJob($bankImport)->handle(new CsvParserService(), app(TransactionIngestor::class));
 
     $bankImport->refresh();
     $firstImported = $bankImport->imported_count;
@@ -96,7 +102,7 @@ test('re-running the same import is idempotent (dedupe via csv_hash)', function 
         'completed_at' => null,
     ]);
 
-    new ImportCsvTransactionsJob($bankImport)->handle(new CsvParserService());
+    new ImportCsvTransactionsJob($bankImport)->handle(new CsvParserService(), app(TransactionIngestor::class));
 
     $bankImport->refresh();
     expect($bankImport->status)->toBe(BankImportStatus::Completed)
@@ -114,7 +120,7 @@ test('status transitions through importing then completed', function () {
     expect($bankImport->status)->toBe(BankImportStatus::Pending)
         ->and($bankImport->started_at)->toBeNull();
 
-    new ImportCsvTransactionsJob($bankImport)->handle(new CsvParserService());
+    new ImportCsvTransactionsJob($bankImport)->handle(new CsvParserService(), app(TransactionIngestor::class));
 
     $bankImport->refresh();
     expect($bankImport->status)->toBe(BankImportStatus::Completed)
@@ -127,7 +133,7 @@ test('dispatches RunTransactionAnalysisJob after successful import', function ()
 
     $bankImport = makeBankImportFromFixture();
 
-    new ImportCsvTransactionsJob($bankImport)->handle(new CsvParserService());
+    new ImportCsvTransactionsJob($bankImport)->handle(new CsvParserService(), app(TransactionIngestor::class));
 
     Queue::assertPushed(
         RunTransactionAnalysisJob::class,
@@ -141,8 +147,7 @@ test('failure transitions status to Failed and records error_summary', function 
     $bankImport = makeBankImportFromFixture();
     $bankImport->update(['stored_path' => 'bank-imports/does-not-exist.csv']);
 
-    expect(fn () => new ImportCsvTransactionsJob($bankImport)
-        ->handle(new CsvParserService()))->toThrow(Exception::class);
+    expect(fn () => new ImportCsvTransactionsJob($bankImport)->handle(new CsvParserService(), app(TransactionIngestor::class)))->toThrow(Exception::class);
 
     $bankImport->refresh();
     expect($bankImport->status)->toBe(BankImportStatus::Failed)
@@ -157,7 +162,7 @@ test('re-importing restores a soft-deleted transaction and preserves its categor
 
     $bankImport = makeBankImportFromFixture();
 
-    new ImportCsvTransactionsJob($bankImport)->handle(new CsvParserService());
+    new ImportCsvTransactionsJob($bankImport)->handle(new CsvParserService(), app(TransactionIngestor::class));
 
     $bankImport->refresh();
     expect($bankImport->status)->toBe(BankImportStatus::Completed)
@@ -187,7 +192,7 @@ test('re-importing restores a soft-deleted transaction and preserves its categor
         'completed_at' => null,
     ]);
 
-    new ImportCsvTransactionsJob($bankImport)->handle(new CsvParserService());
+    new ImportCsvTransactionsJob($bankImport)->handle(new CsvParserService(), app(TransactionIngestor::class));
 
     $bankImport->refresh();
     $restored = Transaction::query()->find($targetId);
@@ -239,7 +244,7 @@ test('per-row failure does not abort the import and is recorded in row_errors', 
                 ],
             ]);
 
-        new ImportCsvTransactionsJob($bankImport)->handle(new CsvParserService());
+        new ImportCsvTransactionsJob($bankImport)->handle(new CsvParserService(), app(TransactionIngestor::class));
 
         $bankImport->refresh();
 
@@ -273,4 +278,92 @@ test('has WithoutOverlapping middleware keyed on bank import', function () {
 
     expect($middleware)->toHaveCount(1)
         ->and($middleware[0])->toBeInstanceOf(Illuminate\Queue\Middleware\WithoutOverlapping::class);
+});
+
+test('a csv row matching an active plan is reconciled at import and renders a single calendar pip', function () {
+    Queue::fake([RunTransactionAnalysisJob::class]);
+
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->csvImport()->create();
+
+    $plan = PlannedTransaction::factory()->for($user)->create([
+        'account_id' => $account->id,
+        'amount' => 50000,
+        'direction' => TransactionDirection::Debit,
+        'frequency' => RecurrenceFrequency::DontRepeat,
+        'start_date' => '2026-06-05',
+        'is_active' => true,
+    ]);
+
+    $csv = <<<'CSV'
+        Date,Description,Amount
+        05/06/2026,RENT PAYMENT,-500.00
+        CSV;
+
+    $storedPath = 'bank-imports/'.bin2hex(random_bytes(8)).'.csv';
+    Storage::disk('local')->put($storedPath, $csv);
+
+    $bankImport = BankImport::factory()->for($user)->for($account)->create([
+        'original_filename' => 'rent.csv',
+        'stored_path' => $storedPath,
+        'column_mapping' => [
+            CsvColumnMapper::FIELD_DATE => 'Date',
+            CsvColumnMapper::FIELD_DESCRIPTION => 'Description',
+            CsvColumnMapper::FIELD_AMOUNT => 'Amount',
+        ],
+    ]);
+
+    new ImportCsvTransactionsJob($bankImport)->handle(new CsvParserService(), app(TransactionIngestor::class));
+
+    $tx = Transaction::query()->where('account_id', $account->id)->first();
+    expect($tx->planned_transaction_id)->toBe($plan->id);
+
+    $activity = new DayActivityLoader()->load(
+        CarbonImmutable::create(2026, 6, 1),
+        CarbonImmutable::create(2026, 6, 30),
+        $user->id,
+    );
+
+    expect($activity['2026-06-05'] ?? null)->not->toBeNull()
+        ->and($activity['2026-06-05']->pips)->toHaveCount(1)
+        ->and($activity['2026-06-05']->pips[0]->matched)->toBeTrue();
+});
+
+test('a csv row with no matching plan is left entered (unlinked)', function () {
+    Queue::fake([RunTransactionAnalysisJob::class]);
+
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->csvImport()->create();
+
+    PlannedTransaction::factory()->for($user)->create([
+        'account_id' => $account->id,
+        'amount' => 50000,
+        'direction' => TransactionDirection::Debit,
+        'frequency' => RecurrenceFrequency::DontRepeat,
+        'start_date' => '2026-06-05',
+        'is_active' => true,
+    ]);
+
+    $csv = <<<'CSV'
+        Date,Description,Amount
+        05/06/2026,GROCERIES,-120.00
+        CSV;
+
+    $storedPath = 'bank-imports/'.bin2hex(random_bytes(8)).'.csv';
+    Storage::disk('local')->put($storedPath, $csv);
+
+    $bankImport = BankImport::factory()->for($user)->for($account)->create([
+        'original_filename' => 'groceries.csv',
+        'stored_path' => $storedPath,
+        'column_mapping' => [
+            CsvColumnMapper::FIELD_DATE => 'Date',
+            CsvColumnMapper::FIELD_DESCRIPTION => 'Description',
+            CsvColumnMapper::FIELD_AMOUNT => 'Amount',
+        ],
+    ]);
+
+    new ImportCsvTransactionsJob($bankImport)->handle(new CsvParserService(), app(TransactionIngestor::class));
+
+    $tx = Transaction::query()->where('account_id', $account->id)->first();
+    expect($tx->planned_transaction_id)->toBeNull();
 });

--- a/tests/Feature/Jobs/ImportCsvTransactionsJobTest.php
+++ b/tests/Feature/Jobs/ImportCsvTransactionsJobTest.php
@@ -286,8 +286,7 @@ test('a csv row matching an active plan is reconciled at import and renders a si
     $user = User::factory()->create();
     $account = Account::factory()->for($user)->csvImport()->create();
 
-    $plan = PlannedTransaction::factory()->for($user)->create([
-        'account_id' => $account->id,
+    $plan = PlannedTransaction::factory()->for($user)->for($account)->create([
         'amount' => 50000,
         'direction' => TransactionDirection::Debit,
         'frequency' => RecurrenceFrequency::DontRepeat,
@@ -335,8 +334,7 @@ test('a csv row with no matching plan is left entered (unlinked)', function () {
     $user = User::factory()->create();
     $account = Account::factory()->for($user)->csvImport()->create();
 
-    PlannedTransaction::factory()->for($user)->create([
-        'account_id' => $account->id,
+    PlannedTransaction::factory()->for($user)->for($account)->create([
         'amount' => 50000,
         'direction' => TransactionDirection::Debit,
         'frequency' => RecurrenceFrequency::DontRepeat,

--- a/tests/Feature/Livewire/ImportBankTest.php
+++ b/tests/Feature/Livewire/ImportBankTest.php
@@ -15,6 +15,7 @@ use App\Models\BankImport;
 use App\Models\User;
 use App\Services\CsvImport\CsvColumnMapper;
 use App\Services\CsvImport\CsvParserService;
+use App\Services\TransactionIngestor;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Queue;
@@ -266,7 +267,7 @@ test('end-to-end: confirming a Beyond Bank upload imports real transactions into
     // complete the process and prove the wiring produces transactions.
     $bankImport = BankImport::query()->where('user_id', $user->id)->latest('id')->firstOrFail();
 
-    new ImportCsvTransactionsJob($bankImport)->handle(new CsvParserService());
+    new ImportCsvTransactionsJob($bankImport)->handle(new CsvParserService(), app(TransactionIngestor::class));
 
     $bankImport->refresh();
 


### PR DESCRIPTION
## What
Reconcile CSV-imported rows to the planned transactions they fulfil **at import time**, so a posting and its planned occurrence no longer both render on the same calendar day (observed Fri 5 Jun 2026).

## Why
`ImportCsvTransactionsJob` wrote new rows directly and only matched plans later, asynchronously, with a stricter (exact-amount) rule than the calendar dedup used — so matches were missed and duplicate pips rendered.

## Changes
- `ImportCsvTransactionsJob::handle()` takes a `TransactionIngestor` (method injection) and routes the **create** path through it: persist → reconcile against active plans via `ReconciliationPolicy` (±10% amount, ±3 days) → emit `TransactionReconciled` / `TransactionEntered`.
- Restore/update paths and the dedupe-by-`csv_hash` logic are unchanged; the async `MatchPlannedTransactionsStage` remains as an idempotent backstop.

## Tests (`op test.filter ImportCsvTransactionsJobTest` — 11 green)
- New: a row matching an active plan links to it and `DayActivityLoader` renders a **single** pip for that day (regression for 5 Jun); a row with no matching plan stays entered (unlinked).
- Existing import / dedupe / restore / per-row-failure tests updated for the new `handle` signature and still pass.

## Dependency
⚠️ Branches off **#277** (`277-reconciliation-policy-events`). Until #277 merges, this PR's diff includes #277's commits — review/merge **#277 first**, then this. Target branch is `develop` per project convention.

Design: `docs/plans/2026-06-05-transaction-reconciliation-lifecycle-design.md` (sections B, C).

Closes #278