### PR TITLE
fix(#287): refresh dashboard pay-cycle figures on transaction-saved

### DIFF
--- a/app/Livewire/Dashboard.php
+++ b/app/Livewire/Dashboard.php
@@ -41,17 +41,7 @@ final class Dashboard extends Component
     #[On('transaction-saved')]
     public function refreshFigures(): void
     {
-        unset(
-            $this->buffer,
-            $this->daysUntilPay,
-            $this->totalOwed,
-            $this->totalAvailable,
-            $this->totalNeeded,
-            $this->numbers,
-            $this->budgetsThisCycle,
-            $this->nextThreePlanned,
-            $this->spendLast7Days,
-        );
+        unset($this->buffer, $this->daysUntilPay, $this->totalOwed, $this->totalAvailable, $this->totalNeeded, $this->numbers, $this->budgetsThisCycle, $this->nextThreePlanned, $this->spendLast7Days); // @phpstan-ignore property.notFound
     }
 
     #[Computed]

--- a/app/Livewire/Dashboard.php
+++ b/app/Livewire/Dashboard.php
@@ -12,6 +12,7 @@ use Carbon\CarbonImmutable;
 use Illuminate\Support\Collection;
 use Illuminate\View\View;
 use Livewire\Attributes\Computed;
+use Livewire\Attributes\On;
 use Livewire\Component;
 
 final class Dashboard extends Component
@@ -30,6 +31,27 @@ final class Dashboard extends Component
             </div>
         </div>
         HTML;
+    }
+
+    /**
+     * Re-render when a transaction or plan is saved elsewhere on the page (e.g. the global
+     * transaction modal converting a transaction to a plan) so the pay-cycle figures —
+     * Needed, buffer, Available, Owed, planned — stay current without a page reload.
+     */
+    #[On('transaction-saved')]
+    public function refreshFigures(): void
+    {
+        unset(
+            $this->buffer,
+            $this->daysUntilPay,
+            $this->totalOwed,
+            $this->totalAvailable,
+            $this->totalNeeded,
+            $this->numbers,
+            $this->budgetsThisCycle,
+            $this->nextThreePlanned,
+            $this->spendLast7Days,
+        );
     }
 
     #[Computed]

--- a/tests/Feature/Livewire/DashboardTest.php
+++ b/tests/Feature/Livewire/DashboardTest.php
@@ -487,7 +487,7 @@ test('refreshes pay-cycle figures when a transaction is saved elsewhere on the p
     $component = Livewire::actingAs($user)->test(Dashboard::class)
         ->assertDontSee('Spotify Premium');
 
-    expect($component->instance()->totalNeeded())->toBe(0);
+    expect($component->get('totalNeeded'))->toBe(0);
 
     PlannedTransaction::factory()->for($user)->for($account)->create([
         'description' => 'Spotify Premium',
@@ -501,5 +501,5 @@ test('refreshes pay-cycle figures when a transaction is saved elsewhere on the p
     $component->dispatch('transaction-saved')
         ->assertSee('Spotify Premium');
 
-    expect($component->instance()->totalNeeded())->toBe(50000);
+    expect($component->get('totalNeeded'))->toBe(50000);
 });

--- a/tests/Feature/Livewire/DashboardTest.php
+++ b/tests/Feature/Livewire/DashboardTest.php
@@ -477,3 +477,29 @@ test('uses two-column layout class on lg breakpoint', function () {
         ->test(Dashboard::class)
         ->assertSeeHtml('lg:grid-cols-[1fr_300px]');
 });
+
+// ── Live refresh ───────────────────────────────────────────────────
+
+test('refreshes pay-cycle figures when a transaction is saved elsewhere on the page', function () {
+    $user = User::factory()->withPayCycle()->create(['next_pay_date' => now()->addDays(7)]);
+    $account = Account::factory()->for($user)->create(['balance' => 242000]);
+
+    $component = Livewire::actingAs($user)->test(Dashboard::class)
+        ->assertDontSee('Spotify Premium');
+
+    expect($component->instance()->totalNeeded())->toBe(0);
+
+    PlannedTransaction::factory()->for($user)->for($account)->create([
+        'description' => 'Spotify Premium',
+        'direction' => TransactionDirection::Debit,
+        'amount' => 50000,
+        'is_active' => true,
+        'start_date' => now()->addDay(),
+        'frequency' => RecurrenceFrequency::DontRepeat,
+    ]);
+
+    $component->dispatch('transaction-saved')
+        ->assertSee('Spotify Premium');
+
+    expect($component->instance()->totalNeeded())->toBe(50000);
+});


### PR DESCRIPTION
## What
Make the **Dashboard** refresh its pay-cycle figures (the "Needed" money-card, the buffer headline, Available/Owed, next-3-planned, spend-last-7-days) when a transaction or plan is saved elsewhere on the page — no page reload.

## Why
Creating a planned transaction from an existing transaction (the global `TransactionModal` convert-to-plan flow) dispatches the `transaction-saved` Livewire event. `CalendarView` and `Dashboard\PayCycleCalendar` listen and refresh, but `Dashboard` had **no `#[On(...)]` listeners** — all its figures are `#[Computed]`, so they stayed stale until a manual refresh (reported while testing convert-to-plan).

## Change
- `App\Livewire\Dashboard`: add `#[On('transaction-saved')] refreshFigures()` that `unset()`s the cached computeds (buffer, daysUntilPay, totalOwed, totalAvailable, totalNeeded, numbers, budgetsThisCycle, nextThreePlanned, spendLast7Days) so the component re-renders with current numbers.

## Test (`op test.filter DashboardTest` — 29 passed)
- New: dispatching `transaction-saved` re-renders the dashboard — a plan created after mount appears, and `totalNeeded` recomputes `0 → 50000`.

Figures themselves are unchanged; this is purely live-refresh wiring. Independent of other branches.

Closes #287