### PR TITLE
feat(#312): show current month heading on dashboard pay-cycle calendar

### DIFF
--- a/app/Livewire/Dashboard/PayCycleCalendar.php
+++ b/app/Livewire/Dashboard/PayCycleCalendar.php
@@ -241,7 +241,7 @@ final class PayCycleCalendar extends Component
     }
 
     /**
-     * @return array{rangeLabel: string, daysUntilPay: int|null}
+     * @return array{rangeLabel: string, daysUntilPay: int|null, monthLabel: string}
      */
     #[Computed]
     public function header(): array
@@ -249,21 +249,31 @@ final class PayCycleCalendar extends Component
         $bounds = $this->bounds; // @phpstan-ignore property.notFound
 
         if ($bounds === null) {
-            return ['rangeLabel' => '', 'daysUntilPay' => null];
+            return ['rangeLabel' => '', 'daysUntilPay' => null, 'monthLabel' => ''];
         }
 
-        $today = CarbonImmutable::today();
+        $start = $bounds['start'];
         $end = $bounds['end'];
+        $today = CarbonImmutable::today();
+
+        if ($start->format('Y-m') === $end->format('Y-m')) {
+            $monthLabel = $start->format('F Y');
+        } elseif ($start->year === $end->year) {
+            $monthLabel = $start->format('M').' – '.$end->format('M Y');
+        } else {
+            $monthLabel = $start->format('M Y').' – '.$end->format('M Y');
+        }
 
         return [
             'rangeLabel' => sprintf(
                 '%s → %s',
-                $bounds['start']->format('j M'),
+                $start->format('j M'),
                 $end->format('j M'),
             ),
             'daysUntilPay' => $this->cycleOffset === 0
                 ? max(0, (int) $today->diffInDays($end, false))
                 : null,
+            'monthLabel' => $monthLabel,
         ];
     }
 

--- a/resources/views/livewire/dashboard/pay-cycle-calendar.blade.php
+++ b/resources/views/livewire/dashboard/pay-cycle-calendar.blade.php
@@ -17,9 +17,9 @@
     @else
         <header class="cyc-head">
             <div>
-                <h3 class="cyc-title">Pay cycle</h3>
+                <h2 class="cyc-title" data-testid="pay-cycle-month">{{ $this->header['monthLabel'] }}</h2>
                 <p class="cyc-sub">
-                    {{ $this->header['rangeLabel'] }}
+                    Pay cycle · {{ $this->header['rangeLabel'] }}
                     @if ($this->header['daysUntilPay'] !== null)
                         · {{ $this->header['daysUntilPay'] }}d to payday
                     @endif

--- a/tests/Feature/Livewire/Dashboard/PayCycleCalendarTest.php
+++ b/tests/Feature/Livewire/Dashboard/PayCycleCalendarTest.php
@@ -855,3 +855,75 @@ test('the add-transaction button opens the modal pre-dated to the selected day',
         ->call('addTransaction')
         ->assertDispatched('open-transaction-modal', date: $iso);
 });
+
+// ── Month heading (issue #312) ────────────────────────────────────
+
+test('header monthLabel shows full month name when cycle is within one month', function () {
+    // Freeze to 2026-07-01; next pay 2026-07-16 → cycle 2026-07-02 – 2026-07-16 (July only).
+    $this->travelTo('2026-07-01');
+    [$user] = fortnightlyThursdayPayUser('2026-07-16');
+
+    $header = Livewire::actingAs($user)
+        ->test(PayCycleCalendar::class)
+        ->instance()
+        ->header();
+
+    expect($header['monthLabel'])->toBe('July 2026');
+});
+
+test('blade renders month heading in h2 with data-testid for same-month cycle', function () {
+    $this->travelTo('2026-07-01');
+    [$user] = fortnightlyThursdayPayUser('2026-07-16');
+
+    Livewire::actingAs($user)
+        ->test(PayCycleCalendar::class)
+        ->assertSeeHtml('data-testid="pay-cycle-month"')
+        ->assertSeeHtml('<h2')
+        ->assertSee('July 2026');
+});
+
+test('header monthLabel spans two months when cycle crosses a month boundary', function () {
+    // Freeze to 2026-06-26; next pay 2026-07-09 → cycle 2026-06-25 – 2026-07-09 (Jun → Jul).
+    $this->travelTo('2026-06-26');
+    [$user] = fortnightlyThursdayPayUser('2026-07-09');
+
+    $header = Livewire::actingAs($user)
+        ->test(PayCycleCalendar::class)
+        ->instance()
+        ->header();
+
+    expect($header['monthLabel'])->toBe('Jun – Jul 2026');
+});
+
+test('header monthLabel spans two years when cycle crosses a year boundary', function () {
+    // Freeze to 2025-12-28; next pay 2026-01-08 → cycle 2025-12-25 – 2026-01-08 (Dec 2025 → Jan 2026).
+    $this->travelTo('2025-12-28');
+    [$user] = fortnightlyThursdayPayUser('2026-01-08');
+
+    $header = Livewire::actingAs($user)
+        ->test(PayCycleCalendar::class)
+        ->instance()
+        ->header();
+
+    expect($header['monthLabel'])->toBe('Dec 2025 – Jan 2026');
+});
+
+test('header monthLabel is empty string when pay cycle is not configured', function () {
+    $user = User::factory()->create();
+
+    $header = Livewire::actingAs($user)
+        ->test(PayCycleCalendar::class)
+        ->instance()
+        ->header();
+
+    expect($header['monthLabel'])->toBe('');
+});
+
+test('cyc-sub paragraph is prefixed with Pay cycle middle dot', function () {
+    $this->travelTo('2026-07-01');
+    [$user] = fortnightlyThursdayPayUser('2026-07-16');
+
+    Livewire::actingAs($user)
+        ->test(PayCycleCalendar::class)
+        ->assertSee('Pay cycle ·');
+});


### PR DESCRIPTION
## Summary

Adds a prominent month heading to the dashboard pay-cycle calendar (issue #312).

## Changes

### `app/Livewire/Dashboard/PayCycleCalendar.php`
- Extended the `#[Computed] header()` method with a third key `monthLabel: string`.
- Three label formats:
  - Same month: `$start->format('F Y')` → "July 2026"
  - Same year, different months: `$start->format('M').' – '.$end->format('M Y')` → "Jun – Jul 2026"
  - Different years: `$start->format('M Y').' – '.$end->format('M Y')` → "Dec 2025 – Jan 2026"
  - Null bounds early-return adds `monthLabel: ''`
- Updated PHPDoc `@return` array-shape to include `monthLabel: string`.

### `resources/views/livewire/dashboard/pay-cycle-calendar.blade.php`
- Replaced `<h3 class="cyc-title">Pay cycle</h3>` with `<h2 class="cyc-title" data-testid="pay-cycle-month">{{ $this->header['monthLabel'] }}</h2>`.
- Updated `cyc-sub` paragraph to prepend "Pay cycle · " so the sub-line reads e.g. "Pay cycle · 24 Jun → 8 Jul · 5d to payday".

## Tests

Six new Pest tests added to `tests/Feature/Livewire/Dashboard/PayCycleCalendarTest.php`, all clock-frozen with `travelTo()`:
- same-month cycle → `monthLabel = 'July 2026'`
- cross-month cycle → `monthLabel = 'Jun – Jul 2026'`
- cross-year cycle → `monthLabel = 'Dec 2025 – Jan 2026'`
- null bounds → `monthLabel = ''`
- blade renders `<h2` with `data-testid="pay-cycle-month"`
- `cyc-sub` carries "Pay cycle ·" prefix

## Verification

```
ddev exec php artisan test --filter=PayCycleCalendarTest
→ 56 passed (191 assertions) in 2.02s
```

pint --dirty: PASS (2 files)
phpstan: No errors (512M, phpstan.neon.dist)
GrumPHP commit gate: ✔

Refs #312