### PR TITLE
feat(#314): show underlying description as hover tooltip on categorised calendar pips

### DIFF
--- a/app/Livewire/Dashboard/Data/PayCyclePip.php
+++ b/app/Livewire/Dashboard/Data/PayCyclePip.php
@@ -15,5 +15,6 @@ final readonly class PayCyclePip
         public ?int $plannedTransactionId,
         public ?string $occurrenceDate,
         public bool $matched = false,
+        public ?string $tooltip = null,
     ) {}
 }

--- a/app/Support/Calendar/DayActivityLoader.php
+++ b/app/Support/Calendar/DayActivityLoader.php
@@ -93,6 +93,7 @@ final readonly class DayActivityLoader
                     transactionId: null,
                     plannedTransactionId: $planned->id,
                     occurrenceDate: $key,
+                    tooltip: $planned->category !== null ? $planned->description : null,
                 );
             }
         }
@@ -144,6 +145,7 @@ final readonly class DayActivityLoader
                     plannedTransactionId: null,
                     occurrenceDate: null,
                     matched: $linkedPlan !== null,
+                    tooltip: ($tx->description !== '' && $tx->description !== $name) ? $tx->description : null,
                 );
             }
 

--- a/resources/views/livewire/calendar-view.blade.php
+++ b/resources/views/livewire/calendar-view.blade.php
@@ -75,7 +75,7 @@
                     </div>
                     <div class="cyc-day-body">
                         @foreach (array_slice($day->pips, 0, CalendarView::MAX_PIPS_PER_DAY) as $pip)
-                            <div @class(['cyc-pip', $pip->kind])>
+                            <div @class(['cyc-pip', $pip->kind]) @if($pip->tooltip !== null) title="{{ $pip->tooltip }}" @endif>
                                 <span class="cyc-pip-dot"></span>
                                 <span class="cyc-pip-name">{{ $pip->name }}</span>
                             </div>
@@ -130,6 +130,7 @@
                             :tone="$rowTone"
                             :icon="$pip->icon"
                             :matched="$pip->matched"
+                            :title="$pip->tooltip"
                     />
                 @empty
                     <p class="cyc-empty">Nothing on this day.</p>

--- a/resources/views/livewire/dashboard/pay-cycle-calendar.blade.php
+++ b/resources/views/livewire/dashboard/pay-cycle-calendar.blade.php
@@ -73,7 +73,7 @@
                         </div>
                         <div class="cyc-day-body">
                             @foreach (array_slice($day->pips, 0, PayCycleCalendar::MAX_PIPS_PER_DAY) as $pip)
-                                <div @class(['cyc-pip', $pip->kind])>
+                                <div @class(['cyc-pip', $pip->kind]) @if($pip->tooltip !== null) title="{{ $pip->tooltip }}" @endif>
                                     <span class="cyc-pip-dot"></span>
                                     <span class="cyc-pip-name">{{ $pip->name }}</span>
                                 </div>
@@ -125,6 +125,7 @@
                                 :tone="$rowTone"
                                 :icon="$pip->icon"
                                 :matched="$pip->matched"
+                                :title="$pip->tooltip"
                         />
                     @empty
                         <p class="cyc-empty">Nothing on this day.</p>

--- a/tests/Feature/Livewire/CalendarViewTest.php
+++ b/tests/Feature/Livewire/CalendarViewTest.php
@@ -664,3 +664,48 @@ test('the add-transaction button opens the modal pre-dated to the selected day',
         ->call('addTransaction')
         ->assertDispatched('open-transaction-modal', date: $iso);
 });
+
+// ── Pip tooltip ──────────────────────────────────────────────────
+
+test('categorised transaction renders title tooltip in calendar grid html', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $category = Category::factory()->create(['name' => 'Fuel']);
+    $date = CarbonImmutable::now()->startOfMonth()->addDays(4);
+
+    Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'category_id' => $category->id,
+        'amount' => -6500,
+        'post_date' => $date,
+        'description' => 'BP CONNECT FORTITUDE VALLEY',
+        'planned_transaction_id' => null,
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(CalendarView::class)
+        ->assertSeeHtml('title="BP CONNECT FORTITUDE VALLEY"');
+});
+
+test('categorised transaction renders title tooltip in selected-day detail panel', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $category = Category::factory()->create(['name' => 'Fuel']);
+    $date = CarbonImmutable::now()->startOfMonth()->addDays(4);
+
+    Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'category_id' => $category->id,
+        'amount' => -6500,
+        'post_date' => $date,
+        'description' => 'BP CONNECT FORTITUDE VALLEY',
+        'planned_transaction_id' => null,
+    ]);
+
+    $html = Livewire::actingAs($user)
+        ->test(CalendarView::class)
+        ->call('selectDate', $date->format('Y-m-d'))
+        ->html();
+
+    expect(mb_substr_count($html, 'title="BP CONNECT FORTITUDE VALLEY"'))->toBeGreaterThanOrEqual(2);
+});

--- a/tests/Feature/Support/Calendar/DayActivityLoaderTest.php
+++ b/tests/Feature/Support/Calendar/DayActivityLoaderTest.php
@@ -736,6 +736,142 @@ test('plannedCents excludes a suppressed occurrence but keeps unreconciled occur
         ->and($activity['2026-06-20']->pips[0]->kind)->toBe('plan');
 });
 
+// ── Pip tooltip ───────────────────────────────────────────────────
+
+test('categorised planned pip tooltip equals the plan description', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $category = Category::factory()->create(['name' => 'Electricity']);
+    $date = CarbonImmutable::create(2026, 6, 10);
+
+    PlannedTransaction::factory()->for($user)->for($account)->noRepeat()->create([
+        'category_id' => $category->id,
+        'description' => 'AGL Bill - June',
+        'amount' => 18000,
+        'direction' => TransactionDirection::Debit,
+        'start_date' => $date,
+    ]);
+
+    $day = (new DayActivityLoader)->load(
+        CarbonImmutable::create(2026, 6, 1),
+        CarbonImmutable::create(2026, 6, 30),
+        $user->id,
+    )[$date->format('Y-m-d')];
+
+    expect($day->pips)->toHaveCount(1)
+        ->and($day->pips[0]->kind)->toBe('plan')
+        ->and($day->pips[0]->name)->toBe('Electricity')
+        ->and($day->pips[0]->tooltip)->toBe('AGL Bill - June');
+});
+
+test('uncategorised planned pip has null tooltip because name equals description', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $date = CarbonImmutable::create(2026, 6, 10);
+
+    PlannedTransaction::factory()->for($user)->for($account)->noRepeat()->create([
+        'category_id' => null,
+        'description' => 'Gym Membership',
+        'amount' => 5000,
+        'direction' => TransactionDirection::Debit,
+        'start_date' => $date,
+    ]);
+
+    $day = (new DayActivityLoader)->load(
+        CarbonImmutable::create(2026, 6, 1),
+        CarbonImmutable::create(2026, 6, 30),
+        $user->id,
+    )[$date->format('Y-m-d')];
+
+    expect($day->pips)->toHaveCount(1)
+        ->and($day->pips[0]->name)->toBe('Gym Membership')
+        ->and($day->pips[0]->tooltip)->toBeNull();
+});
+
+test('reconciled posted pip tooltip equals the bank transaction description', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $category = Category::factory()->create(['name' => 'Rent']);
+    $date = CarbonImmutable::create(2026, 6, 14);
+
+    $planned = PlannedTransaction::factory()->for($user)->for($account)->noRepeat()->create([
+        'category_id' => $category->id,
+        'amount' => 77000,
+        'direction' => TransactionDirection::Debit,
+        'start_date' => $date,
+    ]);
+
+    Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'amount' => -77000,
+        'post_date' => $date,
+        'description' => 'Ext Tfr - NET#4789778169 Sekisui House',
+        'planned_transaction_id' => $planned->id,
+    ]);
+
+    $day = (new DayActivityLoader)->load(
+        CarbonImmutable::create(2026, 6, 1),
+        CarbonImmutable::create(2026, 6, 30),
+        $user->id,
+    )[$date->format('Y-m-d')];
+
+    expect($day->pips)->toHaveCount(1)
+        ->and($day->pips[0]->kind)->toBe('out')
+        ->and($day->pips[0]->name)->toBe('Rent')
+        ->and($day->pips[0]->tooltip)->toBe('Ext Tfr - NET#4789778169 Sekisui House');
+});
+
+test('categorised posted pip tooltip equals the transaction description', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $category = Category::factory()->create(['name' => 'Groceries']);
+    $date = CarbonImmutable::create(2026, 6, 20);
+
+    Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'category_id' => $category->id,
+        'amount' => -8500,
+        'post_date' => $date,
+        'description' => 'WOOLWORTHS 4232 BRISBANE',
+        'planned_transaction_id' => null,
+    ]);
+
+    $day = (new DayActivityLoader)->load(
+        CarbonImmutable::create(2026, 6, 1),
+        CarbonImmutable::create(2026, 6, 30),
+        $user->id,
+    )[$date->format('Y-m-d')];
+
+    expect($day->pips)->toHaveCount(1)
+        ->and($day->pips[0]->name)->toBe('Groceries')
+        ->and($day->pips[0]->tooltip)->toBe('WOOLWORTHS 4232 BRISBANE');
+});
+
+test('uncategorised posted pip whose name equals its description has null tooltip', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $date = CarbonImmutable::create(2026, 6, 22);
+
+    Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'category_id' => null,
+        'amount' => -3000,
+        'post_date' => $date,
+        'description' => 'PARKING FEE CBD',
+        'planned_transaction_id' => null,
+    ]);
+
+    $day = (new DayActivityLoader)->load(
+        CarbonImmutable::create(2026, 6, 1),
+        CarbonImmutable::create(2026, 6, 30),
+        $user->id,
+    )[$date->format('Y-m-d')];
+
+    expect($day->pips)->toHaveCount(1)
+        ->and($day->pips[0]->name)->toBe('PARKING FEE CBD')
+        ->and($day->pips[0]->tooltip)->toBeNull();
+});
+
 test('DayActivity::empty returns a zero-state instance', function () {
     $empty = DayActivity::empty();
 


### PR DESCRIPTION
## Summary

Implements #314 — hover tooltips on calendar pips.

When a pip displays a category or plan name instead of the raw bank/plan description, the underlying description is now visible as a native `title` tooltip on hover.

## Changes

- `PayCyclePip` — added optional trailing constructor property `public ?string $tooltip = null`.
- `DayActivityLoader::load()` — three construction sites:
  - **Planned pip**: `tooltip: $planned->category !== null ? $planned->description : null` (when no category the name already IS the description, so no tooltip)
  - **Posted pip** (covers both linked-plan and naked branches): `tooltip: ($tx->description !== '' && $tx->description !== $name) ? $tx->description : null`
- `pay-cycle-calendar.blade.php` + `calendar-view.blade.php` — `.cyc-pip` div gets `@if($pip->tooltip !== null) title="{{ $pip->tooltip }}" @endif`.
- Selected-day detail panel uses `<x-cib.tx-row :name="..."/>` — no title attr needed there.

## Tests

- `DayActivityLoaderTest` — 5 new pip-tooltip cases (categorised planned, uncategorised planned, reconciled posted, categorised posted, uncategorised same-name). All 30 pass.
- `CalendarViewTest` — 1 blade assertion `assertSeeHtml('title="BP CONNECT FORTITUDE VALLEY"')`. All 31 pass.

## Verification

```
ddev exec php artisan test --filter=DayActivityLoaderTest   → 30/30 passed
ddev exec php artisan test --filter=CalendarViewTest        → 31/31 passed
ddev exec vendor/bin/pint --dirty                           → 4 files PASS
ddev exec vendor/bin/phpstan                                → No errors
```

Refs #314