### PR TITLE
feat(#315): mark last-imported transaction day with teal bottom edge on both calendars

### DIFF
--- a/app/Livewire/CalendarView.php
+++ b/app/Livewire/CalendarView.php
@@ -8,6 +8,7 @@ use App\Casts\MoneyCast;
 use App\Enums\PayFrequency;
 use App\Livewire\Dashboard\Data\PayCyclePip;
 use App\Livewire\Data\CalendarDayData;
+use App\Models\Transaction;
 use App\Models\User;
 use App\Support\Calendar\DayActivity;
 use App\Support\Calendar\DayActivityLoader;
@@ -80,6 +81,16 @@ final class CalendarView extends Component
     }
 
     /**
+     * ISO date (Y-m-d) of the last imported transaction post date for the authenticated user,
+     * or null when no imported transactions exist.
+     */
+    #[Computed]
+    public function importEdgeIso(): ?string
+    {
+        return Transaction::lastImportedPostDate((int) auth()->id())?->format('Y-m-d');
+    }
+
+    /**
      * @return list<CalendarDayData>
      */
     #[Computed]
@@ -102,6 +113,7 @@ final class CalendarView extends Component
             : [];
 
         $activeCycle = $user?->currentPayCycleBounds();
+        $importEdge = $this->importEdgeIso; // @phpstan-ignore property.notFound
 
         $days = [];
         $cursor = $gridStart;
@@ -137,6 +149,7 @@ final class CalendarView extends Component
                 incomeCents: $dayActivity->incomeCents,
                 postedCents: $dayActivity->postedCents,
                 plannedCents: $dayActivity->plannedCents,
+                isImportEdge: $key === $importEdge,
             );
 
             $cursor = $cursor->addDay();
@@ -311,6 +324,6 @@ final class CalendarView extends Component
 
     private function bustCache(): void
     {
-        unset($this->days, $this->monthTotals, $this->selectedDay, $this->headerLabel); // @phpstan-ignore property.notFound
+        unset($this->days, $this->monthTotals, $this->selectedDay, $this->headerLabel, $this->importEdgeIso); // @phpstan-ignore property.notFound
     }
 }

--- a/app/Livewire/Dashboard/Data/PayCycleDayData.php
+++ b/app/Livewire/Dashboard/Data/PayCycleDayData.php
@@ -24,5 +24,6 @@ final readonly class PayCycleDayData
         public int $incomeCents,
         public int $postedCents,
         public int $plannedCents,
+        public bool $isImportEdge = false,
     ) {}
 }

--- a/app/Livewire/Dashboard/PayCycleCalendar.php
+++ b/app/Livewire/Dashboard/PayCycleCalendar.php
@@ -121,12 +121,23 @@ final class PayCycleCalendar extends Component
     }
 
     /**
+     * ISO date (Y-m-d) of the last imported transaction post date for the authenticated user,
+     * or null when no imported transactions exist.
+     */
+    #[Computed]
+    public function importEdgeIso(): ?string
+    {
+        return Transaction::lastImportedPostDate((int) auth()->id())?->format('Y-m-d');
+    }
+
+    /**
      * @return list<PayCycleDayData>
      */
     #[Computed]
     public function days(): array
     {
         $bounds = $this->bounds; // @phpstan-ignore property.notFound
+        $importEdge = $this->importEdgeIso; // @phpstan-ignore property.notFound
 
         if ($bounds === null) {
             return [];
@@ -167,6 +178,7 @@ final class PayCycleCalendar extends Component
                 incomeCents: $dayActivity->incomeCents,
                 postedCents: $dayActivity->postedCents,
                 plannedCents: $dayActivity->plannedCents,
+                isImportEdge: $key === $importEdge,
             );
 
             $cursor = $cursor->addDay();
@@ -414,6 +426,6 @@ final class PayCycleCalendar extends Component
 
     private function bustCache(): void
     {
-        unset($this->bounds, $this->days, $this->totals, $this->selectedDay, $this->isCurrentCycle, $this->header); // @phpstan-ignore property.notFound
+        unset($this->bounds, $this->days, $this->totals, $this->selectedDay, $this->isCurrentCycle, $this->header, $this->importEdgeIso); // @phpstan-ignore property.notFound
     }
 }

--- a/app/Livewire/Data/CalendarDayData.php
+++ b/app/Livewire/Data/CalendarDayData.php
@@ -28,5 +28,6 @@ final readonly class CalendarDayData
         public int $incomeCents,
         public int $postedCents,
         public int $plannedCents,
+        public bool $isImportEdge = false,
     ) {}
 }

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -792,6 +792,17 @@ select:focus[data-flux-control] {
         outline-offset: -3px;
         z-index: 3;
     }
+    .cyc-day.import-edge::after {
+        content: '';
+        position: absolute;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        height: 4px;
+        background: var(--color-cib-teal-500);
+        pointer-events: none;
+        z-index: 2;
+    }
 
     .cyc-day-top {
         display: flex;

--- a/resources/views/livewire/calendar-view.blade.php
+++ b/resources/views/livewire/calendar-view.blade.php
@@ -60,7 +60,9 @@
                             'lastpay' => $day->isPastPayday,
                             'payday' => $day->isNextPayday,
                             'active' => $day->iso === $this->selectedDate,
+                            'import-edge' => $day->isImportEdge,
                         ])
+                        @if($day->isImportEdge) title="Last imported transaction" @endif
                 >
                     <div class="cyc-day-top">
                         <span class="cyc-dnum">{{ $day->day }}</span>

--- a/resources/views/livewire/dashboard/pay-cycle-calendar.blade.php
+++ b/resources/views/livewire/dashboard/pay-cycle-calendar.blade.php
@@ -58,7 +58,9 @@
                                 'payday' => $day->isCycleEnd && $this->isCurrentCycle,
                                 'lastpay' => $day->isCycleStart,
                                 'active' => $day->iso === $this->selectedDate,
+                                'import-edge' => $day->isImportEdge,
                             ])
+                            @if($day->isImportEdge) title="Last imported transaction" @endif
                     >
                         <div class="cyc-day-top">
                             <span class="cyc-dnum">{{ $day->day }}</span>

--- a/tests/Feature/Livewire/CalendarViewTest.php
+++ b/tests/Feature/Livewire/CalendarViewTest.php
@@ -709,3 +709,61 @@ test('categorised transaction renders title tooltip in selected-day detail panel
 
     expect(mb_substr_count($html, 'title="BP CONNECT FORTITUDE VALLEY"'))->toBeGreaterThanOrEqual(2);
 });
+
+// ── Import boundary marker (issue #315) ──────────────────────────────────────
+
+test('last-imported csv transaction day is flagged isImportEdge and all other days are false', function () {
+    $this->travelTo('2026-07-10');
+    $user = User::factory()->create();
+
+    Transaction::factory()->for($user)->fromCsv()->create([
+        'post_date' => '2026-07-07',
+    ]);
+
+    /** @var list<CalendarDayData> $days */
+    $days = Livewire::actingAs($user)
+        ->test(CalendarView::class)
+        ->instance()
+        ->days();
+
+    $edgeDays = collect($days)->filter(fn (CalendarDayData $d) => $d->isImportEdge);
+
+    expect($edgeDays)->toHaveCount(1)
+        ->and($edgeDays->first()?->iso)->toBe('2026-07-07')
+        ->and(collect($days)->every(fn (CalendarDayData $d) => $d->isImportEdge === ($d->iso === '2026-07-07')))->toBeTrue();
+});
+
+test('blade renders import-edge class on the last-imported csv transaction day', function () {
+    $this->travelTo('2026-07-10');
+    $user = User::factory()->create();
+
+    Transaction::factory()->for($user)->fromCsv()->create([
+        'post_date' => '2026-07-07',
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(CalendarView::class)
+        ->assertSee('import-edge');
+});
+
+test('no day is flagged isImportEdge when no csv-imported transactions exist', function () {
+    $this->travelTo('2026-07-10');
+    $user = User::factory()->create();
+
+    /** @var list<CalendarDayData> $days */
+    $days = Livewire::actingAs($user)
+        ->test(CalendarView::class)
+        ->instance()
+        ->days();
+
+    expect(collect($days)->filter(fn (CalendarDayData $d) => $d->isImportEdge))->toBeEmpty();
+});
+
+test('blade does not render import-edge class when no csv-imported transactions exist', function () {
+    $this->travelTo('2026-07-10');
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(CalendarView::class)
+        ->assertDontSee('import-edge');
+});

--- a/tests/Feature/Livewire/Dashboard/PayCycleCalendarTest.php
+++ b/tests/Feature/Livewire/Dashboard/PayCycleCalendarTest.php
@@ -927,3 +927,63 @@ test('cyc-sub paragraph is prefixed with Pay cycle middle dot', function () {
         ->test(PayCycleCalendar::class)
         ->assertSee('Pay cycle ·');
 });
+
+// ── Import boundary marker (issue #315) ──────────────────────────────────────
+
+test('last-imported csv transaction day is flagged isImportEdge and all other days are false', function () {
+    $this->travelTo('2026-05-31');
+    [$user, $account] = fortnightlyThursdayPayUser();
+
+    Transaction::factory()->for($user)->fromCsv()->create([
+        'account_id' => $account->id,
+        'post_date' => '2026-05-27',
+    ]);
+
+    /** @var list<PayCycleDayData> $days */
+    $days = Livewire::actingAs($user)
+        ->test(PayCycleCalendar::class)
+        ->instance()
+        ->days();
+
+    $edgeDays = collect($days)->filter(fn (PayCycleDayData $d) => $d->isImportEdge);
+
+    expect($edgeDays)->toHaveCount(1)
+        ->and($edgeDays->first()?->iso)->toBe('2026-05-27')
+        ->and(collect($days)->every(fn (PayCycleDayData $d) => $d->isImportEdge === ($d->iso === '2026-05-27')))->toBeTrue();
+});
+
+test('blade renders import-edge class on the last-imported csv transaction day', function () {
+    $this->travelTo('2026-05-31');
+    [$user, $account] = fortnightlyThursdayPayUser();
+
+    Transaction::factory()->for($user)->fromCsv()->create([
+        'account_id' => $account->id,
+        'post_date' => '2026-05-27',
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(PayCycleCalendar::class)
+        ->assertSee('import-edge');
+});
+
+test('no day is flagged isImportEdge when no csv-imported transactions exist', function () {
+    $this->travelTo('2026-05-31');
+    [$user] = fortnightlyThursdayPayUser();
+
+    /** @var list<PayCycleDayData> $days */
+    $days = Livewire::actingAs($user)
+        ->test(PayCycleCalendar::class)
+        ->instance()
+        ->days();
+
+    expect(collect($days)->filter(fn (PayCycleDayData $d) => $d->isImportEdge))->toBeEmpty();
+});
+
+test('blade does not render import-edge class when no csv-imported transactions exist', function () {
+    $this->travelTo('2026-05-31');
+    [$user] = fortnightlyThursdayPayUser();
+
+    Livewire::actingAs($user)
+        ->test(PayCycleCalendar::class)
+        ->assertDontSee('import-edge');
+});


### PR DESCRIPTION
## Summary

Implements the import-boundary marker from issue #315.

The day holding the user's most-recent CSV/bank-imported transaction receives an `import-edge` CSS class on both the **dashboard pay-cycle calendar** and the **/calendar grid**. The marker renders as a 4 px teal bottom bar via `.cyc-day.import-edge::after`.

## Changes

| File | What |
|---|---|
| `PayCycleDayData` + `CalendarDayData` | Trailing `public bool $isImportEdge = false` prop |
| `PayCycleCalendar` + `CalendarView` | `#[Computed] importEdgeIso()` calls `Transaction::lastImportedPostDate(auth()->id())`; result wired into day-data via `$key === $importEdge`; bust-cache updated |
| Both Blade day-cells | `'import-edge' => $day->isImportEdge` in `@class`; `title="Last imported transaction"` attribute |
| `app.css` | `.cyc-day.import-edge::after` 4 px teal bottom bar (uses `::after` to avoid colliding with `.cyc-day.today::before` today-ring) |
| 2 test files | 4 new Pest tests each: flagged data object, HTML class, no-import data, no-import HTML |

## Verification

```
Tests: 96 passed (272 assertions) — PayCycleCalendarTest + CalendarViewTest
Pint: PASS (6 files)
PHPStan: No errors
```

## Edge cases handled

- No imported transactions → `importEdgeIso` null → no cell flagged
- Import date outside rendered window → no cell matches → no marker

Refs #315