### PR TITLE
feat(#316): warn when csv import leaves a date gap since last import

### DIFF
--- a/app/Livewire/ImportBank.php
+++ b/app/Livewire/ImportBank.php
@@ -241,6 +241,20 @@ final class ImportBank extends Component
             }
         }
 
+        $continuity = null;
+
+        if ($summary?->earliestDate !== null && $this->accountChoice === 'existing' && $this->accountId !== null) {
+            $lastImported = Transaction::lastImportedPostDate((int) auth()->id(), $this->accountId);
+
+            if ($lastImported !== null) {
+                $continuity = [
+                    'status' => $summary->earliestDate->greaterThan($lastImported) ? 'gap' : 'continuous',
+                    'lastImportedDate' => $lastImported,
+                    'fileEarliest' => $summary->earliestDate,
+                ];
+            }
+        }
+
         if ($this->accountChoice === 'existing' && ! $this->balanceTouched) {
             $this->currentBalance = $summary?->closingBalance !== null
                 ? number_format($summary->closingBalance / 100, 2, '.', '')
@@ -252,6 +266,7 @@ final class ImportBank extends Component
             'bankImport' => $bankImport,
             'previewRows' => $previewRows,
             'summary' => $summary,
+            'continuity' => $continuity,
             'fields' => [
                 CsvColumnMapper::FIELD_DATE => 'Date',
                 CsvColumnMapper::FIELD_DESCRIPTION => 'Description',

--- a/resources/views/livewire/import-bank.blade.php
+++ b/resources/views/livewire/import-bank.blade.php
@@ -155,6 +155,19 @@
             </x-cib.card>
         @endif
 
+        @if($continuity !== null)
+            @if($continuity['status'] === 'gap')
+                <flux:callout variant="warning" data-testid="import-bank-continuity-gap">
+                    <flux:callout.heading>Possible missing records</flux:callout.heading>
+                    This file starts {{ $continuity['fileEarliest']->format('d/m/Y') }}, but your last import covered up to {{ $continuity['lastImportedDate']->format('d/m/Y') }}. Transactions between those dates may be missing.
+                </flux:callout>
+            @else
+                <flux:text size="sm" data-testid="import-bank-continuity-ok">
+                    Continuous with your last import (covered up to {{ $continuity['lastImportedDate']->format('d/m/Y') }}).
+                </flux:text>
+            @endif
+        @endif
+
         @if($accountChoice === 'existing')
             <x-cib.card>
                 <flux:heading size="lg">Account balance</flux:heading>

--- a/tests/Feature/Livewire/ImportBankTest.php
+++ b/tests/Feature/Livewire/ImportBankTest.php
@@ -397,3 +397,54 @@ test('selecting an existing account with no imported transactions shows no last-
         ->set('accountId', $account->id)
         ->assertDontSeeHtml('data-testid="import-bank-last-imported"');
 });
+
+// ── date continuity gap check (#316) ─────────────────────────────────────────
+
+test('uploading a csv whose earliest date is after the last import shows a gap warning', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->csvImport()->create();
+
+    // Last imported transaction is 5 days before the CSV's earliest row (01/01/2026)
+    Transaction::factory()->for($user)->for($account)->fromCsv()->create(['post_date' => '2025-12-27']);
+
+    Livewire::actingAs($user)
+        ->test(ImportBank::class)
+        ->set('accountChoice', 'existing')
+        ->set('accountId', $account->id)
+        ->set('file', fixtureUpload())
+        ->call('uploadAndDetectHeaders')
+        ->assertSeeHtml('data-testid="import-bank-continuity-gap"')
+        ->assertSeeHtml('01/01/2026')
+        ->assertSeeHtml('27/12/2025');
+});
+
+test('uploading a csv that overlaps the last import shows a continuous confirmation', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->csvImport()->create();
+
+    // Last imported transaction is inside the CSV range (CSV starts 01/01/2026)
+    Transaction::factory()->for($user)->for($account)->fromCsv()->create(['post_date' => '2026-01-02']);
+
+    Livewire::actingAs($user)
+        ->test(ImportBank::class)
+        ->set('accountChoice', 'existing')
+        ->set('accountId', $account->id)
+        ->set('file', fixtureUpload())
+        ->call('uploadAndDetectHeaders')
+        ->assertSeeHtml('data-testid="import-bank-continuity-ok"')
+        ->assertDontSeeHtml('data-testid="import-bank-continuity-gap"');
+});
+
+test('uploading a csv for an account with no prior imports shows no continuity message', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->csvImport()->create();
+
+    Livewire::actingAs($user)
+        ->test(ImportBank::class)
+        ->set('accountChoice', 'existing')
+        ->set('accountId', $account->id)
+        ->set('file', fixtureUpload())
+        ->call('uploadAndDetectHeaders')
+        ->assertDontSeeHtml('data-testid="import-bank-continuity-gap"')
+        ->assertDontSeeHtml('data-testid="import-bank-continuity-ok"');
+});


### PR DESCRIPTION
Derives a `$continuity` array in `ImportBank::render()` by comparing the uploaded file's earliest parsed date against the account's last imported post date (via `Transaction::lastImportedPostDate`). When the file starts strictly after the frontier a `'gap'` status is set; when it overlaps or pre-dates it the status is `'continuous'`. Both render as advisory callouts in the step-2 preview — a `flux:callout` warning for gaps and a `flux:text` note for continuous runs. `confirmImport()` is untouched; the check never blocks import.

## Changes
- `app/Livewire/ImportBank.php` — derives `$continuity` in `render()` and passes it to the view
- `resources/views/livewire/import-bank.blade.php` — renders gap/continuous callout after the preview summary card
- `tests/Feature/Livewire/ImportBankTest.php` — 3 new tests: gap warning, continuous confirmation, no prior imports

## Verification
- 23/23 `--filter=ImportBankTest` pass
- `pint --dirty` clean
- `phpstan` 0 errors

Refs #316