### PR TITLE
feat(#313): show last-imported transaction date on csv import page

### DIFF
--- a/app/Livewire/ImportBank.php
+++ b/app/Livewire/ImportBank.php
@@ -9,12 +9,15 @@ use App\Enums\ImportSource;
 use App\Jobs\ImportCsvTransactionsJob;
 use App\Models\Account;
 use App\Models\BankImport;
+use App\Models\Transaction;
 use App\Services\CsvImport\CsvColumnMapper;
 use App\Services\CsvImport\CsvParserService;
+use Carbon\CarbonImmutable;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\View\View;
 use League\Csv\Exception;
 use League\Csv\SyntaxError;
+use Livewire\Attributes\Computed;
 use Livewire\Attributes\Validate;
 use Livewire\Component;
 use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
@@ -205,6 +208,16 @@ final class ImportBank extends Component
     public function updatedCurrentBalance(): void
     {
         $this->balanceTouched = true;
+    }
+
+    #[Computed]
+    public function lastImportedDate(): ?CarbonImmutable
+    {
+        if ($this->accountId === null || $this->accountChoice !== 'existing') {
+            return null;
+        }
+
+        return Transaction::lastImportedPostDate((int) auth()->id(), $this->accountId);
     }
 
     public function render(CsvParserService $parser): View

--- a/app/Models/Transaction.php
+++ b/app/Models/Transaction.php
@@ -104,6 +104,22 @@ final class Transaction extends Model
         }
     }
 
+    /**
+     * Latest post_date among bank-fed (csv/basiq) transactions for a user,
+     * optionally scoped to one account. Null when no imported transactions exist.
+     * SoftDeletes are excluded automatically by the default builder.
+     */
+    public static function lastImportedPostDate(int $userId, ?int $accountId = null): ?CarbonImmutable
+    {
+        $max = self::query()
+            ->where('user_id', $userId)
+            ->whereIn('source', TransactionSource::forAnalysis())
+            ->when($accountId !== null, fn ($q) => $q->where('account_id', $accountId))
+            ->max('post_date');
+
+        return $max === null ? null : CarbonImmutable::parse((string) $max);
+    }
+
     /** @return BelongsTo<User, $this> */
     public function user(): BelongsTo
     {

--- a/resources/views/livewire/import-bank.blade.php
+++ b/resources/views/livewire/import-bank.blade.php
@@ -48,7 +48,7 @@
                     </flux:radio.group>
 
                     @if($accountChoice === 'existing')
-                        <flux:select wire:model="accountId" data-testid="import-bank-account-select">
+                        <flux:select wire:model.live="accountId" data-testid="import-bank-account-select">
                             <option value="">— pick an account —</option>
                             @foreach($accounts as $account)
                                 <option
@@ -62,6 +62,11 @@
                                 </option>
                             @endforeach
                         </flux:select>
+                    @if($this->lastImportedDate !== null)
+                        <flux:text size="sm" class="mt-2" data-testid="import-bank-last-imported">
+                            Last imported transaction: {{ $this->lastImportedDate->format('d/m/Y') }} — export your next statement from this date.
+                        </flux:text>
+                    @endif
                     @else
                         <flux:input
                             wire:model="newAccountName"

--- a/tests/Feature/Livewire/ImportBankTest.php
+++ b/tests/Feature/Livewire/ImportBankTest.php
@@ -12,6 +12,7 @@ use App\Jobs\ImportCsvTransactionsJob;
 use App\Livewire\ImportBank;
 use App\Models\Account;
 use App\Models\BankImport;
+use App\Models\Transaction;
 use App\Models\User;
 use App\Services\CsvImport\CsvColumnMapper;
 use App\Services\CsvImport\CsvParserService;
@@ -369,4 +370,30 @@ test('a manually entered balance is preserved when the mapping changes', functio
         ->set('mapping.'.CsvColumnMapper::FIELD_BALANCE, 'RunningTotal');
 
     expect($component->get('currentBalance'))->toBe('99.99');
+});
+
+// ── lastImportedDate computed property (#313) ─────────────────────────────────
+
+test('selecting an existing account with a prior csv transaction shows last-imported hint', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->csvImport()->create();
+    Transaction::factory()->for($user)->for($account)->fromCsv()->create(['post_date' => '2026-07-09']);
+
+    Livewire::actingAs($user)
+        ->test(ImportBank::class)
+        ->set('accountChoice', 'existing')
+        ->set('accountId', $account->id)
+        ->assertSeeHtml('data-testid="import-bank-last-imported"')
+        ->assertSeeHtml('09/07/2026');
+});
+
+test('selecting an existing account with no imported transactions shows no last-imported hint', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->csvImport()->create();
+
+    Livewire::actingAs($user)
+        ->test(ImportBank::class)
+        ->set('accountChoice', 'existing')
+        ->set('accountId', $account->id)
+        ->assertDontSeeHtml('data-testid="import-bank-last-imported"');
 });

--- a/tests/Feature/Models/TransactionTest.php
+++ b/tests/Feature/Models/TransactionTest.php
@@ -11,6 +11,7 @@ use App\Models\Account;
 use App\Models\Category;
 use App\Models\Transaction;
 use App\Models\User;
+use Carbon\CarbonImmutable;
 use Illuminate\Database\QueryException;
 use Illuminate\Support\Facades\DB;
 
@@ -154,7 +155,7 @@ test('post_date is cast to date', function () {
     $transaction = Transaction::factory()->create(['post_date' => '2026-03-14']);
 
     expect($transaction->post_date)
-        ->toBeInstanceOf(Carbon\CarbonImmutable::class)
+        ->toBeInstanceOf(CarbonImmutable::class)
         ->and($transaction->post_date->toDateString())->toBe('2026-03-14');
 });
 
@@ -484,4 +485,84 @@ test('backfill sets source to basiq for transactions with basiq_id', function ()
 
     expect($basiqTransaction->fresh()->source)->toBe(TransactionSource::Basiq)
         ->and($manualTransaction->fresh()->source)->toBe(TransactionSource::Manual);
+});
+
+// ── Transaction::lastImportedPostDate (#313) ──────────────────────────────────
+
+test('lastImportedPostDate returns the maximum post_date across csv and basiq transactions', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+
+    Transaction::factory()->for($user)->for($account)->fromCsv()->create(['post_date' => '2026-06-01']);
+    Transaction::factory()->for($user)->for($account)->fromBasiq()->create(['post_date' => '2026-07-09']);
+    Transaction::factory()->for($user)->for($account)->fromCsv()->create(['post_date' => '2026-05-15']);
+
+    $result = Transaction::lastImportedPostDate($user->id);
+
+    expect($result)->toBeInstanceOf(CarbonImmutable::class)
+        ->and($result->format('Y-m-d'))->toBe('2026-07-09');
+});
+
+test('lastImportedPostDate ignores manual and planned transactions', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+
+    Transaction::factory()->for($user)->for($account)->create([
+        'source' => TransactionSource::Manual,
+        'post_date' => '2026-07-09',
+    ]);
+    Transaction::factory()->for($user)->for($account)->create([
+        'source' => TransactionSource::Planned,
+        'post_date' => '2026-07-10',
+    ]);
+
+    $result = Transaction::lastImportedPostDate($user->id);
+
+    expect($result)->toBeNull();
+});
+
+test('lastImportedPostDate ignores transactions belonging to other users', function () {
+    $user = User::factory()->create();
+    $otherUser = User::factory()->create();
+
+    Transaction::factory()->for($otherUser)->fromCsv()->create(['post_date' => '2026-07-09']);
+
+    $result = Transaction::lastImportedPostDate($user->id);
+
+    expect($result)->toBeNull();
+});
+
+test('lastImportedPostDate scopes to account when accountId is provided', function () {
+    $user = User::factory()->create();
+    $accountA = Account::factory()->for($user)->create();
+    $accountB = Account::factory()->for($user)->create();
+
+    Transaction::factory()->for($user)->for($accountA)->fromCsv()->create(['post_date' => '2026-07-09']);
+    Transaction::factory()->for($user)->for($accountB)->fromCsv()->create(['post_date' => '2026-06-01']);
+
+    $result = Transaction::lastImportedPostDate($user->id, $accountB->id);
+
+    expect($result)->toBeInstanceOf(CarbonImmutable::class)
+        ->and($result->format('Y-m-d'))->toBe('2026-06-01');
+});
+
+test('lastImportedPostDate returns null when no imported transactions exist', function () {
+    $user = User::factory()->create();
+
+    $result = Transaction::lastImportedPostDate($user->id);
+
+    expect($result)->toBeNull();
+});
+
+test('lastImportedPostDate ignores soft-deleted transactions', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+
+    Transaction::factory()->for($user)->for($account)->fromCsv()->softDeleted()->create(['post_date' => '2026-07-09']);
+    Transaction::factory()->for($user)->for($account)->fromCsv()->create(['post_date' => '2026-06-01']);
+
+    $result = Transaction::lastImportedPostDate($user->id);
+
+    expect($result)->toBeInstanceOf(CarbonImmutable::class)
+        ->and($result->format('Y-m-d'))->toBe('2026-06-01');
 });


### PR DESCRIPTION
## Summary

Adds `Transaction::lastImportedPostDate(int $userId, ?int $accountId = null): ?CarbonImmutable` — a shared primitive returning `max(post_date)` across bank-fed (`csv`/`basiq`) sources, scoped optionally to one account. Soft-deleted rows and manual/planned transactions are excluded automatically by the default query builder.

Surfaces the result in `ImportBank` via a `#[Computed] lastImportedDate()` accessor, rendered as a `<flux:text>` hint below the account select. The select now uses `wire:model.live` so the hint reacts immediately to account changes. Nothing is rendered when no imported transactions exist or when the 'new account' choice is active.

## Files changed
- `app/Models/Transaction.php` — `lastImportedPostDate()` static primitive
- `app/Livewire/ImportBank.php` — `#[Computed] lastImportedDate()` + imports
- `resources/views/livewire/import-bank.blade.php` — `wire:model.live` + hint block
- `tests/Feature/Models/TransactionTest.php` — 6 new unit tests
- `tests/Feature/Livewire/ImportBankTest.php` — 2 new feature tests

## Verification
- `ddev exec php artisan test --filter TransactionTest`: 108 passed (201 assertions)
- `ddev exec php artisan test --filter ImportBankTest`: 20 passed (52 assertions)
- `ddev exec vendor/bin/pint --test --dirty`: PASS (4 files)
- `ddev exec vendor/bin/phpstan`: No errors
- GrumPHP pre-commit hooks: pint ✔ phpstan ✔

Closes #313
Refs #313