### PR TITLE
feat(#279): capture account balance during CSV import

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,6 +68,9 @@ BASIQ_CONSENT_URL=
 BASIQ_WEBHOOK_SECRET=
 BASIQ_SEED_USER_ID=
 
+# Recurring transaction auto-detection (off while the import/reconcile flow is stabilised)
+BUDGET_RECURRING_DETECTION=false
+
 # Fine-grained PAT: "Contents: read and write" for screenshot uploads via release assets
 # Classic PAT: "repo" scope
 # Without these permissions, issues are still created but screenshots are skipped

--- a/app/Events/PlannedTransactionCreated.php
+++ b/app/Events/PlannedTransactionCreated.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Events;
+
+use App\Models\PlannedTransaction;
+
+/**
+ * A planned transaction was created — manually, by promoting an existing transaction,
+ * or from an accepted analysis suggestion. Listeners can react (e.g. reconcile existing
+ * postings to the new plan) without the creation sites needing to know about them.
+ */
+final class PlannedTransactionCreated
+{
+    public function __construct(
+        public PlannedTransaction $plannedTransaction,
+    ) {}
+}

--- a/app/Events/TransactionEntered.php
+++ b/app/Events/TransactionEntered.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Events;
+
+use App\Models\Transaction;
+
+/**
+ * A posted transaction entered the ledger (CSV import, manual entry, or Basiq sync)
+ * without matching an active planned transaction. It stands on its own.
+ */
+final class TransactionEntered
+{
+    public function __construct(
+        public Transaction $transaction,
+    ) {}
+}

--- a/app/Events/TransactionReconciled.php
+++ b/app/Events/TransactionReconciled.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Events;
+
+use App\Models\Transaction;
+
+/**
+ * A posted transaction was reconciled to a planned transaction at ingress — it fulfils
+ * that planned occurrence, so the calendar renders one pip instead of a planned and an
+ * entered pip on the same day.
+ */
+final class TransactionReconciled
+{
+    public function __construct(
+        public Transaction $transaction,
+        public int $plannedTransactionId,
+    ) {}
+}

--- a/app/Jobs/ImportCsvTransactionsJob.php
+++ b/app/Jobs/ImportCsvTransactionsJob.php
@@ -10,6 +10,7 @@ use App\Enums\TransactionStatus;
 use App\Models\BankImport;
 use App\Models\Transaction;
 use App\Services\CsvImport\CsvParserService;
+use App\Services\TransactionIngestor;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Database\QueryException;
@@ -50,7 +51,7 @@ final class ImportCsvTransactionsJob implements ShouldBeUnique, ShouldQueue
     /**
      * @throws Throwable
      */
-    public function handle(CsvParserService $parser): void
+    public function handle(CsvParserService $parser, TransactionIngestor $ingestor): void
     {
         $bankImport = $this->bankImport->fresh();
 
@@ -94,11 +95,11 @@ final class ImportCsvTransactionsJob implements ShouldBeUnique, ShouldQueue
                     ];
 
                     if ($existing === null) {
-                        Transaction::query()->create([
+                        $ingestor->ingest(new Transaction([
                             'account_id' => $bankImport->account_id,
                             'csv_hash' => $row->csvHash,
                             ...$values,
-                        ]);
+                        ]));
                         $imported++;
 
                         continue;

--- a/app/Jobs/SyncTransactionsJob.php
+++ b/app/Jobs/SyncTransactionsJob.php
@@ -11,6 +11,7 @@ use App\Models\Account;
 use App\Models\BasiqRefreshLog;
 use App\Models\Transaction;
 use App\Models\User;
+use App\Services\TransactionIngestor;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
@@ -191,6 +192,7 @@ final class SyncTransactionsJob implements ShouldBeUnique, ShouldQueue
         $transactions = $basiqService->paginateTransactions($this->user->basiq_user_id, $filter);
         $created = 0;
         $updated = 0;
+        $ingestor = app(TransactionIngestor::class);
 
         foreach ($transactions as $dto) {
             $accountId = $accountMap->get($dto->account);
@@ -203,26 +205,33 @@ final class SyncTransactionsJob implements ShouldBeUnique, ShouldQueue
                 continue;
             }
 
-            $wasRecentlyCreated = Transaction::updateOrCreate(
-                ['basiq_id' => $dto->id],
-                [
-                    'user_id' => $this->user->id,
-                    'account_id' => $accountId,
-                    'amount' => self::toCents($dto->amount),
-                    'direction' => $dto->direction,
-                    'description' => $dto->description ?? '',
-                    'post_date' => $dto->postDate,
-                    'transaction_date' => $dto->transactionDate,
-                    'status' => $dto->status ?? 'posted',
-                    'source' => TransactionSource::Basiq,
-                    'basiq_account_id' => $dto->account,
-                    'merchant_name' => $dto->merchant,
-                    'anzsic_code' => $dto->anzsic,
-                    'enrich_data' => $dto->enrichData,
-                ],
-            )->wasRecentlyCreated;
+            $values = [
+                'user_id' => $this->user->id,
+                'account_id' => $accountId,
+                'amount' => self::toCents($dto->amount),
+                'direction' => $dto->direction,
+                'description' => $dto->description ?? '',
+                'post_date' => $dto->postDate,
+                'transaction_date' => $dto->transactionDate,
+                'status' => $dto->status ?? 'posted',
+                'source' => TransactionSource::Basiq,
+                'basiq_account_id' => $dto->account,
+                'merchant_name' => $dto->merchant,
+                'anzsic_code' => $dto->anzsic,
+                'enrich_data' => $dto->enrichData,
+            ];
 
-            $wasRecentlyCreated ? $created++ : $updated++;
+            $existing = Transaction::query()->where('basiq_id', $dto->id)->first();
+
+            if ($existing === null) {
+                $ingestor->ingest(new Transaction(['basiq_id' => $dto->id, ...$values]));
+                $created++;
+
+                continue;
+            }
+
+            $existing->fill($values)->save();
+            $updated++;
         }
 
         $this->user->update(['last_synced_at' => now()]);

--- a/app/Livewire/AnalysisSuggestions.php
+++ b/app/Livewire/AnalysisSuggestions.php
@@ -171,6 +171,7 @@ final class AnalysisSuggestions extends Component
         $suggestions = AnalysisSuggestion::query()
             ->where('user_id', auth()->id())
             ->pending()
+            ->unless((bool) config('budget.recurring_detection'), fn ($q) => $q->whereNot('type', SuggestionType::RecurringTransaction))
             ->get()
             ->groupBy(fn (AnalysisSuggestion $s) => $s->type->value);
 

--- a/app/Livewire/AnalysisSuggestions.php
+++ b/app/Livewire/AnalysisSuggestions.php
@@ -171,7 +171,7 @@ final class AnalysisSuggestions extends Component
         $suggestions = AnalysisSuggestion::query()
             ->where('user_id', auth()->id())
             ->pending()
-            ->unless((bool) config('budget.recurring_detection'), fn ($q) => $q->whereNot('type', SuggestionType::RecurringTransaction))
+            ->unless((bool) config('budget.recurring_detection'), fn ($q) => $q->where('type', '!=', SuggestionType::RecurringTransaction))
             ->get()
             ->groupBy(fn (AnalysisSuggestion $s) => $s->type->value);
 

--- a/app/Livewire/ImportBank.php
+++ b/app/Livewire/ImportBank.php
@@ -46,6 +46,8 @@ final class ImportBank extends Component
     #[Validate('nullable|numeric')]
     public string $currentBalance = '';
 
+    public bool $balanceTouched = false;
+
     /** @var list<string> */
     public array $headers = [];
 
@@ -190,6 +192,7 @@ final class ImportBank extends Component
             'newAccountLast4',
             'newAccountBalance',
             'currentBalance',
+            'balanceTouched',
             'headers',
             'mapping',
             'bankImportId',
@@ -197,6 +200,11 @@ final class ImportBank extends Component
         ]);
 
         $this->step = 1;
+    }
+
+    public function updatedCurrentBalance(): void
+    {
+        $this->balanceTouched = true;
     }
 
     public function render(CsvParserService $parser): View
@@ -220,8 +228,10 @@ final class ImportBank extends Component
             }
         }
 
-        if ($summary !== null && $this->currentBalance === '' && $this->accountChoice === 'existing' && $summary->closingBalance !== null) {
-            $this->currentBalance = number_format($summary->closingBalance / 100, 2, '.', '');
+        if ($this->accountChoice === 'existing' && ! $this->balanceTouched) {
+            $this->currentBalance = $summary?->closingBalance !== null
+                ? number_format($summary->closingBalance / 100, 2, '.', '')
+                : '';
         }
 
         return view('livewire.import-bank', [

--- a/app/Livewire/ImportBank.php
+++ b/app/Livewire/ImportBank.php
@@ -43,6 +43,9 @@ final class ImportBank extends Component
     #[Validate('nullable|numeric')]
     public string $newAccountBalance = '';
 
+    #[Validate('nullable|numeric')]
+    public string $currentBalance = '';
+
     /** @var list<string> */
     public array $headers = [];
 
@@ -127,6 +130,7 @@ final class ImportBank extends Component
             'mapping.amount' => ['nullable', 'string', 'required_without_all:mapping.debit,mapping.credit'],
             'mapping.debit' => ['nullable', 'string'],
             'mapping.credit' => ['nullable', 'string'],
+            'currentBalance' => ['nullable', 'numeric'],
         ]);
 
         if (! empty($this->mapping['amount']) && (! empty($this->mapping['debit']) || ! empty($this->mapping['credit']))) {
@@ -147,6 +151,10 @@ final class ImportBank extends Component
         Account::query()
             ->whereKey($this->accountId)
             ->update(['column_mapping' => $this->mapping]);
+
+        if ($this->currentBalance !== '') {
+            $account->update(['balance' => (int) round(((float) $this->currentBalance) * 100)]);
+        }
 
         ImportCsvTransactionsJob::dispatch($bankImport);
 
@@ -181,6 +189,7 @@ final class ImportBank extends Component
             'newAccountName',
             'newAccountLast4',
             'newAccountBalance',
+            'currentBalance',
             'headers',
             'mapping',
             'bankImportId',
@@ -209,6 +218,10 @@ final class ImportBank extends Component
             } catch (Throwable) {
                 // ignore preview failures — user is still adjusting the mapping
             }
+        }
+
+        if ($summary !== null && $this->currentBalance === '' && $this->accountChoice === 'existing' && $summary->closingBalance !== null) {
+            $this->currentBalance = number_format($summary->closingBalance / 100, 2, '.', '');
         }
 
         return view('livewire.import-bank', [

--- a/app/Livewire/TransactionModal.php
+++ b/app/Livewire/TransactionModal.php
@@ -13,6 +13,7 @@ use App\Models\Category;
 use App\Models\PlannedTransaction;
 use App\Models\Transaction;
 use App\Services\CategoryRuleGenerator;
+use App\Services\TransactionIngestor;
 use App\Support\AmountParser;
 use App\Support\AmountParseResult;
 use Carbon\CarbonImmutable;
@@ -382,7 +383,9 @@ final class TransactionModal extends Component
             return false;
         }
 
-        $this->createSingleTransaction($parsed);
+        app(TransactionIngestor::class)->ingest(
+            new Transaction($this->manualSingleAttributes($parsed, null)),
+        );
 
         return true;
     }
@@ -752,7 +755,15 @@ final class TransactionModal extends Component
 
     private function createSingleTransaction(AmountParseResult $parsed, ?int $plannedTransactionId = null): void
     {
-        Transaction::query()->create([
+        Transaction::query()->create($this->manualSingleAttributes($parsed, $plannedTransactionId));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function manualSingleAttributes(AmountParseResult $parsed, ?int $plannedTransactionId): array
+    {
+        return [
             'user_id' => auth()->id(),
             'account_id' => $this->accountId,
             'category_id' => $this->categoryId,
@@ -766,7 +777,7 @@ final class TransactionModal extends Component
             'source' => TransactionSource::Manual,
             'notes' => $this->notes !== '' ? $this->notes : null,
             'planned_transaction_id' => $plannedTransactionId,
-        ]);
+        ];
     }
 
     private function createTransferPair(AmountParseResult $parsed, ?int $plannedTransactionId = null): void

--- a/app/Models/PlannedTransaction.php
+++ b/app/Models/PlannedTransaction.php
@@ -8,6 +8,7 @@ use App\Casts\MoneyCast;
 use App\Enums\RecurrenceFrequency;
 use App\Enums\TransactionDirection;
 use App\Events\PlannedTransactionCategoryUpdated;
+use App\Events\PlannedTransactionCreated;
 use Carbon\CarbonImmutable;
 use Database\Factories\PlannedTransactionFactory;
 use Illuminate\Database\Eloquent\Builder;
@@ -169,6 +170,10 @@ final class PlannedTransaction extends Model
 
     protected static function booted(): void
     {
+        self::created(static function (PlannedTransaction $plannedTransaction): void {
+            event(new PlannedTransactionCreated($plannedTransaction));
+        });
+
         self::updated(static function (PlannedTransaction $plannedTransaction): void {
             if ($plannedTransaction->wasChanged('category_id')) {
                 event(new PlannedTransactionCategoryUpdated(

--- a/app/Services/CsvImport/CsvParserService.php
+++ b/app/Services/CsvImport/CsvParserService.php
@@ -90,6 +90,8 @@ final class CsvParserService
         $errors = [];
         $seen = [];
         $duplicateCount = 0;
+        $closingBalance = null;
+        $closingDate = null;
 
         $reader = $this->reader($path);
 
@@ -119,6 +121,11 @@ final class CsvParserService
                 $latest = $parsed->postDate;
             }
 
+            if ($parsed->balance !== null && ($closingDate === null || $parsed->postDate->greaterThanOrEqualTo($closingDate))) {
+                $closingDate = $parsed->postDate;
+                $closingBalance = $parsed->balance;
+            }
+
             if ($parsed->direction === TransactionDirection::Debit) {
                 $debitTotal += abs($parsed->amount);
             } else {
@@ -140,6 +147,7 @@ final class CsvParserService
             totalCredits: $creditTotal,
             duplicateCount: $duplicateCount,
             errorRows: $errors,
+            closingBalance: $closingBalance,
         );
     }
 

--- a/app/Services/CsvImport/PreviewSummary.php
+++ b/app/Services/CsvImport/PreviewSummary.php
@@ -19,6 +19,7 @@ final readonly class PreviewSummary
         public int $totalCredits,
         public int $duplicateCount,
         public array $errorRows,
+        public ?int $closingBalance = null,
     ) {}
 
     public function dateRange(): ?string

--- a/app/Services/PipelineStages/IdentifyRecurringTransactionsStage.php
+++ b/app/Services/PipelineStages/IdentifyRecurringTransactionsStage.php
@@ -75,7 +75,7 @@ final readonly class IdentifyRecurringTransactionsStage implements PipelineStage
 
     public function shouldRun(PipelineContext $context): bool
     {
-        return true;
+        return (bool) config('budget.recurring_detection');
     }
 
     public function execute(PipelineContext $context): StageResult

--- a/app/Services/PlannedTransactionMatcher.php
+++ b/app/Services/PlannedTransactionMatcher.php
@@ -15,10 +15,11 @@ use Illuminate\Support\Collection;
  * planned_transaction_id. Runs during sync/import so an occurred payment is recognised as
  * "that planned item" instead of showing as a separate forecast on the calendar.
  *
- * A match needs the same account + direction, an EXACT amount, and a post_date within
- * ReconciliationMatcher::DATE_TOLERANCE_DAYS of a plan occurrence. Matching is one-to-one and
- * uses the same integer day-diff + greedy-nearest claim as the calendar loader, so a match and
- * the calendar agree on which occurrence owns which transaction.
+ * A match needs the same account + direction, an amount within ReconciliationPolicy's
+ * tolerance, and a post_date within ReconciliationPolicy::DATE_TOLERANCE_DAYS of a plan
+ * occurrence. Matching is one-to-one and uses the same integer day-diff + greedy-nearest
+ * claim as the calendar loader, so a match and the calendar agree on which occurrence owns
+ * which transaction.
  */
 final readonly class PlannedTransactionMatcher
 {
@@ -26,7 +27,7 @@ final readonly class PlannedTransactionMatcher
 
     public function matchForUser(User $user): int
     {
-        $tolerance = ReconciliationMatcher::DATE_TOLERANCE_DAYS;
+        $tolerance = ReconciliationPolicy::DATE_TOLERANCE_DAYS;
         $today = CarbonImmutable::today();
         $windowStart = $today->subDays(self::LOOKBACK_DAYS);
         $windowEnd = $today->addDays($tolerance);
@@ -71,7 +72,7 @@ final readonly class PlannedTransactionMatcher
 
         foreach ($plans as $plan) {
             $candidates = ($unmatchedByGroup->get($plan->account_id.'|'.$plan->direction->value) ?? collect())
-                ->filter(fn (Transaction $t): bool => abs((int) $t->amount) === (int) $plan->amount)
+                ->filter(fn (Transaction $t): bool => ReconciliationPolicy::amountMatches((int) $t->amount, (int) $plan->amount))
                 ->values();
 
             $existing = ($matchedByPlan->get($plan->id) ?? collect())->values();

--- a/app/Services/ReconciliationMatcher.php
+++ b/app/Services/ReconciliationMatcher.php
@@ -11,9 +11,9 @@ use Illuminate\Support\Collection;
 
 final readonly class ReconciliationMatcher
 {
-    public const float AMOUNT_TOLERANCE = 0.10;
+    public const float AMOUNT_TOLERANCE = ReconciliationPolicy::AMOUNT_TOLERANCE;
 
-    public const int DATE_TOLERANCE_DAYS = 3;
+    public const int DATE_TOLERANCE_DAYS = ReconciliationPolicy::DATE_TOLERANCE_DAYS;
 
     /**
      * @return Collection<int, Transaction>
@@ -22,8 +22,7 @@ final readonly class ReconciliationMatcher
     {
         $dateFrom = $occurrenceDate->subDays(self::DATE_TOLERANCE_DAYS);
         $dateTo = $occurrenceDate->addDays(self::DATE_TOLERANCE_DAYS);
-        $minAmount = (int) floor($planned->amount * (1 - self::AMOUNT_TOLERANCE));
-        $maxAmount = (int) ceil($planned->amount * (1 + self::AMOUNT_TOLERANCE));
+        [$minAmount, $maxAmount] = ReconciliationPolicy::amountRange((int) $planned->amount);
 
         return Transaction::query()
             ->where('user_id', $planned->user_id)
@@ -40,6 +39,51 @@ final readonly class ReconciliationMatcher
                 fn (Transaction $a, Transaction $b) => abs(abs($a->amount) - abs($planned->amount)) <=> abs(abs($b->amount) - abs($planned->amount)),
             ])
             ->values();
+    }
+
+    /**
+     * The active planned transaction this posting fulfils, or null. Mirrors findSuggestions
+     * in reverse: same account + direction, amount within tolerance, and an occurrence within
+     * the date tolerance that no other transaction has already reconciled. When several plans
+     * qualify, the one whose nearest unclaimed occurrence sits closest to the post date wins.
+     */
+    public function findPlanForTransaction(Transaction $transaction): ?PlannedTransaction
+    {
+        $windowStart = $transaction->post_date->subDays(ReconciliationPolicy::DATE_TOLERANCE_DAYS);
+        $windowEnd = $transaction->post_date->addDays(ReconciliationPolicy::DATE_TOLERANCE_DAYS);
+
+        $plans = PlannedTransaction::query()
+            ->where('user_id', $transaction->user_id)
+            ->where('account_id', $transaction->account_id)
+            ->where('direction', $transaction->direction)
+            ->where('is_active', true)
+            ->excludingTransfers()
+            ->get()
+            ->filter(fn (PlannedTransaction $plan): bool => ReconciliationPolicy::amountMatches((int) $transaction->amount, (int) $plan->amount));
+
+        $bestPlan = null;
+        $bestDiff = null;
+
+        foreach ($plans as $plan) {
+            foreach ($plan->occurrencesBetween($windowStart, $windowEnd) as $occurrence) {
+                $diff = ReconciliationPolicy::dayDiff($transaction->post_date, $occurrence);
+
+                if ($diff > ReconciliationPolicy::DATE_TOLERANCE_DAYS) {
+                    continue;
+                }
+
+                if ($this->findLinkedForOccurrence($plan, $occurrence) !== null) {
+                    continue;
+                }
+
+                if ($bestDiff === null || $diff < $bestDiff) {
+                    $bestDiff = $diff;
+                    $bestPlan = $plan;
+                }
+            }
+        }
+
+        return $bestPlan;
     }
 
     public function findLinkedForOccurrence(PlannedTransaction $planned, CarbonImmutable $occurrenceDate): ?Transaction

--- a/app/Services/ReconciliationMatcher.php
+++ b/app/Services/ReconciliationMatcher.php
@@ -63,6 +63,8 @@ final readonly class ReconciliationMatcher
                 $query->whereNull('until_date')->orWhere('until_date', '>=', $windowStart);
             })
             ->excludingTransfers()
+            ->orderBy('start_date')
+            ->orderBy('id')
             ->get()
             ->filter(fn (PlannedTransaction $plan): bool => ReconciliationPolicy::amountMatches((int) $transaction->amount, (int) $plan->amount));
 

--- a/app/Services/ReconciliationMatcher.php
+++ b/app/Services/ReconciliationMatcher.php
@@ -49,30 +49,55 @@ final readonly class ReconciliationMatcher
      */
     public function findPlanForTransaction(Transaction $transaction): ?PlannedTransaction
     {
-        $windowStart = $transaction->post_date->subDays(ReconciliationPolicy::DATE_TOLERANCE_DAYS);
-        $windowEnd = $transaction->post_date->addDays(ReconciliationPolicy::DATE_TOLERANCE_DAYS);
+        $tolerance = ReconciliationPolicy::DATE_TOLERANCE_DAYS;
+        $windowStart = $transaction->post_date->subDays($tolerance);
+        $windowEnd = $transaction->post_date->addDays($tolerance);
 
         $plans = PlannedTransaction::query()
             ->where('user_id', $transaction->user_id)
             ->where('account_id', $transaction->account_id)
             ->where('direction', $transaction->direction)
             ->where('is_active', true)
+            ->where('start_date', '<=', $windowEnd)
+            ->where(static function ($query) use ($windowStart): void {
+                $query->whereNull('until_date')->orWhere('until_date', '>=', $windowStart);
+            })
             ->excludingTransfers()
             ->get()
             ->filter(fn (PlannedTransaction $plan): bool => ReconciliationPolicy::amountMatches((int) $transaction->amount, (int) $plan->amount));
+
+        if ($plans->isEmpty()) {
+            return null;
+        }
+
+        // Occurrences already reconciled by another transaction, fetched once and matched
+        // in-memory so the ingress path doesn't issue a query per candidate occurrence.
+        $claimedByPlan = Transaction::query()
+            ->where('user_id', $transaction->user_id)
+            ->current()
+            ->whereIn('planned_transaction_id', $plans->pluck('id'))
+            ->whereBetween('post_date', [$windowStart->subDays($tolerance), $windowEnd->addDays($tolerance)])
+            ->get(['planned_transaction_id', 'post_date'])
+            ->groupBy('planned_transaction_id');
 
         $bestPlan = null;
         $bestDiff = null;
 
         foreach ($plans as $plan) {
+            $claimed = $claimedByPlan->get($plan->id) ?? collect();
+
             foreach ($plan->occurrencesBetween($windowStart, $windowEnd) as $occurrence) {
                 $diff = ReconciliationPolicy::dayDiff($transaction->post_date, $occurrence);
 
-                if ($diff > ReconciliationPolicy::DATE_TOLERANCE_DAYS) {
+                if ($diff > $tolerance) {
                     continue;
                 }
 
-                if ($this->findLinkedForOccurrence($plan, $occurrence) !== null) {
+                $alreadyClaimed = $claimed->contains(
+                    fn (Transaction $linked): bool => ReconciliationPolicy::dayDiff($linked->post_date, $occurrence) <= $tolerance,
+                );
+
+                if ($alreadyClaimed) {
                     continue;
                 }
 

--- a/app/Services/ReconciliationPolicy.php
+++ b/app/Services/ReconciliationPolicy.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use Carbon\CarbonImmutable;
+
+/**
+ * The single source of truth for deciding whether a posted transaction fulfils a
+ * planned-transaction occurrence. Ingress (TransactionIngestor), the async backstop
+ * (PlannedTransactionMatcher) and the calendar dedup all reconcile through these rules,
+ * so a match made at import time and the pip the calendar renders never disagree.
+ *
+ * A candidate matches when it shares the plan's account and direction, its amount sits
+ * within AMOUNT_TOLERANCE of the plan amount (covering variable bills), and its post date
+ * is within DATE_TOLERANCE_DAYS of an occurrence.
+ */
+final class ReconciliationPolicy
+{
+    /** Fraction the transaction amount may deviate from the plan amount and still match. */
+    public const float AMOUNT_TOLERANCE = 0.10;
+
+    /** Days a transaction's post date may sit either side of a plan occurrence. */
+    public const int DATE_TOLERANCE_DAYS = 3;
+
+    public static function amountMatches(int $transactionAmount, int $planAmount): bool
+    {
+        [$min, $max] = self::amountRange($planAmount);
+
+        $abs = abs($transactionAmount);
+
+        return $abs >= $min && $abs <= $max;
+    }
+
+    /**
+     * Inclusive [min, max] absolute-cent bounds a transaction amount may fall in to match
+     * the given plan amount. Used to build SQL `ABS(amount) BETWEEN ?` constraints.
+     *
+     * @return array{0: int, 1: int}
+     */
+    public static function amountRange(int $planAmount): array
+    {
+        $abs = abs($planAmount);
+        $delta = (int) round($abs * self::AMOUNT_TOLERANCE);
+
+        return [$abs - $delta, $abs + $delta];
+    }
+
+    public static function datesMatch(CarbonImmutable $postDate, CarbonImmutable $occurrence): bool
+    {
+        return self::dayDiff($postDate, $occurrence) <= self::DATE_TOLERANCE_DAYS;
+    }
+
+    public static function dayDiff(CarbonImmutable $postDate, CarbonImmutable $occurrence): int
+    {
+        return (int) abs($postDate->diffInDays($occurrence));
+    }
+}

--- a/app/Services/TransactionIngestor.php
+++ b/app/Services/TransactionIngestor.php
@@ -27,35 +27,23 @@ final readonly class TransactionIngestor
             $transaction->save();
         }
 
-        if ($this->reconcile($transaction)) {
-            event(new TransactionReconciled($transaction, (int) $transaction->planned_transaction_id));
-
-            return $transaction;
-        }
-
-        event(new TransactionEntered($transaction));
-
-        return $transaction;
-    }
-
-    /**
-     * Link the transaction to the planned occurrence it fulfils, if any. Returns true when
-     * a new link was made. Already-linked transactions are left untouched.
-     */
-    private function reconcile(Transaction $transaction): bool
-    {
+        // Already reconciled (e.g. a re-imported or re-processed row): emit nothing so
+        // downstream listeners aren't told it just "entered" or was freshly reconciled.
         if ($transaction->planned_transaction_id !== null) {
-            return false;
+            return $transaction;
         }
 
         $plan = $this->matcher->findPlanForTransaction($transaction);
 
         if ($plan === null) {
-            return false;
+            event(new TransactionEntered($transaction));
+
+            return $transaction;
         }
 
         $this->matcher->link($transaction, $plan);
+        event(new TransactionReconciled($transaction, $plan->id));
 
-        return true;
+        return $transaction;
     }
 }

--- a/app/Services/TransactionIngestor.php
+++ b/app/Services/TransactionIngestor.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Events\TransactionEntered;
+use App\Events\TransactionReconciled;
+use App\Models\Transaction;
+
+/**
+ * The single funnel every ingress path (CSV import, manual entry, Basiq sync) uses to
+ * record a posted transaction. It persists the transaction, reconciles it against the
+ * user's active planned transactions through ReconciliationPolicy, and emits the matching
+ * lifecycle event. Reconciling here — synchronously, before anything renders — is what
+ * stops a planned pip and an entered pip appearing on the same calendar day.
+ */
+final readonly class TransactionIngestor
+{
+    public function __construct(
+        private ReconciliationMatcher $matcher,
+    ) {}
+
+    public function ingest(Transaction $transaction): Transaction
+    {
+        if (! $transaction->exists) {
+            $transaction->save();
+        }
+
+        if ($this->reconcile($transaction)) {
+            event(new TransactionReconciled($transaction, (int) $transaction->planned_transaction_id));
+
+            return $transaction;
+        }
+
+        event(new TransactionEntered($transaction));
+
+        return $transaction;
+    }
+
+    /**
+     * Link the transaction to the planned occurrence it fulfils, if any. Returns true when
+     * a new link was made. Already-linked transactions are left untouched.
+     */
+    private function reconcile(Transaction $transaction): bool
+    {
+        if ($transaction->planned_transaction_id !== null) {
+            return false;
+        }
+
+        $plan = $this->matcher->findPlanForTransaction($transaction);
+
+        if ($plan === null) {
+            return false;
+        }
+
+        $this->matcher->link($transaction, $plan);
+
+        return true;
+    }
+}

--- a/app/Support/Calendar/DayActivityLoader.php
+++ b/app/Support/Calendar/DayActivityLoader.php
@@ -8,7 +8,7 @@ use App\Enums\TransactionDirection;
 use App\Livewire\Dashboard\Data\PayCyclePip;
 use App\Models\PlannedTransaction;
 use App\Models\Transaction;
-use App\Services\ReconciliationMatcher;
+use App\Services\ReconciliationPolicy;
 use Carbon\CarbonImmutable;
 use Illuminate\Support\Collection;
 
@@ -32,7 +32,7 @@ final readonly class DayActivityLoader
      * grouped by ISO date. Transfers are excluded. Pips per day are sorted by amount desc.
      *
      * A planned occurrence that has been reconciled to a posted transaction (matched within
-     * ReconciliationMatcher::DATE_TOLERANCE_DAYS) is suppressed: only the posted pip renders,
+     * ReconciliationPolicy::DATE_TOLERANCE_DAYS) is suppressed: only the posted pip renders,
      * relabelled with the reconciled plan's category name and icon.
      *
      * @return array<string, DayActivity>
@@ -188,7 +188,7 @@ final readonly class DayActivityLoader
 
             $diff = (int) abs($candidate->post_date->diffInDays($occurrence));
 
-            if ($diff > ReconciliationMatcher::DATE_TOLERANCE_DAYS) {
+            if ($diff > ReconciliationPolicy::DATE_TOLERANCE_DAYS) {
                 continue;
             }
 

--- a/config/budget.php
+++ b/config/budget.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Recurring Transaction Auto-Detection
+    |--------------------------------------------------------------------------
+    |
+    | When enabled, the analysis pipeline scans imported transactions for
+    | recurring patterns and surfaces them as suggestions that can be turned
+    | into planned transactions. Disabled by default while the core
+    | import/reconcile flow is stabilised; it will be rewired into the user
+    | rule system before being re-enabled.
+    |
+    */
+
+    'recurring_detection' => env('BUDGET_RECURRING_DETECTION', false),
+
+];

--- a/resources/views/livewire/import-bank.blade.php
+++ b/resources/views/livewire/import-bank.blade.php
@@ -150,6 +150,26 @@
             </x-cib.card>
         @endif
 
+        @if($accountChoice === 'existing')
+            <x-cib.card>
+                <flux:heading size="lg">Account balance</flux:heading>
+                <flux:text size="sm" class="mt-1">
+                    The account's balance right now. Pre-filled from the statement's closing balance when available.
+                </flux:text>
+                <div class="mt-3 max-w-xs">
+                    <flux:input
+                        wire:model="currentBalance"
+                        label="Current balance"
+                        type="number"
+                        step="0.01"
+                        placeholder="1686.19"
+                        data-testid="import-bank-current-balance"
+                    />
+                    @error('currentBalance') <flux:text class="text-cib-red-600 mt-1 text-sm">{{ $message }}</flux:text> @enderror
+                </div>
+            </x-cib.card>
+        @endif
+
         @if(! empty($previewRows))
             <x-cib.card>
                 <flux:heading size="lg">First 10 rows</flux:heading>

--- a/tests/Feature/Jobs/ImportCsvTransactionsJobTest.php
+++ b/tests/Feature/Jobs/ImportCsvTransactionsJobTest.php
@@ -7,16 +7,22 @@
 declare(strict_types=1);
 
 use App\Enums\BankImportStatus;
+use App\Enums\RecurrenceFrequency;
+use App\Enums\TransactionDirection;
 use App\Enums\TransactionSource;
 use App\Jobs\ImportCsvTransactionsJob;
 use App\Jobs\RunTransactionAnalysisJob;
 use App\Models\Account;
 use App\Models\BankImport;
 use App\Models\Category;
+use App\Models\PlannedTransaction;
 use App\Models\Transaction;
 use App\Models\User;
 use App\Services\CsvImport\CsvColumnMapper;
 use App\Services\CsvImport\CsvParserService;
+use App\Services\TransactionIngestor;
+use App\Support\Calendar\DayActivityLoader;
+use Carbon\CarbonImmutable;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Facades\Storage;
@@ -58,7 +64,7 @@ test('imports rows into transactions with source=csv', function () {
 
     $bankImport = makeBankImportFromFixture();
 
-    new ImportCsvTransactionsJob($bankImport)->handle(new CsvParserService());
+    new ImportCsvTransactionsJob($bankImport)->handle(new CsvParserService(), app(TransactionIngestor::class));
 
     $bankImport->refresh();
     expect($bankImport->status)->toBe(BankImportStatus::Completed)
@@ -79,7 +85,7 @@ test('re-running the same import is idempotent (dedupe via csv_hash)', function 
 
     $bankImport = makeBankImportFromFixture();
 
-    new ImportCsvTransactionsJob($bankImport)->handle(new CsvParserService());
+    new ImportCsvTransactionsJob($bankImport)->handle(new CsvParserService(), app(TransactionIngestor::class));
 
     $bankImport->refresh();
     $firstImported = $bankImport->imported_count;
@@ -96,7 +102,7 @@ test('re-running the same import is idempotent (dedupe via csv_hash)', function 
         'completed_at' => null,
     ]);
 
-    new ImportCsvTransactionsJob($bankImport)->handle(new CsvParserService());
+    new ImportCsvTransactionsJob($bankImport)->handle(new CsvParserService(), app(TransactionIngestor::class));
 
     $bankImport->refresh();
     expect($bankImport->status)->toBe(BankImportStatus::Completed)
@@ -114,7 +120,7 @@ test('status transitions through importing then completed', function () {
     expect($bankImport->status)->toBe(BankImportStatus::Pending)
         ->and($bankImport->started_at)->toBeNull();
 
-    new ImportCsvTransactionsJob($bankImport)->handle(new CsvParserService());
+    new ImportCsvTransactionsJob($bankImport)->handle(new CsvParserService(), app(TransactionIngestor::class));
 
     $bankImport->refresh();
     expect($bankImport->status)->toBe(BankImportStatus::Completed)
@@ -127,7 +133,7 @@ test('dispatches RunTransactionAnalysisJob after successful import', function ()
 
     $bankImport = makeBankImportFromFixture();
 
-    new ImportCsvTransactionsJob($bankImport)->handle(new CsvParserService());
+    new ImportCsvTransactionsJob($bankImport)->handle(new CsvParserService(), app(TransactionIngestor::class));
 
     Queue::assertPushed(
         RunTransactionAnalysisJob::class,
@@ -141,8 +147,7 @@ test('failure transitions status to Failed and records error_summary', function 
     $bankImport = makeBankImportFromFixture();
     $bankImport->update(['stored_path' => 'bank-imports/does-not-exist.csv']);
 
-    expect(fn () => new ImportCsvTransactionsJob($bankImport)
-        ->handle(new CsvParserService()))->toThrow(Exception::class);
+    expect(fn () => new ImportCsvTransactionsJob($bankImport)->handle(new CsvParserService(), app(TransactionIngestor::class)))->toThrow(Exception::class);
 
     $bankImport->refresh();
     expect($bankImport->status)->toBe(BankImportStatus::Failed)
@@ -157,7 +162,7 @@ test('re-importing restores a soft-deleted transaction and preserves its categor
 
     $bankImport = makeBankImportFromFixture();
 
-    new ImportCsvTransactionsJob($bankImport)->handle(new CsvParserService());
+    new ImportCsvTransactionsJob($bankImport)->handle(new CsvParserService(), app(TransactionIngestor::class));
 
     $bankImport->refresh();
     expect($bankImport->status)->toBe(BankImportStatus::Completed)
@@ -187,7 +192,7 @@ test('re-importing restores a soft-deleted transaction and preserves its categor
         'completed_at' => null,
     ]);
 
-    new ImportCsvTransactionsJob($bankImport)->handle(new CsvParserService());
+    new ImportCsvTransactionsJob($bankImport)->handle(new CsvParserService(), app(TransactionIngestor::class));
 
     $bankImport->refresh();
     $restored = Transaction::query()->find($targetId);
@@ -239,7 +244,7 @@ test('per-row failure does not abort the import and is recorded in row_errors', 
                 ],
             ]);
 
-        new ImportCsvTransactionsJob($bankImport)->handle(new CsvParserService());
+        new ImportCsvTransactionsJob($bankImport)->handle(new CsvParserService(), app(TransactionIngestor::class));
 
         $bankImport->refresh();
 
@@ -273,4 +278,92 @@ test('has WithoutOverlapping middleware keyed on bank import', function () {
 
     expect($middleware)->toHaveCount(1)
         ->and($middleware[0])->toBeInstanceOf(Illuminate\Queue\Middleware\WithoutOverlapping::class);
+});
+
+test('a csv row matching an active plan is reconciled at import and renders a single calendar pip', function () {
+    Queue::fake([RunTransactionAnalysisJob::class]);
+
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->csvImport()->create();
+
+    $plan = PlannedTransaction::factory()->for($user)->create([
+        'account_id' => $account->id,
+        'amount' => 50000,
+        'direction' => TransactionDirection::Debit,
+        'frequency' => RecurrenceFrequency::DontRepeat,
+        'start_date' => '2026-06-05',
+        'is_active' => true,
+    ]);
+
+    $csv = <<<'CSV'
+        Date,Description,Amount
+        05/06/2026,RENT PAYMENT,-500.00
+        CSV;
+
+    $storedPath = 'bank-imports/'.bin2hex(random_bytes(8)).'.csv';
+    Storage::disk('local')->put($storedPath, $csv);
+
+    $bankImport = BankImport::factory()->for($user)->for($account)->create([
+        'original_filename' => 'rent.csv',
+        'stored_path' => $storedPath,
+        'column_mapping' => [
+            CsvColumnMapper::FIELD_DATE => 'Date',
+            CsvColumnMapper::FIELD_DESCRIPTION => 'Description',
+            CsvColumnMapper::FIELD_AMOUNT => 'Amount',
+        ],
+    ]);
+
+    new ImportCsvTransactionsJob($bankImport)->handle(new CsvParserService(), app(TransactionIngestor::class));
+
+    $tx = Transaction::query()->where('account_id', $account->id)->first();
+    expect($tx->planned_transaction_id)->toBe($plan->id);
+
+    $activity = new DayActivityLoader()->load(
+        CarbonImmutable::create(2026, 6, 1),
+        CarbonImmutable::create(2026, 6, 30),
+        $user->id,
+    );
+
+    expect($activity['2026-06-05'] ?? null)->not->toBeNull()
+        ->and($activity['2026-06-05']->pips)->toHaveCount(1)
+        ->and($activity['2026-06-05']->pips[0]->matched)->toBeTrue();
+});
+
+test('a csv row with no matching plan is left entered (unlinked)', function () {
+    Queue::fake([RunTransactionAnalysisJob::class]);
+
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->csvImport()->create();
+
+    PlannedTransaction::factory()->for($user)->create([
+        'account_id' => $account->id,
+        'amount' => 50000,
+        'direction' => TransactionDirection::Debit,
+        'frequency' => RecurrenceFrequency::DontRepeat,
+        'start_date' => '2026-06-05',
+        'is_active' => true,
+    ]);
+
+    $csv = <<<'CSV'
+        Date,Description,Amount
+        05/06/2026,GROCERIES,-120.00
+        CSV;
+
+    $storedPath = 'bank-imports/'.bin2hex(random_bytes(8)).'.csv';
+    Storage::disk('local')->put($storedPath, $csv);
+
+    $bankImport = BankImport::factory()->for($user)->for($account)->create([
+        'original_filename' => 'groceries.csv',
+        'stored_path' => $storedPath,
+        'column_mapping' => [
+            CsvColumnMapper::FIELD_DATE => 'Date',
+            CsvColumnMapper::FIELD_DESCRIPTION => 'Description',
+            CsvColumnMapper::FIELD_AMOUNT => 'Amount',
+        ],
+    ]);
+
+    new ImportCsvTransactionsJob($bankImport)->handle(new CsvParserService(), app(TransactionIngestor::class));
+
+    $tx = Transaction::query()->where('account_id', $account->id)->first();
+    expect($tx->planned_transaction_id)->toBeNull();
 });

--- a/tests/Feature/Jobs/ImportCsvTransactionsJobTest.php
+++ b/tests/Feature/Jobs/ImportCsvTransactionsJobTest.php
@@ -286,8 +286,7 @@ test('a csv row matching an active plan is reconciled at import and renders a si
     $user = User::factory()->create();
     $account = Account::factory()->for($user)->csvImport()->create();
 
-    $plan = PlannedTransaction::factory()->for($user)->create([
-        'account_id' => $account->id,
+    $plan = PlannedTransaction::factory()->for($user)->for($account)->create([
         'amount' => 50000,
         'direction' => TransactionDirection::Debit,
         'frequency' => RecurrenceFrequency::DontRepeat,
@@ -335,8 +334,7 @@ test('a csv row with no matching plan is left entered (unlinked)', function () {
     $user = User::factory()->create();
     $account = Account::factory()->for($user)->csvImport()->create();
 
-    PlannedTransaction::factory()->for($user)->create([
-        'account_id' => $account->id,
+    PlannedTransaction::factory()->for($user)->for($account)->create([
         'amount' => 50000,
         'direction' => TransactionDirection::Debit,
         'frequency' => RecurrenceFrequency::DontRepeat,

--- a/tests/Feature/Jobs/SyncTransactionsJobTest.php
+++ b/tests/Feature/Jobs/SyncTransactionsJobTest.php
@@ -11,13 +11,16 @@ use App\DTOs\BasiqAccount;
 use App\DTOs\BasiqJob;
 use App\DTOs\BasiqTransaction;
 use App\Enums\AccountClass;
+use App\Enums\RecurrenceFrequency;
 use App\Enums\RefreshStatus;
 use App\Enums\RefreshTrigger;
+use App\Enums\TransactionDirection;
 use App\Enums\TransactionSource;
 use App\Jobs\RunTransactionAnalysisJob;
 use App\Jobs\SyncTransactionsJob;
 use App\Models\Account;
 use App\Models\BasiqRefreshLog;
+use App\Models\PlannedTransaction;
 use App\Models\Transaction;
 use App\Models\User;
 use Illuminate\Support\Collection;
@@ -774,4 +777,41 @@ test('does not dispatch RunTransactionAnalysisJob when basiq job fails', functio
     new SyncTransactionsJob($user, 'job-1')->handle(app(BasiqServiceContract::class));
 
     Queue::assertNotPushed(RunTransactionAnalysisJob::class);
+});
+
+test('a synced basiq transaction matching an active plan is reconciled', function () {
+    Queue::fake([RunTransactionAnalysisJob::class]);
+
+    $user = User::factory()->withBasiq()->create();
+    $account = Account::factory()->for($user)->create([
+        'basiq_account_id' => 'basiq-acc-1',
+    ]);
+
+    $plan = PlannedTransaction::factory()->for($user)->create([
+        'account_id' => $account->id,
+        'amount' => 5000,
+        'direction' => TransactionDirection::Debit,
+        'frequency' => RecurrenceFrequency::DontRepeat,
+        'start_date' => '2026-03-15',
+        'is_active' => true,
+    ]);
+
+    fakeBasiqJobService('success', function (MockInterface $mock) {
+        $mock->shouldReceive('getAccounts')
+            ->andReturn(new Collection([makeBasiqAccount('basiq-acc-1')]));
+        $mock->shouldReceive('paginateTransactions')
+            ->andReturn(LazyCollection::make([
+                makeBasiqTransaction('txn-1', 'basiq-acc-1', [
+                    'amount' => '-50.00',
+                    'direction' => 'debit',
+                    'postDate' => '2026-03-15',
+                ]),
+            ]));
+    });
+
+    new SyncTransactionsJob($user, 'job-1')->handle(app(BasiqServiceContract::class));
+
+    $txn = Transaction::where('basiq_id', 'txn-1')->first();
+    expect($txn)->not->toBeNull()
+        ->and($txn->planned_transaction_id)->toBe($plan->id);
 });

--- a/tests/Feature/Livewire/AnalysisSuggestionsTest.php
+++ b/tests/Feature/Livewire/AnalysisSuggestionsTest.php
@@ -24,6 +24,7 @@ beforeEach(function () {
     $this->user = User::factory()->create();
     $this->account = Account::factory()->for($this->user)->create();
     $this->pipelineRun = PipelineRun::factory()->for($this->user)->create();
+    config(['budget.recurring_detection' => true]);
 });
 
 function primaryAccountPayload(int $accountId, string $accountName = 'Everyday Account'): array
@@ -204,6 +205,15 @@ test('recurring-transaction accept button uses yellow-pill markup, not flux prim
         ->assertSee('Accept');
 
     expect($component->html())->toMatch('/wire:click="acceptRecurringTransaction\(\d+\)"[^>]*?bg-cib-yellow-400/s');
+});
+test('recurring-transaction suggestions are hidden when auto-detection is disabled', function () {
+    config(['budget.recurring_detection' => false]);
+
+    $suggestion = createSuggestion($this, 'recurring', recurringPayload($this->account->id));
+
+    Livewire::actingAs($this->user)
+        ->test(AnalysisSuggestions::class)
+        ->assertDontSeeHtml('wire:click="acceptRecurringTransaction('.$suggestion->id.')"');
 });
 
 test('user-rule accept button uses yellow-pill markup, not flux primary', function () {

--- a/tests/Feature/Livewire/ImportBankTest.php
+++ b/tests/Feature/Livewire/ImportBankTest.php
@@ -284,3 +284,46 @@ test('end-to-end: confirming a Beyond Bank upload imports real transactions into
         ->where('amount', 150_000)
         ->exists())->toBeTrue();
 });
+
+test('confirmImport prefills and applies the statement closing balance for an existing account', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->csvImport()->create(['balance' => 0]);
+
+    $csv = "Date,Description,Amount,Balance\n01/06/2026,Coffee,-5.00,1000.00\n03/06/2026,Pay,2000.00,3000.00\n";
+    $file = UploadedFile::fake()->createWithContent('statement.csv', $csv);
+
+    $component = Livewire::actingAs($user)
+        ->test(ImportBank::class)
+        ->set('accountChoice', 'existing')
+        ->set('accountId', $account->id)
+        ->set('file', $file)
+        ->call('uploadAndDetectHeaders')
+        ->set('mapping.'.CsvColumnMapper::FIELD_BALANCE, 'Balance');
+
+    expect($component->get('currentBalance'))->toBe('3000.00');
+
+    $component->call('confirmImport')->assertSet('step', 3);
+
+    expect($account->refresh()->balance)->toBe(300000);
+});
+
+test('a manually entered current balance overrides the prefilled closing balance', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->csvImport()->create(['balance' => 0]);
+
+    $csv = "Date,Description,Amount,Balance\n01/06/2026,Coffee,-5.00,1000.00\n03/06/2026,Pay,2000.00,3000.00\n";
+    $file = UploadedFile::fake()->createWithContent('statement.csv', $csv);
+
+    Livewire::actingAs($user)
+        ->test(ImportBank::class)
+        ->set('accountChoice', 'existing')
+        ->set('accountId', $account->id)
+        ->set('file', $file)
+        ->call('uploadAndDetectHeaders')
+        ->set('mapping.'.CsvColumnMapper::FIELD_BALANCE, 'Balance')
+        ->set('currentBalance', '1234.56')
+        ->call('confirmImport')
+        ->assertSet('step', 3);
+
+    expect($account->refresh()->balance)->toBe(123456);
+});

--- a/tests/Feature/Livewire/ImportBankTest.php
+++ b/tests/Feature/Livewire/ImportBankTest.php
@@ -328,3 +328,45 @@ test('a manually entered current balance overrides the prefilled closing balance
 
     expect($account->refresh()->balance)->toBe(123456);
 });
+
+test('changing the balance column re-derives the prefilled current balance', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->csvImport()->create(['balance' => 0]);
+
+    $csv = "Date,Description,Amount,Balance,RunningTotal\n01/06/2026,Coffee,-5.00,1000.00,2000.00\n03/06/2026,Pay,2000.00,3000.00,5000.00\n";
+    $file = UploadedFile::fake()->createWithContent('statement.csv', $csv);
+
+    $component = Livewire::actingAs($user)
+        ->test(ImportBank::class)
+        ->set('accountChoice', 'existing')
+        ->set('accountId', $account->id)
+        ->set('file', $file)
+        ->call('uploadAndDetectHeaders')
+        ->set('mapping.'.CsvColumnMapper::FIELD_BALANCE, 'Balance');
+
+    expect($component->get('currentBalance'))->toBe('3000.00');
+
+    $component->set('mapping.'.CsvColumnMapper::FIELD_BALANCE, 'RunningTotal');
+
+    expect($component->get('currentBalance'))->toBe('5000.00');
+});
+
+test('a manually entered balance is preserved when the mapping changes', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->csvImport()->create(['balance' => 0]);
+
+    $csv = "Date,Description,Amount,Balance,RunningTotal\n01/06/2026,Coffee,-5.00,1000.00,2000.00\n03/06/2026,Pay,2000.00,3000.00,5000.00\n";
+    $file = UploadedFile::fake()->createWithContent('statement.csv', $csv);
+
+    $component = Livewire::actingAs($user)
+        ->test(ImportBank::class)
+        ->set('accountChoice', 'existing')
+        ->set('accountId', $account->id)
+        ->set('file', $file)
+        ->call('uploadAndDetectHeaders')
+        ->set('mapping.'.CsvColumnMapper::FIELD_BALANCE, 'Balance')
+        ->set('currentBalance', '99.99')
+        ->set('mapping.'.CsvColumnMapper::FIELD_BALANCE, 'RunningTotal');
+
+    expect($component->get('currentBalance'))->toBe('99.99');
+});

--- a/tests/Feature/Livewire/ImportBankTest.php
+++ b/tests/Feature/Livewire/ImportBankTest.php
@@ -327,3 +327,45 @@ test('a manually entered current balance overrides the prefilled closing balance
 
     expect($account->refresh()->balance)->toBe(123456);
 });
+
+test('changing the balance column re-derives the prefilled current balance', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->csvImport()->create(['balance' => 0]);
+
+    $csv = "Date,Description,Amount,Balance,RunningTotal\n01/06/2026,Coffee,-5.00,1000.00,2000.00\n03/06/2026,Pay,2000.00,3000.00,5000.00\n";
+    $file = UploadedFile::fake()->createWithContent('statement.csv', $csv);
+
+    $component = Livewire::actingAs($user)
+        ->test(ImportBank::class)
+        ->set('accountChoice', 'existing')
+        ->set('accountId', $account->id)
+        ->set('file', $file)
+        ->call('uploadAndDetectHeaders')
+        ->set('mapping.'.CsvColumnMapper::FIELD_BALANCE, 'Balance');
+
+    expect($component->get('currentBalance'))->toBe('3000.00');
+
+    $component->set('mapping.'.CsvColumnMapper::FIELD_BALANCE, 'RunningTotal');
+
+    expect($component->get('currentBalance'))->toBe('5000.00');
+});
+
+test('a manually entered balance is preserved when the mapping changes', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->csvImport()->create(['balance' => 0]);
+
+    $csv = "Date,Description,Amount,Balance,RunningTotal\n01/06/2026,Coffee,-5.00,1000.00,2000.00\n03/06/2026,Pay,2000.00,3000.00,5000.00\n";
+    $file = UploadedFile::fake()->createWithContent('statement.csv', $csv);
+
+    $component = Livewire::actingAs($user)
+        ->test(ImportBank::class)
+        ->set('accountChoice', 'existing')
+        ->set('accountId', $account->id)
+        ->set('file', $file)
+        ->call('uploadAndDetectHeaders')
+        ->set('mapping.'.CsvColumnMapper::FIELD_BALANCE, 'Balance')
+        ->set('currentBalance', '99.99')
+        ->set('mapping.'.CsvColumnMapper::FIELD_BALANCE, 'RunningTotal');
+
+    expect($component->get('currentBalance'))->toBe('99.99');
+});

--- a/tests/Feature/Livewire/ImportBankTest.php
+++ b/tests/Feature/Livewire/ImportBankTest.php
@@ -285,3 +285,46 @@ test('end-to-end: confirming a Beyond Bank upload imports real transactions into
         ->where('amount', 150_000)
         ->exists())->toBeTrue();
 });
+
+test('confirmImport prefills and applies the statement closing balance for an existing account', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->csvImport()->create(['balance' => 0]);
+
+    $csv = "Date,Description,Amount,Balance\n01/06/2026,Coffee,-5.00,1000.00\n03/06/2026,Pay,2000.00,3000.00\n";
+    $file = UploadedFile::fake()->createWithContent('statement.csv', $csv);
+
+    $component = Livewire::actingAs($user)
+        ->test(ImportBank::class)
+        ->set('accountChoice', 'existing')
+        ->set('accountId', $account->id)
+        ->set('file', $file)
+        ->call('uploadAndDetectHeaders')
+        ->set('mapping.'.CsvColumnMapper::FIELD_BALANCE, 'Balance');
+
+    expect($component->get('currentBalance'))->toBe('3000.00');
+
+    $component->call('confirmImport')->assertSet('step', 3);
+
+    expect($account->refresh()->balance)->toBe(300000);
+});
+
+test('a manually entered current balance overrides the prefilled closing balance', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->csvImport()->create(['balance' => 0]);
+
+    $csv = "Date,Description,Amount,Balance\n01/06/2026,Coffee,-5.00,1000.00\n03/06/2026,Pay,2000.00,3000.00\n";
+    $file = UploadedFile::fake()->createWithContent('statement.csv', $csv);
+
+    Livewire::actingAs($user)
+        ->test(ImportBank::class)
+        ->set('accountChoice', 'existing')
+        ->set('accountId', $account->id)
+        ->set('file', $file)
+        ->call('uploadAndDetectHeaders')
+        ->set('mapping.'.CsvColumnMapper::FIELD_BALANCE, 'Balance')
+        ->set('currentBalance', '1234.56')
+        ->call('confirmImport')
+        ->assertSet('step', 3);
+
+    expect($account->refresh()->balance)->toBe(123456);
+});

--- a/tests/Feature/Livewire/ImportBankTest.php
+++ b/tests/Feature/Livewire/ImportBankTest.php
@@ -15,6 +15,7 @@ use App\Models\BankImport;
 use App\Models\User;
 use App\Services\CsvImport\CsvColumnMapper;
 use App\Services\CsvImport\CsvParserService;
+use App\Services\TransactionIngestor;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Queue;
@@ -266,7 +267,7 @@ test('end-to-end: confirming a Beyond Bank upload imports real transactions into
     // complete the process and prove the wiring produces transactions.
     $bankImport = BankImport::query()->where('user_id', $user->id)->latest('id')->firstOrFail();
 
-    new ImportCsvTransactionsJob($bankImport)->handle(new CsvParserService());
+    new ImportCsvTransactionsJob($bankImport)->handle(new CsvParserService(), app(TransactionIngestor::class));
 
     $bankImport->refresh();
 

--- a/tests/Feature/Livewire/TransactionModalTest.php
+++ b/tests/Feature/Livewire/TransactionModalTest.php
@@ -3282,3 +3282,65 @@ test('converting to a plan without ticking categorise-matching creates no rule a
     expect(UserRule::query()->where('user_id', $user->id)->count())->toBe(0)
         ->and($sibling->fresh()->category_id)->toBeNull();
 });
+
+test('a manual entry on a plan occurrence day reconciles to the plan', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+
+    $plan = PlannedTransaction::factory()->for($user)->create([
+        'account_id' => $account->id,
+        'amount' => 5000,
+        'direction' => TransactionDirection::Debit,
+        'frequency' => RecurrenceFrequency::DontRepeat,
+        'start_date' => '2026-03-15',
+        'is_active' => true,
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('open-transaction-modal', date: '2026-03-15')
+        ->set('transactionType', 'expense')
+        ->set('descriptionInput', '50 gym')
+        ->set('accountId', $account->id)
+        ->call('save')
+        ->assertHasNoErrors();
+
+    $tx = Transaction::query()
+        ->where('user_id', $user->id)
+        ->where('source', TransactionSource::Manual)
+        ->first();
+
+    expect($tx)->not->toBeNull()
+        ->and($tx->planned_transaction_id)->toBe($plan->id);
+});
+
+test('a manual entry with no matching plan is left entered (unlinked)', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+
+    PlannedTransaction::factory()->for($user)->create([
+        'account_id' => $account->id,
+        'amount' => 5000,
+        'direction' => TransactionDirection::Debit,
+        'frequency' => RecurrenceFrequency::DontRepeat,
+        'start_date' => '2026-03-15',
+        'is_active' => true,
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('open-transaction-modal', date: '2026-03-15')
+        ->set('transactionType', 'expense')
+        ->set('descriptionInput', '120 groceries')
+        ->set('accountId', $account->id)
+        ->call('save')
+        ->assertHasNoErrors();
+
+    $tx = Transaction::query()
+        ->where('user_id', $user->id)
+        ->where('source', TransactionSource::Manual)
+        ->first();
+
+    expect($tx)->not->toBeNull()
+        ->and($tx->planned_transaction_id)->toBeNull();
+});

--- a/tests/Feature/Models/PlannedTransactionTest.php
+++ b/tests/Feature/Models/PlannedTransactionTest.php
@@ -6,12 +6,14 @@ declare(strict_types=1);
 
 use App\Enums\RecurrenceFrequency;
 use App\Enums\TransactionDirection;
+use App\Events\PlannedTransactionCreated;
 use App\Models\Account;
 use App\Models\Category;
 use App\Models\PlannedTransaction;
 use App\Models\Transaction;
 use App\Models\User;
 use Carbon\CarbonImmutable;
+use Illuminate\Support\Facades\Event;
 
 // ── Factory & Basics ──────────────────────────────────────────────
 
@@ -20,6 +22,17 @@ test('factory creates a valid planned transaction', function () {
 
     expect($planned)->toBeInstanceOf(PlannedTransaction::class)
         ->and($planned->exists)->toBeTrue();
+});
+
+test('creating a planned transaction fires PlannedTransactionCreated', function () {
+    Event::fake([PlannedTransactionCreated::class]);
+
+    $planned = PlannedTransaction::factory()->create();
+
+    Event::assertDispatched(
+        PlannedTransactionCreated::class,
+        fn (PlannedTransactionCreated $event): bool => $event->plannedTransaction->is($planned),
+    );
 });
 
 test('default factory creates monthly frequency', function () {

--- a/tests/Feature/Services/CsvImport/CsvParserServiceTest.php
+++ b/tests/Feature/Services/CsvImport/CsvParserServiceTest.php
@@ -197,3 +197,30 @@ test('eachRow is a generator that streams rows lazily', function () {
     $rows = iterator_to_array($generator, preserve_keys: false);
     expect($rows)->toHaveCount(2);
 });
+
+test('summarize returns the closing balance from the latest-dated row', function () {
+    $path = tmpCsv("Date,Description,Amount,Balance\n01/06/2026,Coffee,-5.00,1000.00\n03/06/2026,Pay,2000.00,3000.00\n02/06/2026,Snack,-2.00,998.00\n");
+
+    $parser = new CsvParserService();
+    $summary = $parser->summarize($path, [
+        CsvColumnMapper::FIELD_DATE => 'Date',
+        CsvColumnMapper::FIELD_DESCRIPTION => 'Description',
+        CsvColumnMapper::FIELD_AMOUNT => 'Amount',
+        CsvColumnMapper::FIELD_BALANCE => 'Balance',
+    ]);
+
+    expect($summary->closingBalance)->toBe(300000);
+});
+
+test('summarize closing balance is null when no balance column is mapped', function () {
+    $path = tmpCsv("Date,Description,Amount\n01/06/2026,Coffee,-5.00\n");
+
+    $parser = new CsvParserService();
+    $summary = $parser->summarize($path, [
+        CsvColumnMapper::FIELD_DATE => 'Date',
+        CsvColumnMapper::FIELD_DESCRIPTION => 'Description',
+        CsvColumnMapper::FIELD_AMOUNT => 'Amount',
+    ]);
+
+    expect($summary->closingBalance)->toBeNull();
+});

--- a/tests/Feature/Services/PipelineStages/IdentifyRecurringTransactionsStageTest.php
+++ b/tests/Feature/Services/PipelineStages/IdentifyRecurringTransactionsStageTest.php
@@ -821,6 +821,8 @@ test('creates audit entries for skipped candidates with reason in metadata', fun
 // ─── Integration ────────────────────────────────────────────────────────
 
 test('stage is registered in pipeline and full run produces suggestions', function () {
+    config(['budget.recurring_detection' => true]);
+
     createMonthlyGroup($this->user, $this->account, 'Netflix', 1699, 3);
 
     $pipeline = app(App\Services\TransactionAnalysisPipeline::class);
@@ -846,7 +848,11 @@ test('label returns human-readable string', function () {
     expect($this->stage->label())->toBe('Identify Recurring Transactions');
 });
 
-test('shouldRun always returns true', function () {
+test('shouldRun reflects the recurring detection config flag', function () {
+    config(['budget.recurring_detection' => false]);
+    expect($this->stage->shouldRun($this->context))->toBeFalse();
+
+    config(['budget.recurring_detection' => true]);
     expect($this->stage->shouldRun($this->context))->toBeTrue();
 });
 

--- a/tests/Feature/Services/PipelineStages/IdentifyRecurringTransactionsStageTest.php
+++ b/tests/Feature/Services/PipelineStages/IdentifyRecurringTransactionsStageTest.php
@@ -838,6 +838,25 @@ test('stage is registered in pipeline and full run produces suggestions', functi
     expect($suggestions)->toHaveCount(1);
 });
 
+test('stage is skipped in a full run when recurring detection is disabled', function () {
+    config(['budget.recurring_detection' => false]);
+
+    createMonthlyGroup($this->user, $this->account, 'Netflix', 1699, 3);
+
+    $pipeline = app(App\Services\TransactionAnalysisPipeline::class);
+    $run = $pipeline->run($this->user, App\Enums\PipelineTrigger::Sync);
+
+    expect($run->stages_skipped)->toContain('identify-recurring-transactions')
+        ->and($run->stages_completed)->not->toContain('identify-recurring-transactions');
+
+    $suggestions = AnalysisSuggestion::query()
+        ->where('pipeline_run_id', $run->id)
+        ->where('type', SuggestionType::RecurringTransaction)
+        ->get();
+
+    expect($suggestions)->toBeEmpty();
+});
+
 // ─── Contract ───────────────────────────────────────────────────────────
 
 test('key returns expected string', function () {

--- a/tests/Feature/Services/PlannedTransactionMatcherTest.php
+++ b/tests/Feature/Services/PlannedTransactionMatcherTest.php
@@ -75,12 +75,26 @@ test('does not match outside the date tolerance', function () {
         ->and($tx->fresh()->planned_transaction_id)->toBeNull();
 });
 
-test('requires an exact amount (stricter than the human ±10% matcher)', function () {
-    activeRentPlan($this->user, $this->account);
+test('matches within the amount tolerance (±10%)', function () {
+    $plan = activeRentPlan($this->user, $this->account);
 
     $tx = Transaction::factory()->for($this->user)->debit()->create([
         'account_id' => $this->account->id,
         'amount' => -47500,
+        'post_date' => '2026-06-10',
+        'planned_transaction_id' => null,
+    ]);
+
+    expect($this->matcher->matchForUser($this->user))->toBe(1)
+        ->and($tx->fresh()->planned_transaction_id)->toBe($plan->id);
+});
+
+test('does not match outside the amount tolerance', function () {
+    activeRentPlan($this->user, $this->account);
+
+    $tx = Transaction::factory()->for($this->user)->debit()->create([
+        'account_id' => $this->account->id,
+        'amount' => -40000,
         'post_date' => '2026-06-10',
         'planned_transaction_id' => null,
     ]);

--- a/tests/Feature/Services/PostImportAnalysisCsvTest.php
+++ b/tests/Feature/Services/PostImportAnalysisCsvTest.php
@@ -33,6 +33,8 @@ function importedCsvTransaction(User $user, Account $account, array $overrides):
 }
 
 test('a clean CSV import auto-sets the primary account and pay cycle and surfaces recurring suggestions', function () {
+    config(['budget.recurring_detection' => true]);
+
     $user = User::factory()->create([
         'primary_account_id' => null,
         'pay_amount' => null,

--- a/tests/Feature/Services/TransactionIngestorTest.php
+++ b/tests/Feature/Services/TransactionIngestorTest.php
@@ -1,0 +1,113 @@
+<?php
+
+/** @noinspection StaticClosureCanBeUsedInspection */
+
+declare(strict_types=1);
+
+use App\Enums\RecurrenceFrequency;
+use App\Enums\TransactionDirection;
+use App\Events\TransactionEntered;
+use App\Events\TransactionReconciled;
+use App\Models\Account;
+use App\Models\PlannedTransaction;
+use App\Models\Transaction;
+use App\Models\User;
+use App\Services\TransactionIngestor;
+use Illuminate\Support\Facades\Event;
+
+beforeEach(function () {
+    $this->ingestor = app(TransactionIngestor::class);
+    $this->user = User::factory()->create();
+    $this->account = Account::factory()->for($this->user)->create();
+});
+
+function ingestorRentPlan(User $user, Account $account, string $startDate = '2026-06-10'): PlannedTransaction
+{
+    return PlannedTransaction::factory()->for($user)->create([
+        'account_id' => $account->id,
+        'amount' => 50000,
+        'direction' => TransactionDirection::Debit,
+        'frequency' => RecurrenceFrequency::DontRepeat,
+        'start_date' => $startDate,
+        'is_active' => true,
+    ]);
+}
+
+test('reconciles a transaction that fulfils an active plan occurrence', function () {
+    Event::fake([TransactionReconciled::class, TransactionEntered::class]);
+    $plan = ingestorRentPlan($this->user, $this->account);
+
+    $tx = Transaction::factory()->for($this->user)->debit()->make([
+        'account_id' => $this->account->id,
+        'amount' => -49000,
+        'post_date' => '2026-06-11',
+        'planned_transaction_id' => null,
+    ]);
+
+    $result = $this->ingestor->ingest($tx);
+
+    expect($result->planned_transaction_id)->toBe($plan->id);
+
+    Event::assertDispatched(
+        TransactionReconciled::class,
+        fn (TransactionReconciled $e): bool => $e->transaction->is($tx) && $e->plannedTransactionId === $plan->id,
+    );
+    Event::assertNotDispatched(TransactionEntered::class);
+});
+
+test('leaves a transaction with no matching plan entered', function () {
+    Event::fake([TransactionReconciled::class, TransactionEntered::class]);
+    ingestorRentPlan($this->user, $this->account);
+
+    $tx = Transaction::factory()->for($this->user)->debit()->make([
+        'account_id' => $this->account->id,
+        'amount' => -49000,
+        'post_date' => '2026-06-30',
+        'planned_transaction_id' => null,
+    ]);
+
+    $result = $this->ingestor->ingest($tx);
+
+    expect($result->planned_transaction_id)->toBeNull();
+
+    Event::assertDispatched(
+        TransactionEntered::class,
+        fn (TransactionEntered $e): bool => $e->transaction->is($tx),
+    );
+    Event::assertNotDispatched(TransactionReconciled::class);
+});
+
+test('persists an unsaved transaction passed to ingest', function () {
+    $tx = Transaction::factory()->for($this->user)->debit()->make([
+        'account_id' => $this->account->id,
+        'amount' => -1200,
+        'post_date' => '2026-06-11',
+        'planned_transaction_id' => null,
+    ]);
+
+    expect($tx->exists)->toBeFalse();
+
+    $this->ingestor->ingest($tx);
+
+    expect($tx->exists)->toBeTrue()
+        ->and(Transaction::query()->whereKey($tx->id)->exists())->toBeTrue();
+});
+
+test('does not relink a transaction already reconciled to a plan', function () {
+    Event::fake([TransactionReconciled::class, TransactionEntered::class]);
+    $plan = ingestorRentPlan($this->user, $this->account);
+
+    $tx = Transaction::factory()->for($this->user)->debit()->create([
+        'account_id' => $this->account->id,
+        'amount' => -50000,
+        'post_date' => '2026-06-10',
+        'planned_transaction_id' => $plan->id,
+    ]);
+
+    $this->ingestor->ingest($tx);
+
+    expect($tx->fresh()->planned_transaction_id)->toBe($plan->id);
+
+    Event::assertNotDispatched(TransactionReconciled::class);
+    Event::assertDispatched(TransactionEntered::class);
+});

--- a/tests/Feature/Services/TransactionIngestorTest.php
+++ b/tests/Feature/Services/TransactionIngestorTest.php
@@ -23,8 +23,7 @@ beforeEach(function () {
 
 function ingestorRentPlan(User $user, Account $account, string $startDate = '2026-06-10'): PlannedTransaction
 {
-    return PlannedTransaction::factory()->for($user)->create([
-        'account_id' => $account->id,
+    return PlannedTransaction::factory()->for($user)->for($account)->create([
         'amount' => 50000,
         'direction' => TransactionDirection::Debit,
         'frequency' => RecurrenceFrequency::DontRepeat,
@@ -37,8 +36,7 @@ test('reconciles a transaction that fulfils an active plan occurrence', function
     Event::fake([TransactionReconciled::class, TransactionEntered::class]);
     $plan = ingestorRentPlan($this->user, $this->account);
 
-    $tx = Transaction::factory()->for($this->user)->debit()->make([
-        'account_id' => $this->account->id,
+    $tx = Transaction::factory()->for($this->user)->for($this->account)->debit()->make([
         'amount' => -49000,
         'post_date' => '2026-06-11',
         'planned_transaction_id' => null,
@@ -59,8 +57,7 @@ test('leaves a transaction with no matching plan entered', function () {
     Event::fake([TransactionReconciled::class, TransactionEntered::class]);
     ingestorRentPlan($this->user, $this->account);
 
-    $tx = Transaction::factory()->for($this->user)->debit()->make([
-        'account_id' => $this->account->id,
+    $tx = Transaction::factory()->for($this->user)->for($this->account)->debit()->make([
         'amount' => -49000,
         'post_date' => '2026-06-30',
         'planned_transaction_id' => null,
@@ -78,8 +75,7 @@ test('leaves a transaction with no matching plan entered', function () {
 });
 
 test('persists an unsaved transaction passed to ingest', function () {
-    $tx = Transaction::factory()->for($this->user)->debit()->make([
-        'account_id' => $this->account->id,
+    $tx = Transaction::factory()->for($this->user)->for($this->account)->debit()->make([
         'amount' => -1200,
         'post_date' => '2026-06-11',
         'planned_transaction_id' => null,
@@ -97,8 +93,7 @@ test('does not relink or emit lifecycle events for a transaction already reconci
     Event::fake([TransactionReconciled::class, TransactionEntered::class]);
     $plan = ingestorRentPlan($this->user, $this->account);
 
-    $tx = Transaction::factory()->for($this->user)->debit()->create([
-        'account_id' => $this->account->id,
+    $tx = Transaction::factory()->for($this->user)->for($this->account)->debit()->create([
         'amount' => -50000,
         'post_date' => '2026-06-10',
         'planned_transaction_id' => $plan->id,

--- a/tests/Feature/Services/TransactionIngestorTest.php
+++ b/tests/Feature/Services/TransactionIngestorTest.php
@@ -93,7 +93,7 @@ test('persists an unsaved transaction passed to ingest', function () {
         ->and(Transaction::query()->whereKey($tx->id)->exists())->toBeTrue();
 });
 
-test('does not relink a transaction already reconciled to a plan', function () {
+test('does not relink or emit lifecycle events for a transaction already reconciled to a plan', function () {
     Event::fake([TransactionReconciled::class, TransactionEntered::class]);
     $plan = ingestorRentPlan($this->user, $this->account);
 
@@ -109,5 +109,5 @@ test('does not relink a transaction already reconciled to a plan', function () {
     expect($tx->fresh()->planned_transaction_id)->toBe($plan->id);
 
     Event::assertNotDispatched(TransactionReconciled::class);
-    Event::assertDispatched(TransactionEntered::class);
+    Event::assertNotDispatched(TransactionEntered::class);
 });

--- a/tests/Unit/Services/ReconciliationPolicyTest.php
+++ b/tests/Unit/Services/ReconciliationPolicyTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Services\ReconciliationPolicy;
+use Carbon\CarbonImmutable;
+
+test('amountMatches accepts amounts within ±10% of the plan amount', function () {
+    expect(ReconciliationPolicy::amountMatches(-50000, 50000))->toBeTrue()
+        ->and(ReconciliationPolicy::amountMatches(-47500, 50000))->toBeTrue()
+        ->and(ReconciliationPolicy::amountMatches(-45000, 50000))->toBeTrue()
+        ->and(ReconciliationPolicy::amountMatches(-55000, 50000))->toBeTrue();
+});
+
+test('amountMatches rejects amounts outside ±10% of the plan amount', function () {
+    expect(ReconciliationPolicy::amountMatches(-44999, 50000))->toBeFalse()
+        ->and(ReconciliationPolicy::amountMatches(-55001, 50000))->toBeFalse()
+        ->and(ReconciliationPolicy::amountMatches(-40000, 50000))->toBeFalse();
+});
+
+test('amountMatches compares absolute values regardless of sign', function () {
+    expect(ReconciliationPolicy::amountMatches(50000, 50000))->toBeTrue()
+        ->and(ReconciliationPolicy::amountMatches(-50000, 50000))->toBeTrue();
+});
+
+test('amountRange returns inclusive ±10% cent bounds', function () {
+    expect(ReconciliationPolicy::amountRange(50000))->toBe([45000, 55000])
+        ->and(ReconciliationPolicy::amountRange(1699))->toBe([1529, 1869]);
+});
+
+test('datesMatch is true within the date tolerance and false beyond it', function () {
+    $occurrence = CarbonImmutable::create(2026, 6, 10);
+
+    expect(ReconciliationPolicy::datesMatch($occurrence, $occurrence))->toBeTrue()
+        ->and(ReconciliationPolicy::datesMatch($occurrence->addDays(3), $occurrence))->toBeTrue()
+        ->and(ReconciliationPolicy::datesMatch($occurrence->addDays(4), $occurrence))->toBeFalse()
+        ->and(ReconciliationPolicy::datesMatch($occurrence->subDays(3), $occurrence))->toBeTrue();
+});

--- a/tests/Unit/Services/ReconciliationPolicyTest.php
+++ b/tests/Unit/Services/ReconciliationPolicyTest.php
@@ -1,5 +1,7 @@
 <?php
 
+/** @noinspection StaticClosureCanBeUsedInspection */
+
 declare(strict_types=1);
 
 use App\Services\ReconciliationPolicy;


### PR DESCRIPTION
## What
Let the user set an account's current balance at import time instead of editing it manually on the account page afterwards.

## Why
`Account.balance` is a static integer that import never updated, so importing into an **existing** account left the balance stale. The CSV's balance column was parsed per row but never surfaced or applied.

## Changes
- `PreviewSummary` gains `closingBalance` — the balance of the **latest-dated** row (robust to row ordering); `CsvParserService::summarize()` computes it when a balance column is mapped.
- `ImportBank` adds a `currentBalance` field (map/preview step, existing accounts), **prefilled** from `closingBalance`, validated `nullable|numeric`, reset in `startOver`. `confirmImport()` writes it to `account.balance` (cents).
- Blade: a "Current balance" input on step 2 for existing accounts (the new-account path already has its own balance field on step 1).

## Tests (`op test.filter` — green)
- `CsvParserServiceTest` (14): `summarize` returns the latest-row closing balance; null when no balance column is mapped.
- `ImportBankTest` (16): the field prefills from and applies the statement closing balance; a manually entered value overrides the prefill.
- Pint + GrumPHP clean.

Independent of the #277/#278/#280 stack. Target branch is `develop`.

Design: `docs/plans/2026-06-05-transaction-reconciliation-lifecycle-design.md` (section D).

Closes #279