### PR TITLE
fix(#289): make categorise-matching specific and user-editable

### DIFF
--- a/app/Livewire/TransactionModal.php
+++ b/app/Livewire/TransactionModal.php
@@ -64,6 +64,8 @@ final class TransactionModal extends Component
 
     public bool $categoriseMatching = false;
 
+    public string $categoriseMatchValue = '';
+
     #[Locked]
     public bool $originalWasTransfer = false;
 
@@ -134,6 +136,7 @@ final class TransactionModal extends Component
         $this->categoryId = $transaction->category_id;
         $this->date = $transaction->post_date->format('Y-m-d');
         $this->notes = $transaction->notes ?? '';
+        $this->categoriseMatchValue = app(CategoryRuleGenerator::class)->suggestMatchValue($transaction);
 
         $this->showModal = true;
     }
@@ -615,7 +618,7 @@ final class TransactionModal extends Component
         // commits: it can touch many transactions, so keeping it outside avoids
         // holding row locks for the length of an interactive modal save.
         if ($isPlainSource && $this->categoriseMatching && $this->categoryId !== null) {
-            app(CategoryRuleGenerator::class)->generateAndApply($transaction, $this->categoryId);
+            app(CategoryRuleGenerator::class)->generateAndApply($transaction, $this->categoryId, $this->categoriseMatchValue);
         }
 
         return true;
@@ -844,6 +847,7 @@ final class TransactionModal extends Component
         $this->editingPlannedTransactionId = null;
         $this->occurrenceDate = null;
         $this->categoriseMatching = false;
+        $this->categoriseMatchValue = '';
         $this->isBasiqTransaction = false;
         $this->transactionType = 'expense';
         $this->descriptionInput = '';

--- a/app/Services/CategoryRuleGenerator.php
+++ b/app/Services/CategoryRuleGenerator.php
@@ -41,7 +41,7 @@ final readonly class CategoryRuleGenerator
         private RuleActionExecutor $executor,
     ) {}
 
-    public function generateAndApply(Transaction $source, int $categoryId): UserRule
+    public function generateAndApply(Transaction $source, int $categoryId, ?string $matchValue = null): UserRule
     {
         $group = $this->group($source->user_id);
 
@@ -49,7 +49,7 @@ final readonly class CategoryRuleGenerator
             'user_id' => $source->user_id,
             'user_rule_group_id' => $group->id,
             'name' => $this->ruleName($source),
-            'triggers' => [$this->buildTrigger($source)],
+            'triggers' => [$this->buildTrigger($source, $matchValue)],
             'actions' => [[
                 'type' => RuleActionType::SetCategory->value,
                 'value' => (string) $categoryId,
@@ -63,6 +63,25 @@ final readonly class CategoryRuleGenerator
         $this->applyToExisting($source->user_id, $rule);
 
         return $rule;
+    }
+
+    /**
+     * The default "description contains" value offered in the UI when the user
+     * opts into categorising matching transactions. Prefers a clean merchant
+     * name (Basiq), otherwise the most distinctive payee token of the
+     * description. The user can edit it before the rule is applied.
+     */
+    public function suggestMatchValue(Transaction $source): string
+    {
+        if ($source->merchant_name !== null && $source->merchant_name !== '') {
+            return $source->merchant_name;
+        }
+
+        if ($source->clean_description !== null && $source->clean_description !== '') {
+            return $this->merchantToken($source->clean_description);
+        }
+
+        return $this->merchantToken($source->description);
     }
 
     private function applyToExisting(int $userId, UserRule $rule): void
@@ -81,8 +100,18 @@ final readonly class CategoryRuleGenerator
     }
 
     /** @return array<string, string> */
-    private function buildTrigger(Transaction $source): array
+    private function buildTrigger(Transaction $source, ?string $matchValue = null): array
     {
+        $value = $matchValue !== null ? mb_trim($matchValue) : '';
+
+        if ($value !== '') {
+            return [
+                'field' => RuleTriggerField::Description->value,
+                'operator' => RuleTriggerOperator::Contains->value,
+                'value' => $value,
+            ];
+        }
+
         if ($source->merchant_name !== null && $source->merchant_name !== '') {
             return [
                 'field' => RuleTriggerField::MerchantName->value,
@@ -107,23 +136,35 @@ final readonly class CategoryRuleGenerator
     }
 
     /**
-     * The first non-generic payee token of the merchant signature, used as a
+     * The longest non-generic payee token of the merchant signature, used as a
      * case-insensitive `contains` value so the trigger matches the source and
      * its siblings even when reference numbers vary. Leading payment-network /
-     * method tokens (VISA, EFTPOS, PAYPAL, …) are skipped so the rule keys on
-     * the merchant ("NETFLIX.COM") instead of matching every card transaction.
+     * method tokens (VISA, EFTPOS, …) are skipped and the longest remaining
+     * token is the most distinctive payee word ("NETFLIX.COM"), so the rule
+     * keys on the merchant rather than the card network or a short noise word.
      */
     private function merchantToken(string $raw): string
     {
         $tokens = explode(' ', MerchantSignature::for($raw));
 
-        foreach ($tokens as $token) {
-            if (! in_array($token, self::GENERIC_TOKENS, true)) {
-                return $token;
+        $candidates = array_values(array_filter(
+            $tokens,
+            static fn (string $token): bool => ! in_array($token, self::GENERIC_TOKENS, true),
+        ));
+
+        if ($candidates === []) {
+            return $tokens[0];
+        }
+
+        $best = $candidates[0];
+
+        foreach ($candidates as $candidate) {
+            if (mb_strlen($candidate) > mb_strlen($best)) {
+                $best = $candidate;
             }
         }
 
-        return $tokens[0];
+        return $best;
     }
 
     private function ruleName(Transaction $source): string

--- a/app/Services/CategoryRuleGenerator.php
+++ b/app/Services/CategoryRuleGenerator.php
@@ -25,8 +25,9 @@ final readonly class CategoryRuleGenerator
     /**
      * Payment-network / method tokens that lead many card descriptions
      * ("VISA -NETFLIX.COM", "EFTPOS WOOLWORTHS"). They are not the payee, so
-     * they must never become the merchant token — otherwise the generated rule
-     * matches every card transaction instead of the merchant.
+     * merchantToken() skips them whenever a more distinctive token is available
+     * — otherwise the rule would match every card transaction. A generic token
+     * is used only as a last resort, when the signature contains nothing else.
      *
      * @var list<string>
      */

--- a/app/Services/CategoryRuleGenerator.php
+++ b/app/Services/CategoryRuleGenerator.php
@@ -22,6 +22,20 @@ final readonly class CategoryRuleGenerator
 {
     private const string GROUP_NAME = 'Auto-categorisation';
 
+    /**
+     * Payment-network / method tokens that lead many card descriptions
+     * ("VISA -NETFLIX.COM", "EFTPOS WOOLWORTHS"). They are not the payee, so
+     * they must never become the merchant token — otherwise the generated rule
+     * matches every card transaction instead of the merchant.
+     *
+     * @var list<string>
+     */
+    private const array GENERIC_TOKENS = [
+        'VISA', 'MASTERCARD', 'MC', 'AMEX', 'EFTPOS', 'PAYPAL', 'SQ', 'SQUARE',
+        'POS', 'PURCHASE', 'PAYMENT', 'DEBIT', 'CREDIT', 'PAYWAVE', 'PAYPASS',
+        'CONTACTLESS', 'TAP', 'WITHDRAWAL', 'DEPOSIT', 'TRANSFER',
+    ];
+
     public function __construct(
         private RuleEvaluator $evaluator,
         private RuleActionExecutor $executor,
@@ -93,17 +107,23 @@ final readonly class CategoryRuleGenerator
     }
 
     /**
-     * The first stable payee token of the merchant signature. A single token is
-     * a case-insensitive substring of the raw description, so a `contains`
-     * trigger matches the source and its siblings even when reference numbers
-     * vary between them.
+     * The first non-generic payee token of the merchant signature, used as a
+     * case-insensitive `contains` value so the trigger matches the source and
+     * its siblings even when reference numbers vary. Leading payment-network /
+     * method tokens (VISA, EFTPOS, PAYPAL, …) are skipped so the rule keys on
+     * the merchant ("NETFLIX.COM") instead of matching every card transaction.
      */
     private function merchantToken(string $raw): string
     {
-        $signature = MerchantSignature::for($raw);
-        $first = strtok($signature, ' ');
+        $tokens = explode(' ', MerchantSignature::for($raw));
 
-        return $first === false ? $signature : $first;
+        foreach ($tokens as $token) {
+            if (! in_array($token, self::GENERIC_TOKENS, true)) {
+                return $token;
+            }
+        }
+
+        return $tokens[0];
     }
 
     private function ruleName(Transaction $source): string

--- a/resources/views/livewire/transaction-modal.blade.php
+++ b/resources/views/livewire/transaction-modal.blade.php
@@ -167,10 +167,19 @@
 
             @if($editingTransactionId && $mode === 'plan' && $transactionType !== 'transfer')
                 <flux:field variant="inline">
-                    <flux:checkbox wire:model="categoriseMatching"/>
+                    <flux:checkbox wire:model.live="categoriseMatching"/>
                     <flux:label>{{ __('Also categorise matching transactions') }}</flux:label>
                     <flux:description>{{ __('Creates a rule that applies this category to past and future transactions from the same merchant.') }}</flux:description>
                 </flux:field>
+
+                @if($categoriseMatching)
+                    <flux:input
+                        wire:model="categoriseMatchValue"
+                        :label="__('Match when description contains')"
+                        :description="__('Edit to control which transactions are categorised — keep it specific to this merchant.')"
+                        data-testid="transaction-categorise-match-value"
+                    />
+                @endif
             @endif
 
             {{-- Plan-mode fields --}}

--- a/tests/Feature/Livewire/TransactionModalTest.php
+++ b/tests/Feature/Livewire/TransactionModalTest.php
@@ -3283,6 +3283,51 @@ test('converting to a plan without ticking categorise-matching creates no rule a
         ->and($sibling->fresh()->category_id)->toBeNull();
 });
 
+test('the categorise-matching value prefills the suggested merchant token and applies an edited value', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $category = Category::factory()->create(['is_hidden' => false]);
+
+    $source = Transaction::factory()->for($user)->for($account)->manual()->create([
+        'merchant_name' => null,
+        'clean_description' => null,
+        'amount' => 11053,
+        'direction' => TransactionDirection::Debit,
+        'description' => '110.53 VISA -Including Cash OutWOOLWORTHS/111 BOUNDARY SWESTEND',
+        'post_date' => '2026-03-15',
+        'category_id' => null,
+    ]);
+    $wooliesPurchase = Transaction::factory()->for($user)->for($account)->manual()->create([
+        'merchant_name' => null,
+        'clean_description' => null,
+        'amount' => 5420,
+        'direction' => TransactionDirection::Debit,
+        'description' => '54.20 VISA -WOOLWORTHS/111 BOUNDARY SWESTEND',
+        'category_id' => null,
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('edit-transaction', id: $source->id)
+        ->assertSet('categoriseMatchValue', 'OUTWOOLWORTHS/111')
+        ->set('mode', 'plan')
+        ->set('transactionType', 'expense')
+        ->set('descriptionInput', '110.53 Woolworths')
+        ->set('categoryId', $category->id)
+        ->set('frequency', RecurrenceFrequency::EveryMonth->value)
+        ->set('categoriseMatching', true)
+        ->set('categoriseMatchValue', 'WOOLWORTHS/111 BOUNDARY')
+        ->call('save')
+        ->assertHasNoErrors()
+        ->assertSet('showModal', false);
+
+    $rule = UserRule::query()->where('user_id', $user->id)->first();
+
+    expect($rule->triggers[0]['value'])->toBe('WOOLWORTHS/111 BOUNDARY')
+        ->and($source->fresh()->category_id)->toBe($category->id)
+        ->and($wooliesPurchase->fresh()->category_id)->toBe($category->id);
+});
+
 test('a manual entry on a plan occurrence day reconciles to the plan', function () {
     $user = User::factory()->create();
     $account = Account::factory()->for($user)->create();

--- a/tests/Feature/Services/CategoryRuleGeneratorTest.php
+++ b/tests/Feature/Services/CategoryRuleGeneratorTest.php
@@ -139,3 +139,64 @@ test('it reuses a single auto-categorisation group across generated rules', func
     expect($second->user_rule_group_id)->toBe($first->user_rule_group_id)
         ->and(UserRule::query()->where('user_id', $user->id)->count())->toBe(2);
 });
+
+test('an explicit match value builds a description-contains rule and categorises only those matches', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $category = Category::factory()->create(['is_hidden' => false]);
+
+    $wooliesCashout = Transaction::factory()->for($user)->for($account)->manual()->create([
+        'merchant_name' => null,
+        'clean_description' => null,
+        'description' => '110.53 VISA -Including Cash OutWOOLWORTHS/111 BOUNDARY SWESTEND',
+        'direction' => TransactionDirection::Debit,
+        'category_id' => null,
+    ]);
+    $wooliesPurchase = Transaction::factory()->for($user)->for($account)->manual()->create([
+        'merchant_name' => null,
+        'clean_description' => null,
+        'description' => '54.20 VISA -WOOLWORTHS/111 BOUNDARY SWESTEND',
+        'direction' => TransactionDirection::Debit,
+        'category_id' => null,
+    ]);
+    $netflix = Transaction::factory()->for($user)->for($account)->manual()->create([
+        'merchant_name' => null,
+        'clean_description' => null,
+        'description' => '28.99 VISA -NETFLIX.COM Melbourne AU',
+        'direction' => TransactionDirection::Debit,
+        'category_id' => null,
+    ]);
+
+    $rule = app(CategoryRuleGenerator::class)
+        ->generateAndApply($wooliesCashout, $category->id, 'WOOLWORTHS/111 BOUNDARY');
+
+    expect($rule->triggers[0])->toBe([
+        'field' => 'description',
+        'operator' => 'contains',
+        'value' => 'WOOLWORTHS/111 BOUNDARY',
+    ]);
+
+    expect($wooliesCashout->fresh()->category_id)->toBe($category->id)
+        ->and($wooliesPurchase->fresh()->category_id)->toBe($category->id)
+        ->and($netflix->fresh()->category_id)->toBeNull();
+});
+
+test('suggestMatchValue prefers the merchant name, else the longest description token', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $generator = app(CategoryRuleGenerator::class);
+
+    $withMerchant = Transaction::factory()->for($user)->for($account)->manual()->create([
+        'merchant_name' => 'Netflix',
+        'clean_description' => null,
+        'description' => '28.99 VISA -NETFLIX.COM Melbourne AU 619459 #2892',
+    ]);
+    $csvOnly = Transaction::factory()->for($user)->for($account)->manual()->create([
+        'merchant_name' => null,
+        'clean_description' => null,
+        'description' => '28.99 VISA -NETFLIX.COM Melbourne AU 619459 #2892',
+    ]);
+
+    expect($generator->suggestMatchValue($withMerchant))->toBe('Netflix')
+        ->and($generator->suggestMatchValue($csvOnly))->toBe('NETFLIX.COM');
+});

--- a/tests/Feature/Services/CategoryRuleGeneratorTest.php
+++ b/tests/Feature/Services/CategoryRuleGeneratorTest.php
@@ -81,6 +81,44 @@ test('it falls back to a description token trigger when there is no merchant nam
         ->and($sibling->fresh()->category_id)->toBe($category->id);
 });
 
+test('it skips a leading payment-network token and keys the rule on the merchant', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $category = Category::factory()->create(['is_hidden' => false]);
+
+    $source = Transaction::factory()->for($user)->for($account)->manual()->create([
+        'merchant_name' => null,
+        'clean_description' => null,
+        'description' => '28.99 VISA -NETFLIX.COM Melbourne AU 619459 #2892',
+        'direction' => TransactionDirection::Debit,
+        'category_id' => null,
+    ]);
+    $sibling = Transaction::factory()->for($user)->for($account)->manual()->create([
+        'merchant_name' => null,
+        'clean_description' => null,
+        'description' => '28.99 VISA -NETFLIX.COM Sydney AU 778812 #4410',
+        'direction' => TransactionDirection::Debit,
+        'category_id' => null,
+    ]);
+    $unrelatedVisa = Transaction::factory()->for($user)->for($account)->manual()->create([
+        'merchant_name' => null,
+        'clean_description' => null,
+        'description' => '12.50 VISA -WOOLWORTHS Brisbane AU 100200 #3050',
+        'direction' => TransactionDirection::Debit,
+        'category_id' => null,
+    ]);
+
+    $rule = app(CategoryRuleGenerator::class)->generateAndApply($source, $category->id);
+
+    expect($rule->triggers[0]['field'])->toBe('description')
+        ->and($rule->triggers[0]['operator'])->toBe('contains')
+        ->and($rule->triggers[0]['value'])->toBe('NETFLIX.COM');
+
+    expect($source->fresh()->category_id)->toBe($category->id)
+        ->and($sibling->fresh()->category_id)->toBe($category->id)
+        ->and($unrelatedVisa->fresh()->category_id)->toBeNull();
+});
+
 test('it reuses a single auto-categorisation group across generated rules', function () {
     $user = User::factory()->create();
     $account = Account::factory()->for($user)->create();


### PR DESCRIPTION
## What
Fix bulk **"categorise matching"** miscategorising unrelated transactions, and make the match **specific + user-editable**.

## Repro
Converting `28.99 VISA -NETFLIX.COM ... 619459 #2892` to a plan with matching on recategorised 4 unrelated 03/06 rows. Follow-up: a single token is still too weak for messy descriptions like `110.53 VISA -Including Cash OutWOOLWORTHS/111 BOUNDARY SWESTEND`.

## Cause
`merchantToken()` used the **first** token of the merchant signature — for a CSV row that's the generic card-network word `VISA`, so the rule matched every Visa transaction.

## Fix
1. **Skip generic payment-network/method tokens** (VISA, EFTPOS, PAYPAL, …) and pick the **longest** remaining (most distinctive) token — `NETFLIX.COM`, not `VISA`.
2. **User confirms/edits the match.** `generateAndApply()` takes an optional match value; `suggestMatchValue()` provides the default (merchant name, else longest token). `TransactionModal` prefills it and shows an editable **“Match when description contains”** field when “categorise matching” is ticked, so you see and control exactly what will match (e.g. broaden to `WOOLWORTHS/111 BOUNDARY`) before applying. `Contains` is case-insensitive literal substring, so siblings with varying refs still match.

## Tests (`op test.filter` — green)
- `CategoryRuleGeneratorTest` (6): VISA-prefixed Netflix → `contains NETFLIX.COM` (unrelated Visa/Woolworths left alone); explicit value builds a `description contains` rule matching only those; `suggestMatchValue` prefers merchant name else longest token.
- `TransactionModalTest` (139): the field prefills the suggested token (`OUTWOOLWORTHS/111`) and an edited value (`WOOLWORTHS/111 BOUNDARY`) drives the rule + categorises both Woolworths rows.

Closes #289