### PR TITLE
feat(#301): on-demand recurring scan + review on /rules

### DIFF
--- a/app/Livewire/PlannedTransactionManager.php
+++ b/app/Livewire/PlannedTransactionManager.php
@@ -1,0 +1,305 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire;
+
+use App\Enums\RecurrenceFrequency;
+use App\Enums\TransactionDirection;
+use App\Models\Account;
+use App\Models\Category;
+use App\Models\PlannedTransaction;
+use App\Models\Transaction;
+use App\Models\User;
+use Carbon\CarbonImmutable;
+use Flux\Flux;
+use Illuminate\Contracts\View\View;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\Rule;
+use Livewire\Component;
+
+final class PlannedTransactionManager extends Component
+{
+    public ?int $accountId = null;
+
+    public bool $showEditModal = false;
+
+    public ?int $editingId = null;
+
+    public string $amount = '';
+
+    public string $frequency = '';
+
+    public int|string|null $categoryId = null;
+
+    public string $direction = '';
+
+    public bool $isActive = true;
+
+    public ?string $untilDate = null;
+
+    public bool $showDeleteModal = false;
+
+    public ?int $deletingId = null;
+
+    public string $deletingDescription = '';
+
+    public function mount(): void
+    {
+        $user = $this->authenticatedUser();
+        $firstAccountId = $user->accounts()->orderBy('id')->value('id');
+
+        $this->accountId = $user->primary_account_id ?? ($firstAccountId === null ? null : (int) $firstAccountId);
+    }
+
+    public function openEdit(int $id): void
+    {
+        $plan = $this->findUserPlan($id);
+
+        if (! $plan || ! $this->guardEditablePlan($plan)) {
+            return;
+        }
+
+        $this->resetValidation();
+        $this->editingId = $plan->id;
+        $this->amount = (string) ($plan->amount / 100);
+        $this->frequency = $plan->frequency->value;
+        $this->categoryId = $plan->category_id;
+        $this->direction = $plan->direction->value;
+        $this->isActive = $plan->is_active;
+        $this->untilDate = $plan->until_date?->format('Y-m-d');
+        $this->showEditModal = true;
+    }
+
+    public function save(): void
+    {
+        $this->validate($this->formRules());
+
+        if ($this->editingId === null) {
+            return;
+        }
+
+        $plan = $this->findUserPlan($this->editingId);
+
+        if (! $plan || ! $this->guardEditablePlan($plan)) {
+            return;
+        }
+
+        DB::transaction(function () use ($plan): void {
+            $plan->update([
+                'amount' => (int) round((float) $this->amount * 100),
+                'frequency' => $this->frequency,
+                'category_id' => $this->resolvedCategoryId(),
+                'direction' => $this->direction,
+                'until_date' => $this->untilDate !== null && $this->untilDate !== '' ? $this->untilDate : null,
+                'is_active' => $this->isActive,
+            ]);
+        });
+
+        Flux::toast(text: 'Planned transaction updated', variant: 'success');
+
+        $this->showEditModal = false;
+        $this->resetEditForm();
+    }
+
+    public function toggleActive(int $id): void
+    {
+        $plan = $this->findUserPlan($id);
+
+        if (! $plan || ! $this->guardEditablePlan($plan)) {
+            return;
+        }
+
+        DB::transaction(fn (): bool => $plan->update(['is_active' => ! $plan->is_active]));
+    }
+
+    public function confirmDelete(int $id): void
+    {
+        $plan = $this->findUserPlan($id);
+
+        if (! $plan || ! $this->guardEditablePlan($plan)) {
+            return;
+        }
+
+        $this->deletingId = $plan->id;
+        $this->deletingDescription = $plan->description;
+        $this->showDeleteModal = true;
+    }
+
+    public function delete(): void
+    {
+        if ($this->deletingId === null) {
+            return;
+        }
+
+        $plan = $this->findUserPlan($this->deletingId);
+
+        if (! $plan || ! $this->guardEditablePlan($plan)) {
+            return;
+        }
+
+        DB::transaction(fn (): ?bool => $plan->delete());
+
+        Flux::toast(text: 'Planned transaction deleted', variant: 'success');
+
+        $this->showDeleteModal = false;
+        $this->resetDeleteForm();
+    }
+
+    public function render(): View
+    {
+        $user = $this->authenticatedUser();
+
+        return view('livewire.planned-transaction-manager', [
+            'accounts' => $this->accountsForUser($user),
+            'plans' => $this->plannedTransactionsForSelectedAccount($user),
+            'categories' => Category::visibleSortedByFullPath(),
+            'frequencies' => RecurrenceFrequency::cases(),
+            'directions' => TransactionDirection::cases(),
+        ]);
+    }
+
+    private function authenticatedUser(): User
+    {
+        $user = auth()->user();
+
+        abort_unless($user instanceof User, 403);
+
+        return $user;
+    }
+
+    private function findUserPlan(int $id): ?PlannedTransaction
+    {
+        $plan = PlannedTransaction::query()
+            ->where('user_id', auth()->id())
+            ->find($id);
+
+        return $plan instanceof PlannedTransaction ? $plan : null;
+    }
+
+    private function guardEditablePlan(PlannedTransaction $plan): bool
+    {
+        if (! $plan->is_pay_cycle_income) {
+            return true;
+        }
+
+        Flux::toast(text: 'Pay cycle income is managed elsewhere', variant: 'warning');
+
+        return false;
+    }
+
+    /** @return Collection<int, Account> */
+    private function accountsForUser(User $user): Collection
+    {
+        return Account::query()
+            ->where('user_id', $user->id)
+            ->orderBy('name')
+            ->get(['id', 'name']);
+    }
+
+    /** @return Collection<int, PlannedTransaction> */
+    private function plannedTransactionsForSelectedAccount(User $user): Collection
+    {
+        if (! $this->selectedAccountBelongsTo($user)) {
+            return collect();
+        }
+
+        $today = CarbonImmutable::today();
+
+        $plans = PlannedTransaction::query()
+            ->where('user_id', $user->id)
+            ->where('account_id', $this->accountId)
+            ->with(['category.parent.parent'])
+            ->withCount([
+                'transactions as matched_count' => static function (Builder $query): Builder {
+                    /** @var Builder<Transaction> $query */
+                    return $query->current();
+                },
+            ])
+            ->orderByDesc('is_active')
+            ->orderBy('description')
+            ->get();
+
+        $plans->each(function (PlannedTransaction $plan) use ($today): void {
+            $plan->setAttribute('next_occurrence', $plan->nextOccurrenceOnOrAfter($today));
+        });
+
+        return $plans;
+    }
+
+    private function selectedAccountBelongsTo(User $user): bool
+    {
+        if ($this->accountId === null) {
+            return false;
+        }
+
+        return Account::query()
+            ->where('user_id', $user->id)
+            ->whereKey($this->accountId)
+            ->exists();
+    }
+
+    /** @return array<string, list<mixed>> */
+    private function formRules(): array
+    {
+        return [
+            'amount' => ['required', 'numeric', 'min:0.01'],
+            'frequency' => ['required', 'string', Rule::in($this->frequencyValues())],
+            'direction' => ['required', 'string', Rule::in($this->directionValues())],
+            'untilDate' => ['nullable', 'date'],
+        ];
+    }
+
+    private function resolvedCategoryId(): ?int
+    {
+        if ($this->categoryId === null || $this->categoryId === '') {
+            return null;
+        }
+
+        $categoryId = (int) $this->categoryId;
+
+        return Category::query()
+            ->visible()
+            ->whereKey($categoryId)
+            ->exists()
+                ? $categoryId
+                : null;
+    }
+
+    /** @return list<string> */
+    private function frequencyValues(): array
+    {
+        return array_map(
+            static fn (RecurrenceFrequency $frequency): string => $frequency->value,
+            RecurrenceFrequency::cases(),
+        );
+    }
+
+    /** @return list<string> */
+    private function directionValues(): array
+    {
+        return array_map(
+            static fn (TransactionDirection $direction): string => $direction->value,
+            TransactionDirection::cases(),
+        );
+    }
+
+    private function resetEditForm(): void
+    {
+        $this->editingId = null;
+        $this->amount = '';
+        $this->frequency = '';
+        $this->categoryId = null;
+        $this->direction = '';
+        $this->isActive = true;
+        $this->untilDate = null;
+    }
+
+    private function resetDeleteForm(): void
+    {
+        $this->deletingId = null;
+        $this->deletingDescription = '';
+    }
+}

--- a/app/Livewire/PlannedTransactionManager.php
+++ b/app/Livewire/PlannedTransactionManager.php
@@ -185,6 +185,7 @@ final class PlannedTransactionManager extends Component
             return true;
         }
 
+        $this->resetModals();
         Flux::toast(text: 'Pay cycle income is managed elsewhere', variant: 'warning');
 
         return false;
@@ -245,7 +246,7 @@ final class PlannedTransactionManager extends Component
     private function formRules(): array
     {
         return [
-            'amount' => ['required', 'numeric', 'min:0.01'],
+            'amount' => ['required', 'numeric', 'decimal:0,2', 'min:0.01'],
             'frequency' => ['required', 'string', Rule::in($this->frequencyValues())],
             'direction' => ['required', 'string', Rule::in($this->directionValues())],
             'untilDate' => ['nullable', 'date'],
@@ -301,5 +302,13 @@ final class PlannedTransactionManager extends Component
     {
         $this->deletingId = null;
         $this->deletingDescription = '';
+    }
+
+    private function resetModals(): void
+    {
+        $this->showEditModal = false;
+        $this->showDeleteModal = false;
+        $this->resetEditForm();
+        $this->resetDeleteForm();
     }
 }

--- a/app/Livewire/RecurringTransactionReview.php
+++ b/app/Livewire/RecurringTransactionReview.php
@@ -49,8 +49,10 @@ final class RecurringTransactionReview extends Component
             return;
         }
 
+        $candidates = $detector->detect($user, $this->accountId);
+
         /** @var list<int> $suggestionIds */
-        $suggestionIds = DB::transaction(function () use ($detector, $writer, $user): array {
+        $suggestionIds = DB::transaction(function () use ($writer, $user, $candidates): array {
             $run = PipelineRun::create([
                 'user_id' => $user->id,
                 'trigger' => PipelineTrigger::Manual,
@@ -68,7 +70,6 @@ final class RecurringTransactionReview extends Component
                     'resolved_at' => CarbonImmutable::now(),
                 ]);
 
-            $candidates = $detector->detect($user, $this->accountId);
             $ids = $writer->writeForRun($user, $run, $candidates);
 
             $run->update([

--- a/app/Livewire/RecurringTransactionReview.php
+++ b/app/Livewire/RecurringTransactionReview.php
@@ -1,0 +1,205 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire;
+
+use App\Enums\PipelineRunStatus;
+use App\Enums\PipelineTrigger;
+use App\Enums\SuggestionStatus;
+use App\Enums\SuggestionType;
+use App\Models\Account;
+use App\Models\AnalysisSuggestion;
+use App\Models\Category;
+use App\Models\PipelineRun;
+use App\Models\User;
+use App\Services\Recurring\RecurringSuggestionWriter;
+use App\Services\Recurring\RecurringTransactionDetector;
+use App\Services\SuggestionApplier;
+use Carbon\CarbonImmutable;
+use Flux\Flux;
+use Illuminate\Contracts\View\View;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Livewire\Component;
+use Throwable;
+
+final class RecurringTransactionReview extends Component
+{
+    public ?int $accountId = null;
+
+    /** @var array<int, int|string|null> */
+    public array $recurringCategories = [];
+
+    public function mount(): void
+    {
+        $user = $this->authenticatedUser();
+        $firstAccountId = $user->accounts()->orderBy('id')->value('id');
+
+        $this->accountId = $user->primary_account_id ?? ($firstAccountId === null ? null : (int) $firstAccountId);
+    }
+
+    public function findRecurring(RecurringTransactionDetector $detector, RecurringSuggestionWriter $writer): void
+    {
+        $user = $this->authenticatedUser();
+
+        if (! $this->selectedAccountBelongsTo($user)) {
+            Flux::toast(text: 'Select one of your accounts before scanning', variant: 'warning');
+
+            return;
+        }
+
+        /** @var list<int> $suggestionIds */
+        $suggestionIds = DB::transaction(function () use ($detector, $writer, $user): array {
+            $run = PipelineRun::create([
+                'user_id' => $user->id,
+                'trigger' => PipelineTrigger::Manual,
+                'status' => PipelineRunStatus::Running,
+                'started_at' => CarbonImmutable::now(),
+            ]);
+
+            AnalysisSuggestion::query()
+                ->where('user_id', $user->id)
+                ->ofType(SuggestionType::RecurringTransaction)
+                ->pending()
+                ->where('payload->account_id', $this->accountId)
+                ->update([
+                    'status' => SuggestionStatus::Superseded,
+                    'resolved_at' => CarbonImmutable::now(),
+                ]);
+
+            $candidates = $detector->detect($user, $this->accountId);
+            $ids = $writer->writeForRun($user, $run, $candidates);
+
+            $run->update([
+                'status' => PipelineRunStatus::Completed,
+                'completed_at' => CarbonImmutable::now(),
+            ]);
+
+            return $ids;
+        });
+
+        $count = count($suggestionIds);
+        $message = $count === 1
+            ? 'Found 1 recurring pattern'
+            : "Found {$count} recurring patterns";
+
+        Flux::toast(text: $message, variant: 'success');
+    }
+
+    /**
+     * @throws Throwable
+     */
+    public function accept(int $suggestionId, SuggestionApplier $applier): void
+    {
+        $suggestion = $this->findPendingSuggestion($suggestionId);
+
+        if (! $suggestion) {
+            return;
+        }
+
+        $rawCategory = $this->recurringCategories[$suggestionId] ?? $suggestion->payload['category_id'] ?? null;
+        $categoryId = $rawCategory !== '' && $rawCategory !== null ? (int) $rawCategory : null;
+
+        if ($categoryId !== null && ! Category::visible()->where('id', $categoryId)->exists()) {
+            $categoryId = null;
+        }
+
+        $user = $this->authenticatedUser();
+
+        $applier->applyRecurringTransaction($suggestion, $user, $categoryId);
+
+        Flux::toast(text: 'Recurring transaction created', variant: 'success');
+    }
+
+    public function dismiss(int $suggestionId): void
+    {
+        $suggestion = $this->findPendingSuggestion($suggestionId);
+
+        if (! $suggestion) {
+            return;
+        }
+
+        $suggestion->update([
+            'status' => SuggestionStatus::Rejected,
+            'resolved_at' => CarbonImmutable::now(),
+        ]);
+
+        Flux::toast(text: 'Recurring transaction dismissed', variant: 'warning');
+    }
+
+    public function render(): View
+    {
+        $accounts = $this->accountsForUser();
+        $suggestions = $this->pendingSuggestionsForSelectedAccount();
+
+        foreach ($suggestions as $suggestion) {
+            if (! array_key_exists($suggestion->id, $this->recurringCategories)) {
+                $this->recurringCategories[$suggestion->id] = $suggestion->payload['category_id'] ?? null;
+            }
+        }
+
+        return view('livewire.recurring-transaction-review', [
+            'accounts' => $accounts,
+            'suggestions' => $suggestions,
+            'categories' => Category::visibleSortedByFullPath(),
+        ]);
+    }
+
+    private function authenticatedUser(): User
+    {
+        $user = auth()->user();
+
+        abort_unless($user instanceof User, 403);
+
+        return $user;
+    }
+
+    private function selectedAccountBelongsTo(User $user): bool
+    {
+        if ($this->accountId === null) {
+            return false;
+        }
+
+        return Account::query()
+            ->where('user_id', $user->id)
+            ->whereKey($this->accountId)
+            ->exists();
+    }
+
+    private function findPendingSuggestion(int $suggestionId): ?AnalysisSuggestion
+    {
+        $suggestion = AnalysisSuggestion::query()
+            ->where('user_id', auth()->id())
+            ->ofType(SuggestionType::RecurringTransaction)
+            ->pending()
+            ->find($suggestionId);
+
+        return $suggestion instanceof AnalysisSuggestion ? $suggestion : null;
+    }
+
+    /** @return Collection<int, Account> */
+    private function accountsForUser(): Collection
+    {
+        return Account::query()
+            ->where('user_id', auth()->id())
+            ->orderBy('name')
+            ->get(['id', 'name']);
+    }
+
+    /** @return Collection<int, AnalysisSuggestion> */
+    private function pendingSuggestionsForSelectedAccount(): Collection
+    {
+        if ($this->accountId === null) {
+            return collect();
+        }
+
+        return AnalysisSuggestion::query()
+            ->where('user_id', auth()->id())
+            ->ofType(SuggestionType::RecurringTransaction)
+            ->pending()
+            ->where('payload->account_id', $this->accountId)
+            ->latest()
+            ->get();
+    }
+}

--- a/app/Models/PlannedTransaction.php
+++ b/app/Models/PlannedTransaction.php
@@ -168,6 +168,50 @@ final class PlannedTransaction extends Model
         return $dates;
     }
 
+    /**
+     * The first occurrence on or after $from, respecting until_date, advancing
+     * from start_date so the cadence anchor (e.g. day-of-month) is preserved.
+     * Unlike occurrencesBetween() this is not bound to a fixed window, so a
+     * long-running daily plan still resolves its next date. Null when inactive
+     * or ended.
+     */
+    public function nextOccurrenceOnOrAfter(CarbonImmutable $from): ?CarbonImmutable
+    {
+        if (! $this->is_active) {
+            return null;
+        }
+
+        $current = $this->start_date;
+
+        if ($this->frequency === RecurrenceFrequency::DontRepeat) {
+            if ($this->until_date !== null && $current->greaterThan($this->until_date)) {
+                return null;
+            }
+
+            return $current->greaterThanOrEqualTo($from) ? $current : null;
+        }
+
+        for ($i = 0; $i < 100000; $i++) {
+            if ($this->until_date !== null && $current->greaterThan($this->until_date)) {
+                return null;
+            }
+
+            if ($current->greaterThanOrEqualTo($from)) {
+                return $current;
+            }
+
+            $next = $this->frequency->nextOccurrence($current);
+
+            if ($next === null) {
+                return null;
+            }
+
+            $current = $next;
+        }
+
+        return null;
+    }
+
     protected static function booted(): void
     {
         self::created(static function (PlannedTransaction $plannedTransaction): void {

--- a/app/Models/PlannedTransaction.php
+++ b/app/Models/PlannedTransaction.php
@@ -191,7 +191,9 @@ final class PlannedTransaction extends Model
             return $current->greaterThanOrEqualTo($from) ? $current : null;
         }
 
-        for ($i = 0; $i < 100000; $i++) {
+        $maxIterations = (int) abs($this->start_date->diffInDays($from)) + 367;
+
+        for ($i = 0; $i < $maxIterations; $i++) {
             if ($this->until_date !== null && $current->greaterThan($this->until_date)) {
                 return null;
             }

--- a/resources/views/livewire/planned-transaction-manager.blade.php
+++ b/resources/views/livewire/planned-transaction-manager.blade.php
@@ -1,0 +1,172 @@
+@php
+    use App\Casts\MoneyCast;
+    use Illuminate\Support\Str;
+@endphp
+
+<flux:card>
+    <div class="space-y-5">
+        <div class="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+            <div>
+                <flux:heading size="lg">Planned transactions</flux:heading>
+                <flux:text size="sm" class="mt-1 text-zinc-500">Manage the recurring plans that match future imports for this account.</flux:text>
+            </div>
+
+            <flux:field class="min-w-56">
+                <flux:label>Account</flux:label>
+                <flux:select wire:model.live="accountId" size="sm">
+                    @if($accounts->isEmpty())
+                        <flux:select.option value="">No accounts</flux:select.option>
+                    @endif
+
+                    @foreach($accounts as $account)
+                        <flux:select.option value="{{ $account->id }}">{{ $account->name }}</flux:select.option>
+                    @endforeach
+                </flux:select>
+            </flux:field>
+        </div>
+
+        @if($plans->isNotEmpty())
+            <div class="overflow-x-auto rounded-lg border border-neutral-200">
+                <table class="w-full text-sm">
+                    <thead>
+                        <tr class="border-b border-neutral-200 text-left text-zinc-500">
+                            <th class="px-4 py-3 font-medium">Description</th>
+                            <th class="px-4 py-3 text-right font-medium">Amount</th>
+                            <th class="px-4 py-3 font-medium">Direction</th>
+                            <th class="px-4 py-3 font-medium">Frequency</th>
+                            <th class="px-4 py-3 font-medium">Category</th>
+                            <th class="px-4 py-3 font-medium">Matches</th>
+                            <th class="px-4 py-3 font-medium">Next occurrence</th>
+                            <th class="px-4 py-3 text-right font-medium">Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody class="divide-y divide-neutral-200">
+                        @foreach($plans as $plan)
+                            <tr wire:key="planned-transaction-{{ $plan->id }}">
+                                <td class="px-4 py-3 align-top">
+                                    <div class="flex flex-wrap items-center gap-2">
+                                        <flux:text class="font-medium text-zinc-900">{{ $plan->description }}</flux:text>
+                                        @unless($plan->is_active)
+                                            <flux:badge size="sm" color="yellow">Inactive</flux:badge>
+                                        @endunless
+                                        @if($plan->is_pay_cycle_income)
+                                            <flux:badge size="sm" color="green">Income</flux:badge>
+                                        @endif
+                                    </div>
+                                </td>
+                                <td class="px-4 py-3 text-right align-top">
+                                    <flux:text class="tabular-nums font-medium text-zinc-900">{{ MoneyCast::format($plan->amount) }}</flux:text>
+                                </td>
+                                <td class="px-4 py-3 align-top">
+                                    <flux:text>{{ Str::headline($plan->direction->value) }}</flux:text>
+                                </td>
+                                <td class="px-4 py-3 align-top">
+                                    <flux:text>{{ $plan->frequency->label() }}</flux:text>
+                                </td>
+                                <td class="px-4 py-3 align-top">
+                                    <flux:text>{{ $plan->category?->fullPath() ?? 'No category' }}</flux:text>
+                                </td>
+                                <td class="px-4 py-3 align-top">
+                                    <flux:badge size="sm" color="purple">{{ $plan->matched_count }} {{ Str::plural('match', (int) $plan->matched_count) }}</flux:badge>
+                                </td>
+                                <td class="px-4 py-3 align-top">
+                                    <flux:text>{{ $plan->next_occurrence?->format('Y-m-d') ?? '—' }}</flux:text>
+                                </td>
+                                <td class="px-4 py-3 align-top">
+                                    <div class="flex justify-end gap-2">
+                                        @if($plan->is_pay_cycle_income)
+                                            <flux:text size="sm" class="text-zinc-500">Managed from pay cycle</flux:text>
+                                        @else
+                                            <flux:button variant="ghost" size="sm" wire:click="openEdit({{ $plan->id }})">
+                                                <flux:icon.pencil class="size-4" />
+                                            </flux:button>
+                                            <flux:button variant="ghost" size="sm" wire:click="toggleActive({{ $plan->id }})">
+                                                {{ $plan->is_active ? 'Deactivate' : 'Activate' }}
+                                            </flux:button>
+                                            <flux:button variant="ghost" size="sm" wire:click="confirmDelete({{ $plan->id }})">
+                                                <flux:icon.trash class="size-4" />
+                                            </flux:button>
+                                        @endif
+                                    </div>
+                                </td>
+                            </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+            </div>
+        @else
+            <div class="flex flex-col items-center justify-center rounded-lg border border-dashed border-neutral-200 py-10 text-center">
+                <flux:icon.calendar-days class="mb-3 size-10 text-zinc-400" />
+                <flux:heading size="sm">No planned transactions for this account yet.</flux:heading>
+            </div>
+        @endif
+    </div>
+
+    <flux:modal wire:model="showEditModal" class="max-w-lg">
+        <div class="space-y-4">
+            <flux:heading size="lg">Edit planned transaction</flux:heading>
+
+            <flux:field>
+                <flux:label>Amount</flux:label>
+                <flux:input wire:model="amount" type="number" step="0.01" min="0.01" placeholder="0.00" />
+                <flux:error name="amount" />
+            </flux:field>
+
+            <flux:field>
+                <flux:label>Frequency</flux:label>
+                <flux:select wire:model="frequency">
+                    <flux:select.option value="">Select frequency</flux:select.option>
+                    @foreach($frequencies as $recurrenceFrequency)
+                        <flux:select.option value="{{ $recurrenceFrequency->value }}">{{ $recurrenceFrequency->label() }}</flux:select.option>
+                    @endforeach
+                </flux:select>
+                <flux:error name="frequency" />
+            </flux:field>
+
+            <flux:field>
+                <flux:label>Direction</flux:label>
+                <flux:select wire:model="direction">
+                    <flux:select.option value="">Select direction</flux:select.option>
+                    @foreach($directions as $transactionDirection)
+                        <flux:select.option value="{{ $transactionDirection->value }}">{{ Str::headline($transactionDirection->value) }}</flux:select.option>
+                    @endforeach
+                </flux:select>
+                <flux:error name="direction" />
+            </flux:field>
+
+            <x-category-combobox
+                wire:model="categoryId"
+                :categories="$categories"
+                label="Category"
+                placeholder="No category"
+            />
+
+            <flux:field>
+                <flux:label>Until date</flux:label>
+                <flux:input wire:model="untilDate" type="date" />
+                <flux:error name="untilDate" />
+            </flux:field>
+
+            <flux:field>
+                <flux:checkbox wire:model="isActive" label="Active" />
+            </flux:field>
+
+            <div class="flex justify-end gap-2">
+                <flux:button variant="ghost" wire:click="$set('showEditModal', false)">Cancel</flux:button>
+                <flux:button variant="primary" wire:click="save">Update</flux:button>
+            </div>
+        </div>
+    </flux:modal>
+
+    <flux:modal wire:model="showDeleteModal" class="max-w-sm">
+        <div class="space-y-4">
+            <flux:heading size="lg">Delete planned transaction</flux:heading>
+            <flux:text>Are you sure you want to delete <strong>{{ $deletingDescription }}</strong>?</flux:text>
+
+            <div class="flex justify-end gap-2">
+                <flux:button variant="ghost" wire:click="$set('showDeleteModal', false)">Cancel</flux:button>
+                <flux:button variant="danger" wire:click="delete">Delete</flux:button>
+            </div>
+        </div>
+    </flux:modal>
+</flux:card>

--- a/resources/views/livewire/recurring-transaction-review.blade.php
+++ b/resources/views/livewire/recurring-transaction-review.blade.php
@@ -76,6 +76,8 @@
                                 size="sm"
                                 wire:key="accept-recurring-{{ $suggestion->id }}"
                                 wire:click="accept({{ $suggestion->id }})"
+                                wire:loading.attr="disabled"
+                                wire:target="accept({{ $suggestion->id }})"
                             >
                                 Accept
                             </flux:button>
@@ -84,6 +86,8 @@
                                 size="sm"
                                 wire:key="dismiss-recurring-{{ $suggestion->id }}"
                                 wire:click="dismiss({{ $suggestion->id }})"
+                                wire:loading.attr="disabled"
+                                wire:target="dismiss({{ $suggestion->id }})"
                             >
                                 Dismiss
                             </flux:button>

--- a/resources/views/livewire/recurring-transaction-review.blade.php
+++ b/resources/views/livewire/recurring-transaction-review.blade.php
@@ -1,0 +1,101 @@
+@php
+    use App\Casts\MoneyCast;
+    use App\Enums\RecurrenceFrequency;
+@endphp
+
+<flux:card>
+    <div class="space-y-5">
+        <div class="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+            <div>
+                <flux:heading size="lg">Recurring transactions</flux:heading>
+                <flux:text size="sm" class="mt-1 text-zinc-500">Find regular payments and turn them into planned transactions.</flux:text>
+            </div>
+
+            <div class="flex flex-col gap-3 sm:flex-row sm:items-end">
+                <flux:field class="min-w-56">
+                    <flux:label>Account</flux:label>
+                    <flux:select wire:model.live="accountId" size="sm">
+                        @if($accounts->isEmpty())
+                            <flux:select.option value="">No accounts</flux:select.option>
+                        @endif
+
+                        @foreach($accounts as $account)
+                            <flux:select.option value="{{ $account->id }}">{{ $account->name }}</flux:select.option>
+                        @endforeach
+                    </flux:select>
+                </flux:field>
+
+                <flux:button
+                    variant="primary"
+                    size="sm"
+                    wire:click="findRecurring"
+                    wire:loading.attr="disabled"
+                    wire:target="findRecurring"
+                    :disabled="$accounts->isEmpty()"
+                >
+                    <span wire:loading.remove wire:target="findRecurring">Find recurring</span>
+                    <span wire:loading wire:target="findRecurring">Finding...</span>
+                </flux:button>
+            </div>
+        </div>
+
+        @forelse($suggestions as $suggestion)
+            <div wire:key="recurring-suggestion-{{ $suggestion->id }}" class="rounded-lg border border-neutral-200 p-4">
+                <div class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+                    <div class="min-w-0 flex-1">
+                        <div class="flex flex-wrap items-center gap-2">
+                            <flux:heading size="sm">{{ $suggestion->payload['clean_description'] }}</flux:heading>
+                            <flux:badge size="sm" color="zinc">
+                                {{ RecurrenceFrequency::from($suggestion->payload['frequency'])->label() }}
+                            </flux:badge>
+                            <flux:badge size="sm" color="blue">
+                                {{ (int) round(((float) $suggestion->payload['confidence_score']) * 100) }}% confidence
+                            </flux:badge>
+                            <flux:badge size="sm" color="purple">
+                                {{ count($suggestion->payload['matched_transaction_ids']) }} matches
+                            </flux:badge>
+                        </div>
+
+                        <flux:text size="sm" class="mt-1 font-bold tabular-nums text-zinc-900">
+                            {{ MoneyCast::format(abs((int) $suggestion->payload['amount'])) }}
+                        </flux:text>
+                    </div>
+
+                    <div class="flex flex-col gap-3 sm:flex-row sm:items-center">
+                        <x-category-combobox
+                            wire:model="recurringCategories.{{ $suggestion->id }}"
+                            :categories="$categories"
+                            placeholder="No category"
+                            size="sm"
+                            class="w-full sm:w-48"
+                        />
+
+                        <div class="flex items-center gap-2">
+                            <flux:button
+                                variant="primary"
+                                size="sm"
+                                wire:key="accept-recurring-{{ $suggestion->id }}"
+                                wire:click="accept({{ $suggestion->id }})"
+                            >
+                                Accept
+                            </flux:button>
+                            <flux:button
+                                variant="ghost"
+                                size="sm"
+                                wire:key="dismiss-recurring-{{ $suggestion->id }}"
+                                wire:click="dismiss({{ $suggestion->id }})"
+                            >
+                                Dismiss
+                            </flux:button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        @empty
+            <div class="flex flex-col items-center justify-center rounded-lg border border-dashed border-neutral-200 py-10 text-center">
+                <flux:icon.arrow-path class="mb-3 size-10 text-zinc-400" />
+                <flux:heading size="sm">No recurring patterns found for this account — run a scan.</flux:heading>
+            </div>
+        @endforelse
+    </div>
+</flux:card>

--- a/resources/views/rules.blade.php
+++ b/resources/views/rules.blade.php
@@ -1,4 +1,5 @@
 <x-layouts::app :title="__('Rules')">
     <livewire:recurring-transaction-review />
+    <livewire:planned-transaction-manager />
     <livewire:user-rule-manager />
 </x-layouts::app>

--- a/resources/views/rules.blade.php
+++ b/resources/views/rules.blade.php
@@ -1,3 +1,4 @@
 <x-layouts::app :title="__('Rules')">
+    <livewire:recurring-transaction-review />
     <livewire:user-rule-manager />
 </x-layouts::app>

--- a/tests/Feature/Livewire/PlannedTransactionManagerTest.php
+++ b/tests/Feature/Livewire/PlannedTransactionManagerTest.php
@@ -186,7 +186,9 @@ test('pay cycle income plans cannot be saved through a forced edit', function ()
         ->set('amount', '12.34')
         ->set('frequency', RecurrenceFrequency::EveryWeek->value)
         ->set('direction', TransactionDirection::Debit->value)
-        ->call('save');
+        ->call('save')
+        ->assertSet('showEditModal', false)
+        ->assertSet('editingId', null);
 
     $fresh = $incomePlan->fresh();
 
@@ -205,6 +207,21 @@ test('rejects a sub-cent amount on save', function () {
         ->test(PlannedTransactionManager::class)
         ->call('openEdit', $plan->id)
         ->set('amount', '0.004')
+        ->call('save')
+        ->assertHasErrors(['amount']);
+
+    expect($plan->fresh()->amount)->toBe(2500);
+});
+
+test('rejects an amount with more than two decimal places', function () {
+    $plan = PlannedTransaction::factory()->for($this->user)->for($this->primaryAccount)->create([
+        'amount' => 2500,
+    ]);
+
+    Livewire::actingAs($this->user)
+        ->test(PlannedTransactionManager::class)
+        ->call('openEdit', $plan->id)
+        ->set('amount', '10.005')
         ->call('save')
         ->assertHasErrors(['amount']);
 

--- a/tests/Feature/Livewire/PlannedTransactionManagerTest.php
+++ b/tests/Feature/Livewire/PlannedTransactionManagerTest.php
@@ -1,0 +1,239 @@
+<?php
+
+/** @noinspection StaticClosureCanBeUsedInspection */
+
+declare(strict_types=1);
+
+use App\Enums\RecurrenceFrequency;
+use App\Enums\TransactionDirection;
+use App\Livewire\PlannedTransactionManager;
+use App\Models\Account;
+use App\Models\Category;
+use App\Models\PlannedTransaction;
+use App\Models\Transaction;
+use App\Models\User;
+use Livewire\Livewire;
+
+beforeEach(function () {
+    $this->user = User::factory()->create();
+    $this->primaryAccount = Account::factory()->for($this->user)->create(['name' => 'Primary Account']);
+    $this->secondaryAccount = Account::factory()->for($this->user)->create(['name' => 'Secondary Account']);
+    $this->user->update(['primary_account_id' => $this->primaryAccount->id]);
+    $this->category = Category::factory()->create();
+});
+
+test('mount defaults account id to the primary account', function () {
+    Livewire::actingAs($this->user)
+        ->test(PlannedTransactionManager::class)
+        ->assertSet('accountId', $this->primaryAccount->id);
+});
+
+test('lists the selected accounts planned transactions and excludes another accounts plans', function () {
+    PlannedTransaction::factory()->for($this->user)->for($this->primaryAccount)->create([
+        'description' => 'Primary Netflix',
+    ]);
+
+    PlannedTransaction::factory()->for($this->user)->for($this->secondaryAccount)->create([
+        'description' => 'Secondary Spotify',
+    ]);
+
+    Livewire::actingAs($this->user)
+        ->test(PlannedTransactionManager::class)
+        ->set('accountId', $this->secondaryAccount->id)
+        ->assertSee('Secondary Spotify')
+        ->assertDontSee('Primary Netflix');
+});
+
+test('matched count equals the number of linked transactions', function () {
+    $plan = PlannedTransaction::factory()->for($this->user)->for($this->primaryAccount)->create([
+        'description' => 'Gym Membership',
+    ]);
+
+    Transaction::factory()->count(2)
+        ->for($this->user)
+        ->for($this->primaryAccount)
+        ->create(['planned_transaction_id' => $plan->id]);
+
+    Transaction::factory()->for($this->user)->for($this->primaryAccount)->create();
+
+    Livewire::actingAs($this->user)
+        ->test(PlannedTransactionManager::class)
+        ->assertSee('Gym Membership')
+        ->assertSee('2 matches');
+});
+
+test('save updates amount frequency category direction and until date on the plan', function () {
+    $newCategory = Category::factory()->create();
+
+    $plan = PlannedTransaction::factory()->for($this->user)->for($this->primaryAccount)->create([
+        'amount' => 1099,
+        'frequency' => RecurrenceFrequency::EveryMonth,
+        'category_id' => $this->category->id,
+        'direction' => TransactionDirection::Debit,
+        'until_date' => null,
+        'is_active' => true,
+    ]);
+
+    Livewire::actingAs($this->user)
+        ->test(PlannedTransactionManager::class)
+        ->call('openEdit', $plan->id)
+        ->assertSet('editingId', $plan->id)
+        ->set('amount', '25.50')
+        ->set('frequency', RecurrenceFrequency::Every2Weeks->value)
+        ->set('categoryId', (string) $newCategory->id)
+        ->set('direction', TransactionDirection::Credit->value)
+        ->set('untilDate', '2026-09-30')
+        ->set('isActive', false)
+        ->call('save');
+
+    $freshPlan = $plan->fresh();
+
+    expect($freshPlan)->not->toBeNull()
+        ->and($freshPlan->amount)->toBe(2550)
+        ->and($freshPlan->frequency)->toBe(RecurrenceFrequency::Every2Weeks)
+        ->and($freshPlan->category_id)->toBe($newCategory->id)
+        ->and($freshPlan->direction)->toBe(TransactionDirection::Credit)
+        ->and($freshPlan->until_date?->toDateString())->toBe('2026-09-30')
+        ->and($freshPlan->is_active)->toBeFalse();
+});
+
+test('toggleActive flips is_active', function () {
+    $plan = PlannedTransaction::factory()->for($this->user)->for($this->primaryAccount)->create([
+        'is_active' => true,
+    ]);
+
+    Livewire::actingAs($this->user)
+        ->test(PlannedTransactionManager::class)
+        ->call('toggleActive', $plan->id);
+
+    expect($plan->fresh()->is_active)->toBeFalse();
+});
+
+test('delete removes the plan', function () {
+    $plan = PlannedTransaction::factory()->for($this->user)->for($this->primaryAccount)->create([
+        'description' => 'Delete Me',
+    ]);
+
+    Livewire::actingAs($this->user)
+        ->test(PlannedTransactionManager::class)
+        ->call('confirmDelete', $plan->id)
+        ->call('delete');
+
+    expect(PlannedTransaction::query()->find($plan->id))->toBeNull();
+});
+
+test('pay cycle income plans cannot be opened for edit', function () {
+    $incomePlan = PlannedTransaction::factory()->for($this->user)->for($this->primaryAccount)->create([
+        'description' => 'Salary Income',
+        'amount' => 320000,
+        'is_pay_cycle_income' => true,
+        'direction' => TransactionDirection::Credit,
+    ]);
+
+    Livewire::actingAs($this->user)
+        ->test(PlannedTransactionManager::class)
+        ->call('openEdit', $incomePlan->id)
+        ->assertSet('showEditModal', false)
+        ->assertSet('editingId', null)
+        ->assertSet('amount', '')
+        ->assertSet('direction', '')
+        ->assertSet('frequency', '');
+
+    $freshPlan = $incomePlan->fresh();
+
+    expect($freshPlan)->not->toBeNull()
+        ->and($freshPlan->description)->toBe('Salary Income')
+        ->and($freshPlan->amount)->toBe(320000)
+        ->and($freshPlan->is_pay_cycle_income)->toBeTrue();
+});
+
+test('pay cycle income plans cannot be deleted', function () {
+    $incomePlan = PlannedTransaction::factory()->for($this->user)->for($this->primaryAccount)->create([
+        'description' => 'Protected Income',
+        'amount' => 410000,
+        'is_pay_cycle_income' => true,
+        'direction' => TransactionDirection::Credit,
+    ]);
+
+    Livewire::actingAs($this->user)
+        ->test(PlannedTransactionManager::class)
+        ->call('confirmDelete', $incomePlan->id)
+        ->assertSet('showDeleteModal', false)
+        ->assertSet('deletingId', null)
+        ->set('deletingId', $incomePlan->id)
+        ->call('delete');
+
+    $freshPlan = $incomePlan->fresh();
+
+    expect($freshPlan)->not->toBeNull()
+        ->and($freshPlan->description)->toBe('Protected Income')
+        ->and($freshPlan->amount)->toBe(410000)
+        ->and($freshPlan->is_pay_cycle_income)->toBeTrue();
+});
+
+test('pay cycle income plans cannot be saved through a forced edit', function () {
+    $incomePlan = PlannedTransaction::factory()->for($this->user)->for($this->primaryAccount)->create([
+        'description' => 'Forced Income',
+        'amount' => 500000,
+        'frequency' => RecurrenceFrequency::EveryMonth,
+        'direction' => TransactionDirection::Credit,
+        'is_pay_cycle_income' => true,
+    ]);
+
+    Livewire::actingAs($this->user)
+        ->test(PlannedTransactionManager::class)
+        ->set('editingId', $incomePlan->id)
+        ->set('amount', '12.34')
+        ->set('frequency', RecurrenceFrequency::EveryWeek->value)
+        ->set('direction', TransactionDirection::Debit->value)
+        ->call('save');
+
+    $fresh = $incomePlan->fresh();
+
+    expect($fresh->amount)->toBe(500000)
+        ->and($fresh->frequency)->toBe(RecurrenceFrequency::EveryMonth)
+        ->and($fresh->direction)->toBe(TransactionDirection::Credit)
+        ->and($fresh->is_pay_cycle_income)->toBeTrue();
+});
+
+test('rejects a sub-cent amount on save', function () {
+    $plan = PlannedTransaction::factory()->for($this->user)->for($this->primaryAccount)->create([
+        'amount' => 2500,
+    ]);
+
+    Livewire::actingAs($this->user)
+        ->test(PlannedTransactionManager::class)
+        ->call('openEdit', $plan->id)
+        ->set('amount', '0.004')
+        ->call('save')
+        ->assertHasErrors(['amount']);
+
+    expect($plan->fresh()->amount)->toBe(2500);
+});
+
+test('renders formatted money frequency and the income badge', function () {
+    PlannedTransaction::factory()->for($this->user)->for($this->primaryAccount)->create([
+        'description' => 'Internet Bill',
+        'amount' => 8999,
+        'frequency' => RecurrenceFrequency::EveryMonth,
+        'is_pay_cycle_income' => false,
+    ]);
+    PlannedTransaction::factory()->for($this->user)->for($this->primaryAccount)->create([
+        'description' => 'Salary',
+        'is_pay_cycle_income' => true,
+    ]);
+
+    Livewire::actingAs($this->user)
+        ->test(PlannedTransactionManager::class)
+        ->assertSee('Internet Bill')
+        ->assertSee('$89.99')
+        ->assertSee('Every month')
+        ->assertSee('Income')
+        ->assertSee('Managed from pay cycle');
+});
+
+test('shows an empty state when the account has no plans', function () {
+    Livewire::actingAs($this->user)
+        ->test(PlannedTransactionManager::class)
+        ->assertSee('No planned transactions for this account yet.');
+});

--- a/tests/Feature/Livewire/RecurringTransactionReviewTest.php
+++ b/tests/Feature/Livewire/RecurringTransactionReviewTest.php
@@ -1,0 +1,240 @@
+<?php
+
+/** @noinspection StaticClosureCanBeUsedInspection */
+
+declare(strict_types=1);
+
+use App\Enums\RecurrenceFrequency;
+use App\Enums\SuggestionStatus;
+use App\Enums\SuggestionType;
+use App\Enums\TransactionDirection;
+use App\Livewire\RecurringTransactionReview;
+use App\Models\Account;
+use App\Models\AnalysisSuggestion;
+use App\Models\PipelineRun;
+use App\Models\PlannedTransaction;
+use App\Models\Transaction;
+use App\Models\User;
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Collection;
+use Livewire\Livewire;
+
+function createRecurringReviewTransaction(User $user, Account $account, array $overrides = []): Transaction
+{
+    return Transaction::factory()->fromBasiq()->create(array_merge([
+        'user_id' => $user->id,
+        'account_id' => $account->id,
+    ], $overrides));
+}
+
+/** @return Collection<int, Transaction> */
+function createRecurringReviewMonthlyGroup(
+    User $user,
+    Account $account,
+    string $merchantName,
+    int $amount,
+    int $count = 3,
+    ?string $startDate = null,
+): Collection {
+    $start = CarbonImmutable::parse($startDate ?? '2026-01-15');
+    $transactions = collect();
+
+    for ($i = 0; $i < $count; $i++) {
+        $transactions->push(createRecurringReviewTransaction($user, $account, [
+            'merchant_name' => $merchantName,
+            'amount' => $amount,
+            'post_date' => $start->addMonthsNoOverflow($i),
+            'direction' => TransactionDirection::Debit,
+        ]));
+    }
+
+    return $transactions;
+}
+
+test('mount sets account id to the users primary account id', function () {
+    $user = User::factory()->create();
+    Account::factory()->for($user)->create();
+    $primaryAccount = Account::factory()->for($user)->create();
+    $user->update(['primary_account_id' => $primaryAccount->id]);
+
+    Livewire::actingAs($user)
+        ->test(RecurringTransactionReview::class)
+        ->assertSet('accountId', $primaryAccount->id);
+});
+
+test('find recurring creates pending suggestions for the selected account and renders them', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $user->update(['primary_account_id' => $account->id]);
+
+    createRecurringReviewMonthlyGroup($user, $account, 'Netflix', 1699, 3);
+
+    Livewire::actingAs($user)
+        ->test(RecurringTransactionReview::class)
+        ->call('findRecurring')
+        ->assertSee('Netflix')
+        ->assertSee('$16.99')
+        ->assertSee('Every month')
+        ->assertSee('3 matches');
+
+    $suggestion = AnalysisSuggestion::query()
+        ->where('user_id', $user->id)
+        ->ofType(SuggestionType::RecurringTransaction)
+        ->pending()
+        ->first();
+
+    expect($suggestion)->not->toBeNull()
+        ->and($suggestion->payload['account_id'])->toBe($account->id)
+        ->and($suggestion->payload['clean_description'])->toBe('Netflix')
+        ->and($suggestion->payload['amount'])->toBe(1699)
+        ->and($suggestion->pipelineRun)->toBeInstanceOf(PipelineRun::class)
+        ->and($suggestion->pipelineRun->trigger->value)->toBe('manual')
+        ->and($suggestion->pipelineRun->status->value)->toBe('completed')
+        ->and($suggestion->pipelineRun->completed_at)->not->toBeNull();
+});
+
+test('account scoping hides recurring series from another account while reviewing the primary account', function () {
+    $user = User::factory()->create();
+    $primaryAccount = Account::factory()->for($user)->create();
+    $secondAccount = Account::factory()->for($user)->create();
+    $user->update(['primary_account_id' => $primaryAccount->id]);
+
+    createRecurringReviewMonthlyGroup($user, $primaryAccount, 'Netflix', 1699, 3);
+    createRecurringReviewMonthlyGroup($user, $secondAccount, 'Spotify', 1299, 3);
+
+    Livewire::actingAs($user)
+        ->test(RecurringTransactionReview::class)
+        ->call('findRecurring')
+        ->assertSee('Netflix')
+        ->assertDontSee('Spotify');
+
+    $suggestions = AnalysisSuggestion::query()
+        ->where('user_id', $user->id)
+        ->ofType(SuggestionType::RecurringTransaction)
+        ->pending()
+        ->get();
+
+    expect($suggestions)->toHaveCount(1)
+        ->and($suggestions->first()->payload['account_id'])->toBe($primaryAccount->id);
+});
+
+test('accept creates an active planned transaction and links matched transactions', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $user->update(['primary_account_id' => $account->id]);
+
+    $transactions = createRecurringReviewMonthlyGroup($user, $account, 'Netflix', 1699, 3);
+
+    Livewire::actingAs($user)
+        ->test(RecurringTransactionReview::class)
+        ->call('findRecurring');
+
+    $suggestion = AnalysisSuggestion::query()
+        ->where('user_id', $user->id)
+        ->ofType(SuggestionType::RecurringTransaction)
+        ->pending()
+        ->firstOrFail();
+
+    Livewire::actingAs($user)
+        ->test(RecurringTransactionReview::class)
+        ->call('accept', $suggestion->id);
+
+    $planned = PlannedTransaction::query()
+        ->where('user_id', $user->id)
+        ->first();
+
+    expect($planned)->not->toBeNull()
+        ->and($planned->is_active)->toBeTrue()
+        ->and($planned->amount)->toBe(1699)
+        ->and($planned->frequency)->toBe(RecurrenceFrequency::EveryMonth)
+        ->and($planned->account_id)->toBe($account->id)
+        ->and($planned->direction)->toBe(TransactionDirection::Debit)
+        ->and($suggestion->fresh()->status)->toBe(SuggestionStatus::Accepted);
+
+    $transactions->each(fn (Transaction $transaction) => expect($transaction->fresh()->planned_transaction_id)->toBe($planned->id));
+});
+
+test('dismiss rejects a pending recurring suggestion', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $user->update(['primary_account_id' => $account->id]);
+
+    createRecurringReviewMonthlyGroup($user, $account, 'Netflix', 1699, 3);
+
+    Livewire::actingAs($user)
+        ->test(RecurringTransactionReview::class)
+        ->call('findRecurring');
+
+    $suggestion = AnalysisSuggestion::query()
+        ->where('user_id', $user->id)
+        ->ofType(SuggestionType::RecurringTransaction)
+        ->pending()
+        ->firstOrFail();
+
+    Livewire::actingAs($user)
+        ->test(RecurringTransactionReview::class)
+        ->call('dismiss', $suggestion->id);
+
+    expect($suggestion->fresh()->status)->toBe(SuggestionStatus::Rejected)
+        ->and($suggestion->fresh()->resolved_at)->not->toBeNull();
+});
+
+test('accepted recurring patterns are not suggested again on a later scan', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $user->update(['primary_account_id' => $account->id]);
+
+    createRecurringReviewMonthlyGroup($user, $account, 'Netflix', 1699, 3);
+
+    Livewire::actingAs($user)
+        ->test(RecurringTransactionReview::class)
+        ->call('findRecurring');
+
+    $suggestion = AnalysisSuggestion::query()
+        ->where('user_id', $user->id)
+        ->ofType(SuggestionType::RecurringTransaction)
+        ->pending()
+        ->firstOrFail();
+
+    Livewire::actingAs($user)
+        ->test(RecurringTransactionReview::class)
+        ->call('accept', $suggestion->id)
+        ->call('findRecurring');
+
+    $suggestions = AnalysisSuggestion::query()
+        ->where('user_id', $user->id)
+        ->ofType(SuggestionType::RecurringTransaction)
+        ->get();
+
+    expect($suggestions)->toHaveCount(1)
+        ->and($suggestions->first()->status)->toBe(SuggestionStatus::Accepted)
+        ->and(AnalysisSuggestion::query()
+            ->where('user_id', $user->id)
+            ->ofType(SuggestionType::RecurringTransaction)
+            ->pending()
+            ->count())->toBe(0);
+});
+
+test('rescanning without resolving supersedes the prior pending suggestion instead of duplicating it', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $user->update(['primary_account_id' => $account->id]);
+
+    createRecurringReviewMonthlyGroup($user, $account, 'Netflix', 1699, 3);
+
+    Livewire::actingAs($user)
+        ->test(RecurringTransactionReview::class)
+        ->call('findRecurring')
+        ->call('findRecurring');
+
+    expect(AnalysisSuggestion::query()
+        ->where('user_id', $user->id)
+        ->ofType(SuggestionType::RecurringTransaction)
+        ->pending()
+        ->count())->toBe(1)
+        ->and(AnalysisSuggestion::query()
+            ->where('user_id', $user->id)
+            ->ofType(SuggestionType::RecurringTransaction)
+            ->where('status', SuggestionStatus::Superseded)
+            ->count())->toBe(1);
+});

--- a/tests/Feature/Models/PlannedTransactionTest.php
+++ b/tests/Feature/Models/PlannedTransactionTest.php
@@ -521,3 +521,26 @@ test('excludingTransfers includes plans with no transfer_to_account_id and non-T
 
     expect(PlannedTransaction::excludingTransfers()->count())->toBe(1);
 });
+
+test('nextOccurrenceOnOrAfter resolves for a long-running daily plan with an old start date', function () {
+    $plan = PlannedTransaction::factory()->create([
+        'frequency' => RecurrenceFrequency::Everyday,
+        'start_date' => CarbonImmutable::parse('2018-01-01'),
+        'until_date' => null,
+        'is_active' => true,
+    ]);
+
+    $next = $plan->nextOccurrenceOnOrAfter(CarbonImmutable::parse('2026-06-27'));
+
+    expect($next)->not->toBeNull()
+        ->and($next->toDateString())->toBe('2026-06-27');
+});
+
+test('nextOccurrenceOnOrAfter returns null for an inactive plan', function () {
+    $plan = PlannedTransaction::factory()->inactive()->create([
+        'frequency' => RecurrenceFrequency::EveryMonth,
+        'start_date' => CarbonImmutable::parse('2026-01-01'),
+    ]);
+
+    expect($plan->nextOccurrenceOnOrAfter(CarbonImmutable::parse('2026-06-27')))->toBeNull();
+});


### PR DESCRIPTION
Part of #300 (sub-task #301). Stacked on #304 (base = `feature/303-extract-account-scoped-recurringtransactiondetector`).

Surfaces recurring detection on `/rules`: on-demand, per-account scan → review → confirm to planned transactions. **Reuses #303's detector/writer; no new matching code; no migration.**

## What
- `app/Livewire/RecurringTransactionReview.php` — account selector (default primary); `findRecurring()` (manual `PipelineRun` → `RecurringTransactionDetector::detect(user, account)` → `RecurringSuggestionWriter::writeForRun`); review list with inline category override; `accept()` → `SuggestionApplier::applyRecurringTransaction` → active `PlannedTransaction` + linked transactions; `dismiss()` → `Rejected`.
- `resources/views/livewire/recurring-transaction-review.blade.php` — Flux card mirroring the analysis-suggestions UI; scan loading state; empty state.
- `resources/views/rules.blade.php` — mounts the component above the rule manager.

## Idempotency (review-driven)
A re-scan supersedes the account's unresolved **pending** recurring suggestions (mirrors `TransactionAnalysisPipeline`) so repeated scans don't duplicate a pending pattern or allow double-accept into duplicate plans. Accepted/active patterns are skipped by the writer; matched transactions are excluded by the detector.

## Future-import matching
None added — the existing `ReconciliationPolicy` (ingress + backstop) matches future imports to the created plans.

## Verification
- Pint clean; PHPStan (app/) green.
- Pest: **66 passed / 221 assertions** — 7 new Livewire tests (mount default = primary; scan persists + renders; account scoping; accept → active plan + linked txns + Accepted; dismiss → Rejected; re-scan supersede; accepted-not-re-offered), plus the #303 detector/writer/stage suites unchanged & green.
- No schema change.
