### PR TITLE
chore(#280): route manual + Basiq ingress through TransactionIngestor

### DIFF
--- a/app/Jobs/SyncTransactionsJob.php
+++ b/app/Jobs/SyncTransactionsJob.php
@@ -11,6 +11,7 @@ use App\Models\Account;
 use App\Models\BasiqRefreshLog;
 use App\Models\Transaction;
 use App\Models\User;
+use App\Services\TransactionIngestor;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
@@ -191,6 +192,7 @@ final class SyncTransactionsJob implements ShouldBeUnique, ShouldQueue
         $transactions = $basiqService->paginateTransactions($this->user->basiq_user_id, $filter);
         $created = 0;
         $updated = 0;
+        $ingestor = app(TransactionIngestor::class);
 
         foreach ($transactions as $dto) {
             $accountId = $accountMap->get($dto->account);
@@ -203,26 +205,33 @@ final class SyncTransactionsJob implements ShouldBeUnique, ShouldQueue
                 continue;
             }
 
-            $wasRecentlyCreated = Transaction::updateOrCreate(
-                ['basiq_id' => $dto->id],
-                [
-                    'user_id' => $this->user->id,
-                    'account_id' => $accountId,
-                    'amount' => self::toCents($dto->amount),
-                    'direction' => $dto->direction,
-                    'description' => $dto->description ?? '',
-                    'post_date' => $dto->postDate,
-                    'transaction_date' => $dto->transactionDate,
-                    'status' => $dto->status ?? 'posted',
-                    'source' => TransactionSource::Basiq,
-                    'basiq_account_id' => $dto->account,
-                    'merchant_name' => $dto->merchant,
-                    'anzsic_code' => $dto->anzsic,
-                    'enrich_data' => $dto->enrichData,
-                ],
-            )->wasRecentlyCreated;
+            $values = [
+                'user_id' => $this->user->id,
+                'account_id' => $accountId,
+                'amount' => self::toCents($dto->amount),
+                'direction' => $dto->direction,
+                'description' => $dto->description ?? '',
+                'post_date' => $dto->postDate,
+                'transaction_date' => $dto->transactionDate,
+                'status' => $dto->status ?? 'posted',
+                'source' => TransactionSource::Basiq,
+                'basiq_account_id' => $dto->account,
+                'merchant_name' => $dto->merchant,
+                'anzsic_code' => $dto->anzsic,
+                'enrich_data' => $dto->enrichData,
+            ];
 
-            $wasRecentlyCreated ? $created++ : $updated++;
+            $existing = Transaction::query()->where('basiq_id', $dto->id)->first();
+
+            if ($existing === null) {
+                $ingestor->ingest(new Transaction(['basiq_id' => $dto->id, ...$values]));
+                $created++;
+
+                continue;
+            }
+
+            $existing->fill($values)->save();
+            $updated++;
         }
 
         $this->user->update(['last_synced_at' => now()]);

--- a/app/Livewire/TransactionModal.php
+++ b/app/Livewire/TransactionModal.php
@@ -13,6 +13,7 @@ use App\Models\Category;
 use App\Models\PlannedTransaction;
 use App\Models\Transaction;
 use App\Services\CategoryRuleGenerator;
+use App\Services\TransactionIngestor;
 use App\Support\AmountParser;
 use App\Support\AmountParseResult;
 use Carbon\CarbonImmutable;
@@ -382,7 +383,9 @@ final class TransactionModal extends Component
             return false;
         }
 
-        $this->createSingleTransaction($parsed);
+        app(TransactionIngestor::class)->ingest(
+            new Transaction($this->manualSingleAttributes($parsed, null)),
+        );
 
         return true;
     }
@@ -752,7 +755,15 @@ final class TransactionModal extends Component
 
     private function createSingleTransaction(AmountParseResult $parsed, ?int $plannedTransactionId = null): void
     {
-        Transaction::query()->create([
+        Transaction::query()->create($this->manualSingleAttributes($parsed, $plannedTransactionId));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function manualSingleAttributes(AmountParseResult $parsed, ?int $plannedTransactionId): array
+    {
+        return [
             'user_id' => auth()->id(),
             'account_id' => $this->accountId,
             'category_id' => $this->categoryId,
@@ -766,7 +777,7 @@ final class TransactionModal extends Component
             'source' => TransactionSource::Manual,
             'notes' => $this->notes !== '' ? $this->notes : null,
             'planned_transaction_id' => $plannedTransactionId,
-        ]);
+        ];
     }
 
     private function createTransferPair(AmountParseResult $parsed, ?int $plannedTransactionId = null): void

--- a/tests/Feature/Jobs/SyncTransactionsJobTest.php
+++ b/tests/Feature/Jobs/SyncTransactionsJobTest.php
@@ -11,13 +11,16 @@ use App\DTOs\BasiqAccount;
 use App\DTOs\BasiqJob;
 use App\DTOs\BasiqTransaction;
 use App\Enums\AccountClass;
+use App\Enums\RecurrenceFrequency;
 use App\Enums\RefreshStatus;
 use App\Enums\RefreshTrigger;
+use App\Enums\TransactionDirection;
 use App\Enums\TransactionSource;
 use App\Jobs\RunTransactionAnalysisJob;
 use App\Jobs\SyncTransactionsJob;
 use App\Models\Account;
 use App\Models\BasiqRefreshLog;
+use App\Models\PlannedTransaction;
 use App\Models\Transaction;
 use App\Models\User;
 use Illuminate\Support\Collection;
@@ -774,4 +777,41 @@ test('does not dispatch RunTransactionAnalysisJob when basiq job fails', functio
     new SyncTransactionsJob($user, 'job-1')->handle(app(BasiqServiceContract::class));
 
     Queue::assertNotPushed(RunTransactionAnalysisJob::class);
+});
+
+test('a synced basiq transaction matching an active plan is reconciled', function () {
+    Queue::fake([RunTransactionAnalysisJob::class]);
+
+    $user = User::factory()->withBasiq()->create();
+    $account = Account::factory()->for($user)->create([
+        'basiq_account_id' => 'basiq-acc-1',
+    ]);
+
+    $plan = PlannedTransaction::factory()->for($user)->create([
+        'account_id' => $account->id,
+        'amount' => 5000,
+        'direction' => TransactionDirection::Debit,
+        'frequency' => RecurrenceFrequency::DontRepeat,
+        'start_date' => '2026-03-15',
+        'is_active' => true,
+    ]);
+
+    fakeBasiqJobService('success', function (MockInterface $mock) {
+        $mock->shouldReceive('getAccounts')
+            ->andReturn(new Collection([makeBasiqAccount('basiq-acc-1')]));
+        $mock->shouldReceive('paginateTransactions')
+            ->andReturn(LazyCollection::make([
+                makeBasiqTransaction('txn-1', 'basiq-acc-1', [
+                    'amount' => '-50.00',
+                    'direction' => 'debit',
+                    'postDate' => '2026-03-15',
+                ]),
+            ]));
+    });
+
+    new SyncTransactionsJob($user, 'job-1')->handle(app(BasiqServiceContract::class));
+
+    $txn = Transaction::where('basiq_id', 'txn-1')->first();
+    expect($txn)->not->toBeNull()
+        ->and($txn->planned_transaction_id)->toBe($plan->id);
 });

--- a/tests/Feature/Livewire/TransactionModalTest.php
+++ b/tests/Feature/Livewire/TransactionModalTest.php
@@ -3282,3 +3282,65 @@ test('converting to a plan without ticking categorise-matching creates no rule a
     expect(UserRule::query()->where('user_id', $user->id)->count())->toBe(0)
         ->and($sibling->fresh()->category_id)->toBeNull();
 });
+
+test('a manual entry on a plan occurrence day reconciles to the plan', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+
+    $plan = PlannedTransaction::factory()->for($user)->create([
+        'account_id' => $account->id,
+        'amount' => 5000,
+        'direction' => TransactionDirection::Debit,
+        'frequency' => RecurrenceFrequency::DontRepeat,
+        'start_date' => '2026-03-15',
+        'is_active' => true,
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('open-transaction-modal', date: '2026-03-15')
+        ->set('transactionType', 'expense')
+        ->set('descriptionInput', '50 gym')
+        ->set('accountId', $account->id)
+        ->call('save')
+        ->assertHasNoErrors();
+
+    $tx = Transaction::query()
+        ->where('user_id', $user->id)
+        ->where('source', TransactionSource::Manual)
+        ->first();
+
+    expect($tx)->not->toBeNull()
+        ->and($tx->planned_transaction_id)->toBe($plan->id);
+});
+
+test('a manual entry with no matching plan is left entered (unlinked)', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+
+    PlannedTransaction::factory()->for($user)->create([
+        'account_id' => $account->id,
+        'amount' => 5000,
+        'direction' => TransactionDirection::Debit,
+        'frequency' => RecurrenceFrequency::DontRepeat,
+        'start_date' => '2026-03-15',
+        'is_active' => true,
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('open-transaction-modal', date: '2026-03-15')
+        ->set('transactionType', 'expense')
+        ->set('descriptionInput', '120 groceries')
+        ->set('accountId', $account->id)
+        ->call('save')
+        ->assertHasNoErrors();
+
+    $tx = Transaction::query()
+        ->where('user_id', $user->id)
+        ->where('source', TransactionSource::Manual)
+        ->first();
+
+    expect($tx)->not->toBeNull()
+        ->and($tx->planned_transaction_id)->toBeNull();
+});


### PR DESCRIPTION
## What
Route the two remaining ingress paths — manual entry and Basiq sync — through `TransactionIngestor`, so every ingress reconciles consistently and emits the same lifecycle events as CSV import (#278).

## Why
A fresh manual entry (`TransactionModal::createTransaction`) or a synced Basiq row that fulfils an active plan was created directly and only matched later by the async backstop — so it could render alongside the planned pip (the same class of duplicate as the 5 Jun CSV issue).

## Changes
- **`TransactionModal`** — `createTransaction()` builds the posting and `ingest()`s it (reconcile-or-enter). Extracted `manualSingleAttributes()` shared with `createSingleTransaction`. The `convertEnteredToPlanned` / `convertPlannedToEntered` / `realizePlannedOccurrence` paths keep their **explicit** plan linking (they manage the link deliberately — `convertPlannedToEntered` deletes its plan mid-transaction); transfers and updates are untouched.
- **`SyncTransactionsJob`** — the create branch of the per-transaction loop now `ingest()`s new Basiq rows (dedup by `basiq_id` preserved; updates still `fill()->save()`). Ingestor resolved in-method to avoid changing `handle()`'s signature across ~25 call sites.

## Tests (`op test.filter` — green)
- `TransactionModalTest` (138): a manual entry on a plan-occurrence day reconciles; a non-matching entry stays entered.
- `SyncTransactionsJobTest` (32): a synced row matching an active plan reconciles; existing sync / dedup / mapping behaviour unchanged.
- Pint + GrumPHP clean.

## Dependency
⚠️ Branches off **#277** (`277-reconciliation-policy-events`). Until #277 merges, this PR's diff includes #277's commits — review/merge **#277 first**. Independent of #278 (CSV). Target branch is `develop`.

Design: `docs/plans/2026-06-05-transaction-reconciliation-lifecycle-design.md` (sections A, C).

Closes #280