### PR TITLE
fix: [310] use available credit for accounts with a credit limit

### DIFF
--- a/app/Models/Account.php
+++ b/app/Models/Account.php
@@ -130,8 +130,8 @@ final class Account extends Model
 
     public function availableBalance(): int
     {
-        if ($this->type === AccountClass::CreditCard) {
-            return ($this->credit_limit ?? 0) + $this->balance;
+        if ($this->credit_limit !== null) {
+            return $this->credit_limit + $this->balance;
         }
 
         return $this->balance;
@@ -139,8 +139,12 @@ final class Account extends Model
 
     public function amountOwed(): int
     {
-        if ($this->type === AccountClass::CreditCard || $this->type === AccountClass::Loan) {
-            return abs($this->balance);
+        $isDebtAccount = $this->credit_limit !== null
+            || $this->type === AccountClass::CreditCard
+            || $this->type === AccountClass::Loan;
+
+        if ($isDebtAccount) {
+            return abs(min(0, $this->balance));
         }
 
         return 0;

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -176,7 +176,10 @@ final class User extends Authenticatable
     {
         return $this->accounts()
             ->active()
-            ->whereIn('type', [AccountClass::CreditCard, AccountClass::Loan])
+            ->where(static function ($query): void {
+                $query->whereIn('type', [AccountClass::CreditCard, AccountClass::Loan])
+                    ->orWhereNotNull('credit_limit');
+            })
             ->get()
             ->sum(fn (Account $a) => $a->amountOwed());
     }

--- a/app/Services/Projection/MonthlyProjectionService.php
+++ b/app/Services/Projection/MonthlyProjectionService.php
@@ -57,7 +57,7 @@ final readonly class MonthlyProjectionService
 
         ksort($dailyBuckets);
 
-        $startingBalanceCents = (int) $primaryAccount->balance;
+        $startingBalanceCents = $primaryAccount->availableBalance();
         $runningBalance = $startingBalanceCents;
         $points = [
             new BalancePoint(

--- a/tests/Feature/Livewire/DashboardTest.php
+++ b/tests/Feature/Livewire/DashboardTest.php
@@ -4,6 +4,7 @@
 
 declare(strict_types=1);
 
+use App\Enums\AccountClass;
 use App\Enums\RecurrenceFrequency;
 use App\Enums\TransactionDirection;
 use App\Livewire\Dashboard;
@@ -330,6 +331,19 @@ test('totals isolate current user from other users accounts', function () {
         ->and($numbers['owed'])->toBe(0);
 });
 
+test('available reflects credit limit for a limit-bearing non-credit-card account', function () {
+    $user = User::factory()->withPayCycle()->create();
+    Account::factory()->for($user)->create(['type' => AccountClass::Transaction, 'balance' => 219340]);
+    Account::factory()->for($user)->create(['type' => AccountClass::Transaction, 'balance' => -340642, 'credit_limit' => 500000]);
+
+    $numbers = Livewire::actingAs($user)
+        ->test(Dashboard::class)
+        ->instance()
+        ->numbers();
+
+    expect($numbers['available'])->toBe(378698)
+        ->and($numbers['owed'])->toBe(340642);
+});
 // ── Spend last 7 days ──────────────────────────────────────────────
 
 test('spend last 7 days sums debit transactions within the window', function () {

--- a/tests/Feature/Models/AccountTest.php
+++ b/tests/Feature/Models/AccountTest.php
@@ -201,3 +201,21 @@ test('amountOwed returns zero for savings account', function () {
 
     expect($account->amountOwed())->toBe(0);
 });
+
+test('availableBalance uses credit limit for any account with a credit limit', function () {
+    $account = Account::factory()->create(['type' => AccountClass::Transaction, 'balance' => -340642, 'credit_limit' => 500000]);
+
+    expect($account->availableBalance())->toBe(159358);
+});
+
+test('amountOwed counts debt for any account with a credit limit', function () {
+    $account = Account::factory()->create(['type' => AccountClass::Transaction, 'balance' => -340642, 'credit_limit' => 500000]);
+
+    expect($account->amountOwed())->toBe(340642);
+});
+
+test('amountOwed is zero when a credit-limit account is in credit', function () {
+    $account = Account::factory()->create(['type' => AccountClass::Transaction, 'balance' => 20000, 'credit_limit' => 500000]);
+
+    expect($account->amountOwed())->toBe(0);
+});

--- a/tests/Feature/Models/UserTest.php
+++ b/tests/Feature/Models/UserTest.php
@@ -4,6 +4,7 @@
 
 declare(strict_types=1);
 
+use App\Enums\AccountClass;
 use App\Enums\PayFrequency;
 use App\Enums\RecurrenceFrequency;
 use App\Enums\TransactionDirection;
@@ -143,6 +144,22 @@ test('totalAvailable returns zero when no spendable accounts exist', function ()
     Account::factory()->mortgage()->for($user)->create(['balance' => -30000000]);
 
     expect($user->totalAvailable())->toBe(0);
+});
+
+test('totalAvailable uses available credit for accounts with a credit limit regardless of type', function () {
+    $user = User::factory()->create();
+    Account::factory()->for($user)->create(['type' => AccountClass::Transaction, 'balance' => 219340]);
+    Account::factory()->for($user)->create(['type' => AccountClass::Transaction, 'balance' => -340642, 'credit_limit' => 500000]);
+
+    expect($user->totalAvailable())->toBe(378698);
+});
+
+test('totalOwed includes accounts that have a credit limit even when not typed credit card', function () {
+    $user = User::factory()->create();
+    Account::factory()->for($user)->create(['type' => AccountClass::Transaction, 'balance' => 219340]);
+    Account::factory()->for($user)->create(['type' => AccountClass::Transaction, 'balance' => -340642, 'credit_limit' => 500000]);
+
+    expect($user->totalOwed())->toBe(340642);
 });
 
 test('daysUntilNextPay returns correct days when pay cycle configured', function () {

--- a/tests/Feature/Services/Projection/MonthlyProjectionServiceTest.php
+++ b/tests/Feature/Services/Projection/MonthlyProjectionServiceTest.php
@@ -4,6 +4,7 @@
 
 declare(strict_types=1);
 
+use App\Enums\AccountClass;
 use App\Enums\PayFrequency;
 use App\Enums\RecurrenceFrequency;
 use App\Enums\TransactionDirection;
@@ -283,6 +284,7 @@ test('a configured pay cycle feeds the projection so the balance steps up on eac
     $account = Account::factory()->for($user)->create(['balance' => 100000]);
     $user->update(['primary_account_id' => $account->id]);
 
+    /** @noinspection PhpUnhandledExceptionInspection */
     app(PayCycleConfigurator::class)->apply(
         $user->fresh(),
         300000,
@@ -300,4 +302,15 @@ test('a configured pay cycle feeds the projection so the balance steps up on eac
         ->and($firstPayday->balanceCents)->toBe(400000)
         ->and($firstPayday->balanceCents)->toBeGreaterThan($projection->points[0]->balanceCents)
         ->and($projection->firstNegativeDate)->toBeNull();
+});
+
+test('starting balance uses available credit when primary account has a credit limit', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create(['type' => AccountClass::Transaction, 'balance' => -340642, 'credit_limit' => 500000]);
+    $user->update(['primary_account_id' => $account->id]);
+
+    $projection = app(MonthlyProjectionService::class)->forUser($user->fresh());
+
+    expect($projection->startingBalanceCents)->toBe(159358)
+        ->and($projection->points[0]->balanceCents)->toBe(159358);
 });


### PR DESCRIPTION
## Problem

The dashboard "Available" and "Owed" figures were wrong for credit-card accounts (reported in #310). For a user whose credit card **"BB - CC"** ($5,000 limit, −$3,406.42 balance) should surface its *available credit*, the dashboard instead showed **Available −$1,213.02** and **Owed $0.00**.

## Root cause

`Account::availableBalance()` and `amountOwed()` branched on `type === AccountClass::CreditCard`. That account was entered via the manual UI, where the **"credit account" checkbox (which sets `credit_limit`) is decoupled from the Account-Type dropdown** — so it carried a $5,000 limit but `type = transaction`. Both methods fell through: Available used the raw negative balance, Owed returned 0.

`credit_limit` presence — not `type` — is the intended "credit account" signal (the checkbox reads *"credit account, e.g. credit card, line of credit"*; Basiq-synced cards were unaffected).

## Changes

- `Account::availableBalance()` → `credit_limit + balance` when a limit is set, else `balance`.
- `Account::amountOwed()` → counts debt when a limit is set **or** type is CreditCard/Loan; returns `abs(min(0, balance))` (accounts in credit → 0).
- `User::totalOwed()` → query widened to include accounts with a non-null `credit_limit`.
- `MonthlyProjectionService` → projection starts from `availableBalance()`, so the 12-month line reflects available funds when the primary account is a credit account.

## Verification

- New regression tests across Account, User, Dashboard, and MonthlyProjectionService (TDD, red → green).
- `107 passed (183 assertions)` on the affected suites; no existing tests broken.
- Pint + PHPStan clean (also enforced by GrumPHP).
- Live data for the reporting account now resolves to **Available +$3,786.98**, **Owed $3,406.42**, buffer *AFFORD $2,470.61* (was −$1,213.02 / $0.00 / *SHORT $2,529.39*).

Refs #310
