### PR TITLE
feat: planned indicator and filter on transactions page

### DIFF
--- a/app/Livewire/TransactionList.php
+++ b/app/Livewire/TransactionList.php
@@ -23,8 +23,13 @@ final class TransactionList extends Component
 
     private const array VALID_DIRECTIONS = ['all', 'incoming', 'outgoing'];
 
+    private const array VALID_PLANNED_FILTERS = ['all', 'planned', 'unplanned'];
+
     #[Url]
     public string $direction = 'all';
+
+    #[Url]
+    public string $planned = 'all';
 
     #[Url]
     public ?int $account = null;
@@ -54,6 +59,10 @@ final class TransactionList extends Component
     {
         if (! in_array($this->direction, self::VALID_DIRECTIONS, true)) {
             $this->direction = 'all';
+        }
+
+        if (! in_array($this->planned, self::VALID_PLANNED_FILTERS, true)) {
+            $this->planned = 'all';
         }
 
         $this->period = match ($this->period) {
@@ -88,6 +97,15 @@ final class TransactionList extends Component
     {
         if (! in_array($this->direction, self::VALID_DIRECTIONS, true)) {
             $this->direction = 'all';
+        }
+
+        $this->resetPage();
+    }
+
+    public function updatedPlanned(): void
+    {
+        if (! in_array($this->planned, self::VALID_PLANNED_FILTERS, true)) {
+            $this->planned = 'all';
         }
 
         $this->resetPage();
@@ -140,6 +158,8 @@ final class TransactionList extends Component
             ->when($directionEnum, fn ($q, $dir) => $q->where('direction', $dir))
             ->when($this->account, fn ($q, $id) => $q->where('account_id', $id))
             ->when($this->category, fn ($q, $id) => $q->where('category_id', $id))
+            ->when($this->planned === 'planned', fn ($q) => $q->whereNotNull('planned_transaction_id'))
+            ->when($this->planned === 'unplanned', fn ($q) => $q->whereNull('planned_transaction_id'))
             ->when($this->search, fn ($q, $term) => $q->where(function ($q) use ($term) {
                 $q->where('description', 'like', "%{$term}%")
                     ->orWhere('clean_description', 'like', "%{$term}%")

--- a/resources/views/livewire/transaction-list.blade.php
+++ b/resources/views/livewire/transaction-list.blade.php
@@ -65,6 +65,16 @@
                 wire-model="account"
             />
         @endif
+
+        <x-cib.filter-toggle
+            :options="[
+                ['value' => 'all', 'label' => 'All'],
+                ['value' => 'planned', 'label' => 'Planned'],
+                ['value' => 'unplanned', 'label' => 'Unplanned'],
+            ]"
+            :selected="$planned"
+            wire-model="planned"
+        />
     </div>
 
     <flux:input wire:model.live.debounce.300ms="search" placeholder="Search transactions..." icon="magnifying-glass" size="sm"/>
@@ -126,6 +136,7 @@
                                         $transaction->category?->name,
                                         $account === null ? $transaction->account?->name : null,
                                     ]);
+                                    $isPlanned = $transaction->planned_transaction_id !== null;
                                 @endphp
                                 <x-cib.tx-row
                                     wire:key="txn-{{ $transaction->id }}"
@@ -135,8 +146,8 @@
                                     :tone="$tone"
                                     :icon="$transaction->category?->resolveIcon()"
                                 >
-                                    @if(! empty($metaParts))
-                                        <x-slot:meta>{{ implode(' · ', $metaParts) }}</x-slot:meta>
+                                    @if(! empty($metaParts) || $isPlanned)
+                                        <x-slot:meta>{{ implode(' · ', $metaParts) }}@if($isPlanned) <span class="pill plan">Planned</span>@endif</x-slot:meta>
                                     @endif
                                 </x-cib.tx-row>
                             @endforeach

--- a/tests/Feature/Livewire/TransactionListTest.php
+++ b/tests/Feature/Livewire/TransactionListTest.php
@@ -9,6 +9,7 @@ use App\Enums\PayFrequency;
 use App\Livewire\TransactionList;
 use App\Models\Account;
 use App\Models\Category;
+use App\Models\PlannedTransaction;
 use App\Models\Transaction;
 use App\Models\User;
 use Carbon\CarbonImmutable;
@@ -470,6 +471,7 @@ test('filter state persists via url query string', function () {
             'search' => 'test',
             'sortBy' => 'amount',
             'sortDir' => 'asc',
+            'planned' => 'unplanned',
         ])
         ->assertSet('direction', 'incoming')
         ->assertSet('account', $account->id)
@@ -477,7 +479,8 @@ test('filter state persists via url query string', function () {
         ->assertSet('period', '7d')
         ->assertSet('search', 'test')
         ->assertSet('sortBy', 'amount')
-        ->assertSet('sortDir', 'asc');
+        ->assertSet('sortDir', 'asc')
+        ->assertSet('planned', 'unplanned');
 });
 
 test('loading indicator markup is present', function () {
@@ -882,7 +885,7 @@ test('account filter renders via x-cib.filter-toggle when multiple accounts', fu
         ->test(TransactionList::class)
         ->html();
 
-    expect(mb_substr_count($html, 'class="type-toggle'))->toBe(2);
+    expect(mb_substr_count($html, 'class="type-toggle'))->toBe(3);
 });
 
 test('account filter hidden when only one account', function () {
@@ -893,7 +896,7 @@ test('account filter hidden when only one account', function () {
         ->test(TransactionList::class)
         ->html();
 
-    expect(mb_substr_count($html, 'class="type-toggle'))->toBe(1);
+    expect(mb_substr_count($html, 'class="type-toggle'))->toBe(2);
 });
 
 test('empty state uses x-cib.empty-state primitive with banknotes icon', function () {
@@ -1016,4 +1019,111 @@ test('grouped collection is passed to view keyed by post_date Y-m-d', function (
             && $grouped->has('2026-04-12')
             && $grouped->get('2026-04-10')->count() === 2
             && $grouped->get('2026-04-12')->count() === 1);
+});
+
+test('planned pill shown for transactions linked to a planned transaction', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $plan = PlannedTransaction::factory()->for($user)->create(['account_id' => $account->id]);
+
+    Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'planned_transaction_id' => $plan->id,
+        'description' => 'RENT PAYMENT',
+        'post_date' => now()->subDays(5),
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(TransactionList::class)
+        ->assertSee('RENT PAYMENT')
+        ->assertSeeHtml('pill plan');
+});
+
+test('planned pill absent for unlinked transactions', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+
+    Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'description' => 'WOOLWORTHS SYDNEY',
+        'post_date' => now()->subDays(5),
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(TransactionList::class)
+        ->assertSee('WOOLWORTHS SYDNEY')
+        ->assertDontSeeHtml('pill plan');
+});
+
+test('unplanned filter hides transactions linked to a planned transaction', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $plan = PlannedTransaction::factory()->for($user)->create(['account_id' => $account->id]);
+
+    Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'planned_transaction_id' => $plan->id,
+        'description' => 'RENT PAYMENT',
+        'post_date' => now()->subDays(5),
+    ]);
+
+    Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'description' => 'WOOLWORTHS SYDNEY',
+        'post_date' => now()->subDays(5),
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(TransactionList::class, ['planned' => 'unplanned'])
+        ->assertSee('WOOLWORTHS SYDNEY')
+        ->assertDontSee('RENT PAYMENT');
+});
+
+test('planned filter shows only linked transactions', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $plan = PlannedTransaction::factory()->for($user)->create(['account_id' => $account->id]);
+
+    Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'planned_transaction_id' => $plan->id,
+        'description' => 'RENT PAYMENT',
+        'post_date' => now()->subDays(5),
+    ]);
+
+    Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'description' => 'WOOLWORTHS SYDNEY',
+        'post_date' => now()->subDays(5),
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(TransactionList::class, ['planned' => 'planned'])
+        ->assertSee('RENT PAYMENT')
+        ->assertDontSee('WOOLWORTHS SYDNEY');
+});
+
+test('invalid planned value normalizes to all', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $plan = PlannedTransaction::factory()->for($user)->create(['account_id' => $account->id]);
+
+    Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'planned_transaction_id' => $plan->id,
+        'description' => 'RENT PAYMENT',
+        'post_date' => now()->subDays(5),
+    ]);
+
+    Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'description' => 'WOOLWORTHS SYDNEY',
+        'post_date' => now()->subDays(5),
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(TransactionList::class, ['planned' => 'garbage'])
+        ->assertSet('planned', 'all')
+        ->assertSee('RENT PAYMENT')
+        ->assertSee('WOOLWORTHS SYDNEY');
 });


### PR DESCRIPTION
## Why
On `/transactions` each row's meta showed only `Category · Account`, with no signal that a transaction is already linked to a planned transaction (`transactions.planned_transaction_id`). Users couldn't tell which transactions still need a plan configured.

## What
- **Planned indicator**: a bold "Planned" pill after the account in the row meta, reusing the dormant `.tx-meta .pill.plan` style (no CSS change).
- **Planned filter**: a third All/Planned/Unplanned `x-cib.filter-toggle` beside the direction/account toggles, URL-persisted as `?planned=`, filtering on `planned_transaction_id` (NULL = unplanned). Invalid values normalize to `all`; pagination resets on change.

No eager-load added — `planned_transaction_id` is a column already on the row, so `scopeWithRelations` is untouched. Scope is the transactions page only; dashboard/calendar deferred to a follow-up.

## Verification
- `ddev exec vendor/bin/pest tests/Feature/Livewire/TransactionListTest.php` — 63 passed (5 new tests for the pill + filter, extended URL-persistence test, and 2 updated toggle-count assertions).
- `pint --dirty` clean; `phpstan` no errors.

Refs #323