### PR TITLE
feat(#329): fold intl transaction fees into their parent purchase

### DIFF
--- a/app/Enums/RuleActionType.php
+++ b/app/Enums/RuleActionType.php
@@ -11,6 +11,7 @@ enum RuleActionType: string
     case AppendNotes = 'append_notes';
     case SetNotes = 'set_notes';
     case LinkToPlannedTransaction = 'link_to_planned_transaction';
+    case FoldIntoParent = 'fold_into_parent';
 
     public function label(): string
     {
@@ -20,6 +21,7 @@ enum RuleActionType: string
             self::AppendNotes => 'Append Notes',
             self::SetNotes => 'Set Notes',
             self::LinkToPlannedTransaction => 'Link to Planned Transaction',
+            self::FoldIntoParent => 'Fold into parent transaction',
         };
     }
 
@@ -31,6 +33,12 @@ enum RuleActionType: string
             self::AppendNotes => 'notes',
             self::SetNotes => 'notes',
             self::LinkToPlannedTransaction => 'planned_transaction_id',
+            self::FoldIntoParent => '',
         };
+    }
+
+    public function requiresValue(): bool
+    {
+        return $this !== self::FoldIntoParent;
     }
 }

--- a/app/Jobs/ImportCsvTransactionsJob.php
+++ b/app/Jobs/ImportCsvTransactionsJob.php
@@ -106,6 +106,10 @@ final class ImportCsvTransactionsJob implements ShouldBeUnique, ShouldQueue
                     }
 
                     if ($existing->trashed()) {
+                        if ($existing->folded_into_transaction_id !== null) {
+                            continue; // folded fee: stays hidden; merged parent already carries its amount
+                        }
+
                         $existing->fill($values);
                         $existing->restore();
                         $restored++;

--- a/app/Livewire/UserRuleManager.php
+++ b/app/Livewire/UserRuleManager.php
@@ -483,7 +483,7 @@ final class UserRuleManager extends Component
     /** @return array<string, array<int, mixed>> */
     private function ruleFormRules(): array
     {
-        return [
+        $rules = [
             'ruleName' => ['required', 'string', 'max:255'],
             'triggers' => ['required', 'array', 'min:1'],
             'triggers.*.field' => ['required', Rule::in(array_column(RuleTriggerField::cases(), 'value'))],
@@ -491,8 +491,20 @@ final class UserRuleManager extends Component
             'triggers.*.value' => $this->triggerValueRules(),
             'actions' => ['required', 'array', 'min:1'],
             'actions.*.type' => ['required', Rule::in(array_column(RuleActionType::cases(), 'value'))],
-            'actions.*.value' => ['required', 'string'],
         ];
+
+        // Build the value rule per action index: value-requiring types must have
+        // a non-empty value (required is implicit so it catches empty strings),
+        // while valueless actions (e.g. fold into parent) accept an empty value.
+        foreach (array_keys($this->actions) as $index) {
+            $type = RuleActionType::tryFrom($this->actions[$index]['type'] ?? '');
+
+            $rules["actions.{$index}.value"] = $type !== null && ! $type->requiresValue()
+                ? ['nullable', 'string']
+                : ['required', 'string'];
+        }
+
+        return $rules;
     }
 
     /** @return array<int, mixed> */

--- a/app/Models/Transaction.php
+++ b/app/Models/Transaction.php
@@ -40,6 +40,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  * @property int|null $transfer_pair_id
  * @property int|null $planned_transaction_id
  * @property int|null $parent_transaction_id
+ * @property int|null $folded_into_transaction_id
  * @property string|null $notes
  * @property CarbonImmutable $created_at
  * @property CarbonImmutable $updated_at
@@ -76,6 +77,7 @@ final class Transaction extends Model
         'transfer_pair_id',
         'planned_transaction_id',
         'parent_transaction_id',
+        'folded_into_transaction_id',
         'notes',
     ];
 
@@ -160,6 +162,18 @@ final class Transaction extends Model
     public function children(): HasMany
     {
         return $this->hasMany(self::class, 'parent_transaction_id');
+    }
+
+    /** @return BelongsTo<self, $this> */
+    public function foldedInto(): BelongsTo
+    {
+        return $this->belongsTo(self::class, 'folded_into_transaction_id');
+    }
+
+    /** @return HasMany<self, $this> */
+    public function foldedFees(): HasMany
+    {
+        return $this->hasMany(self::class, 'folded_into_transaction_id')->withTrashed();
     }
 
     /**

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -48,8 +48,8 @@ final class AppServiceProvider extends ServiceProvider
             stages: [
                 $this->app->make(IdentifyPrimaryAccountStage::class),
                 $this->app->make(SetPayCycleStage::class),
-                $this->app->make(IdentifyRecurringTransactionsStage::class),
                 $this->app->make(UserRulesStage::class),
+                $this->app->make(IdentifyRecurringTransactionsStage::class),
                 $this->app->make(MatchPlannedTransactionsStage::class),
             ],
         ));

--- a/app/Services/PipelineStages/UserRulesStage.php
+++ b/app/Services/PipelineStages/UserRulesStage.php
@@ -55,6 +55,9 @@ final readonly class UserRulesStage implements PipelineStageContract
             return new StageResult(success: true, stage: self::STAGE_KEY);
         }
 
+        // Transactions are loaded once, upfront. A merged child created mid-run
+        // (by a fold action) is therefore not rule-processed until the next
+        // pipeline run — an accepted limitation.
         $transactions = Transaction::query()
             ->where('user_id', $context->user->id)
             ->current()
@@ -138,7 +141,14 @@ final readonly class UserRulesStage implements PipelineStageContract
             return;
         }
 
-        $this->executor->execute($transaction, $rule->actions);
+        $applied = $this->executor->execute($transaction, $rule->actions);
+
+        // Only record the audit entry when the rule actually took effect. An
+        // ineffective auto-apply (e.g. an orphan fee whose parent has not been
+        // imported yet) is left unrecorded so the next pipeline run retries it.
+        if (! $applied) {
+            return;
+        }
 
         PipelineAuditEntry::create([
             'pipeline_run_id' => $context->pipelineRun->id,

--- a/app/Services/RuleActionExecutor.php
+++ b/app/Services/RuleActionExecutor.php
@@ -11,9 +11,16 @@ use App\Models\Transaction;
 
 final readonly class RuleActionExecutor
 {
-    /** @param  array<int, array<string, string>>  $actions */
-    public function execute(Transaction $transaction, array $actions): void
+    public function __construct(private TransactionFeeFolder $feeFolder) {}
+
+    /**
+     * @param  array<int, array<string, string>>  $actions
+     * @return bool Whether any action took effect.
+     */
+    public function execute(Transaction $transaction, array $actions): bool
     {
+        $applied = false;
+
         foreach ($actions as $action) {
             $type = RuleActionType::tryFrom($action['type'] ?? '');
 
@@ -23,46 +30,69 @@ final readonly class RuleActionExecutor
 
             $value = $action['value'] ?? '';
 
-            match ($type) {
+            $applied = match ($type) {
                 RuleActionType::SetCategory => $this->setCategory($transaction, $value),
-                RuleActionType::SetDescription => $transaction->description = $value,
+                RuleActionType::SetDescription => $this->setDescription($transaction, $value),
                 RuleActionType::AppendNotes => $this->appendNotes($transaction, $value),
-                RuleActionType::SetNotes => $transaction->notes = $value,
+                RuleActionType::SetNotes => $this->setNotes($transaction, $value),
                 RuleActionType::LinkToPlannedTransaction => $this->linkToPlannedTransaction($transaction, $value),
-            };
+                RuleActionType::FoldIntoParent => $this->feeFolder->fold($transaction) instanceof Transaction,
+            } || $applied;
         }
 
         if ($transaction->isDirty()) {
             $transaction->save();
         }
+
+        return $applied;
     }
 
-    private function setCategory(Transaction $transaction, string $value): void
+    private function setCategory(Transaction $transaction, string $value): bool
     {
         $categoryId = (int) $value;
 
         if (Category::visible()->where('id', $categoryId)->exists()) {
             $transaction->category_id = $categoryId;
         }
+
+        return true;
     }
 
-    private function appendNotes(Transaction $transaction, string $value): void
+    private function setDescription(Transaction $transaction, string $value): bool
+    {
+        $transaction->description = $value;
+
+        return true;
+    }
+
+    private function appendNotes(Transaction $transaction, string $value): bool
     {
         if ($transaction->notes === null || $transaction->notes === '') {
             $transaction->notes = $value;
 
-            return;
+            return true;
         }
 
         $transaction->notes .= "\n".$value;
+
+        return true;
     }
 
-    private function linkToPlannedTransaction(Transaction $transaction, string $value): void
+    private function setNotes(Transaction $transaction, string $value): bool
+    {
+        $transaction->notes = $value;
+
+        return true;
+    }
+
+    private function linkToPlannedTransaction(Transaction $transaction, string $value): bool
     {
         $plannedId = (int) $value;
 
         if (PlannedTransaction::where('id', $plannedId)->where('user_id', $transaction->user_id)->exists()) {
             $transaction->planned_transaction_id = $plannedId;
         }
+
+        return true;
     }
 }

--- a/app/Services/RuleActionExecutor.php
+++ b/app/Services/RuleActionExecutor.php
@@ -15,11 +15,16 @@ final readonly class RuleActionExecutor
 
     /**
      * @param  array<int, array<string, string>>  $actions
-     * @return bool Whether any action took effect.
+     * @return bool Whether the rule fully applied. Returns false when a fold
+     *              action was requested but did not fold (e.g. an orphan fee
+     *              whose parent is not yet imported), so the caller leaves it
+     *              unaudited for the next pipeline run to retry — even if other
+     *              actions in the same rule took effect.
      */
     public function execute(Transaction $transaction, array $actions): bool
     {
         $applied = false;
+        $foldPending = false;
 
         foreach ($actions as $action) {
             $type = RuleActionType::tryFrom($action['type'] ?? '');
@@ -30,21 +35,27 @@ final readonly class RuleActionExecutor
 
             $value = $action['value'] ?? '';
 
-            $applied = match ($type) {
+            $effect = match ($type) {
                 RuleActionType::SetCategory => $this->setCategory($transaction, $value),
                 RuleActionType::SetDescription => $this->setDescription($transaction, $value),
                 RuleActionType::AppendNotes => $this->appendNotes($transaction, $value),
                 RuleActionType::SetNotes => $this->setNotes($transaction, $value),
                 RuleActionType::LinkToPlannedTransaction => $this->linkToPlannedTransaction($transaction, $value),
                 RuleActionType::FoldIntoParent => $this->feeFolder->fold($transaction) instanceof Transaction,
-            } || $applied;
+            };
+
+            if ($type === RuleActionType::FoldIntoParent && ! $effect) {
+                $foldPending = true;
+            }
+
+            $applied = $effect || $applied;
         }
 
         if ($transaction->isDirty()) {
             $transaction->save();
         }
 
-        return $applied;
+        return $applied && ! $foldPending;
     }
 
     private function setCategory(Transaction $transaction, string $value): bool

--- a/app/Services/TransactionFeeFolder.php
+++ b/app/Services/TransactionFeeFolder.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Casts\MoneyCast;
+use App\Models\Transaction;
+use Illuminate\Support\Facades\DB;
+
+final readonly class TransactionFeeFolder
+{
+    /**
+     * Fold an international transaction fee into its matching parent purchase.
+     *
+     * Soft-deletes the fee (hiding it everywhere), links it to a merged
+     * version-chain child of the parent that carries the combined amount, and
+     * returns that merged child. Returns null (no side effects) when the fee is
+     * not eligible or no unambiguous parent exists.
+     */
+    public function fold(Transaction $fee): ?Transaction
+    {
+        if ($fee->trashed()
+            || $fee->folded_into_transaction_id !== null
+            || $fee->planned_transaction_id !== null
+            || $fee->transfer_pair_id !== null
+        ) {
+            return null;
+        }
+
+        $parent = $this->findParent($fee);
+
+        if ($parent === null) {
+            return null;
+        }
+
+        return DB::transaction(function () use ($fee, $parent): Transaction {
+            $note = sprintf('Includes intl transaction fee %s (folded)', MoneyCast::format($fee->amount));
+
+            $merged = $parent->createChild([
+                'amount' => $parent->amount + $fee->amount,
+                'csv_hash' => null,
+                'notes' => $parent->notes === null || $parent->notes === ''
+                    ? $note
+                    : $parent->notes."\n".$note,
+            ]);
+
+            $fee->folded_into_transaction_id = $merged->id;
+            $fee->save();
+            $fee->delete();
+
+            return $merged;
+        });
+    }
+
+    /**
+     * Locate the single current purchase this fee belongs to. Matching is on the
+     * trailing five digits of the fee reference (the auth code that appears
+     * before " #<card>" in the parent), same account/direction/post_date, with
+     * the parent strictly larger in magnitude. Ambiguity or no match yields null.
+     */
+    public function findParent(Transaction $fee): ?Transaction
+    {
+        if (! preg_match('/(\d{5})\s*$/', $fee->description, $matches)) {
+            return null;
+        }
+
+        $candidates = Transaction::query()
+            ->where('user_id', $fee->user_id)
+            ->where('account_id', $fee->account_id)
+            ->where('direction', $fee->direction)
+            ->whereDate('post_date', $fee->post_date->toDateString())
+            ->whereKeyNot($fee->id)
+            ->where('description', 'like', "%{$matches[1]} #%")
+            ->whereRaw('ABS(amount) > ?', [abs($fee->amount)])
+            ->current()
+            ->get();
+
+        return $candidates->count() === 1 ? $candidates->first() : null;
+    }
+}

--- a/database/migrations/2026_07_11_000000_add_folded_into_transaction_id_to_transactions_table.php
+++ b/database/migrations/2026_07_11_000000_add_folded_into_transaction_id_to_transactions_table.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('transactions', function (Blueprint $table) {
+            $table->foreignId('folded_into_transaction_id')
+                ->nullable()
+                ->after('parent_transaction_id')
+                ->constrained('transactions')
+                ->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('transactions', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('folded_into_transaction_id');
+        });
+    }
+};

--- a/resources/views/livewire/transaction-modal.blade.php
+++ b/resources/views/livewire/transaction-modal.blade.php
@@ -227,8 +227,8 @@
                 </div>
             @endif
 
-            {{-- Transfer / basiq notes --}}
-            @if($transactionType === 'transfer' || $isBasiqTransaction)
+            {{-- Transfer / basiq notes, plus any existing notes (e.g. folded intl-fee note) --}}
+            @if($transactionType === 'transfer' || $isBasiqTransaction || $notes !== '')
                 <flux:textarea
                     wire:model="notes"
                     :label="$transactionType === 'transfer' ? __('Transfer description') : __('Notes')"

--- a/resources/views/livewire/user-rule-manager.blade.php
+++ b/resources/views/livewire/user-rule-manager.blade.php
@@ -261,6 +261,8 @@
                                         <flux:select.option value="{{ $pt->id }}">{{ $pt->description }}</flux:select.option>
                                     @endforeach
                                 </flux:select>
+                            @elseif(isset($action['type']) && $action['type'] === RuleActionType::FoldIntoParent->value)
+                                <flux:text size="sm" class="mt-2">Finds the matching parent purchase (same day, same account, matching reference) and folds this fee into it.</flux:text>
                             @else
                                 <flux:input wire:model="actions.{{ $index }}.value" size="sm" placeholder="Value" />
                             @endif

--- a/tests/Feature/Jobs/ImportCsvTransactionsJobTest.php
+++ b/tests/Feature/Jobs/ImportCsvTransactionsJobTest.php
@@ -365,3 +365,43 @@ test('a csv row with no matching plan is left entered (unlinked)', function () {
     $tx = Transaction::query()->where('account_id', $account->id)->first();
     expect($tx->planned_transaction_id)->toBeNull();
 });
+
+test('a folded fee is not restored on re-import', function () {
+    Queue::fake([RunTransactionAnalysisJob::class]);
+
+    $bankImport = makeBankImportFromFixture();
+
+    new ImportCsvTransactionsJob($bankImport)->handle(new CsvParserService(), app(TransactionIngestor::class));
+
+    $target = Transaction::query()
+        ->where('account_id', $bankImport->account_id)
+        ->whereNotNull('csv_hash')
+        ->first();
+
+    $merged = Transaction::factory()->create([
+        'user_id' => $bankImport->user_id,
+        'account_id' => $bankImport->account_id,
+    ]);
+    $target->update(['folded_into_transaction_id' => $merged->id]);
+    $targetId = $target->id;
+    $target->delete();
+
+    $bankImport->update([
+        'status' => BankImportStatus::Pending,
+        'imported_count' => 0,
+        'skipped_count' => 0,
+        'restored_count' => 0,
+        'row_count' => 0,
+        'row_errors' => null,
+        'completed_at' => null,
+    ]);
+
+    new ImportCsvTransactionsJob($bankImport)->handle(new CsvParserService(), app(TransactionIngestor::class));
+
+    $bankImport->refresh();
+
+    expect($bankImport->status)->toBe(BankImportStatus::Completed)
+        ->and($bankImport->restored_count)->toBe(0)
+        ->and(Transaction::query()->find($targetId))->toBeNull()
+        ->and(Transaction::withTrashed()->find($targetId)->trashed())->toBeTrue();
+});

--- a/tests/Feature/Livewire/TransactionListTest.php
+++ b/tests/Feature/Livewire/TransactionListTest.php
@@ -12,6 +12,7 @@ use App\Models\Category;
 use App\Models\PlannedTransaction;
 use App\Models\Transaction;
 use App\Models\User;
+use App\Services\TransactionFeeFolder;
 use Carbon\CarbonImmutable;
 use Livewire\Livewire;
 
@@ -1126,4 +1127,31 @@ test('invalid planned value normalizes to all', function () {
         ->assertSet('planned', 'all')
         ->assertSee('RENT PAYMENT')
         ->assertSee('WOOLWORTHS SYDNEY');
+});
+
+test('a folded fee shows the merged amount and hides the fee and superseded parent', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $postDate = now()->subDays(2);
+
+    Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'description' => 'VISA -JetBrains Prague CZ FRGN AMT 051280 #8357',
+        'amount' => -1394,
+        'post_date' => $postDate,
+    ]);
+    $fee = Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'description' => 'Int Tran Fee - JetBrains CZ - 951280',
+        'amount' => -42,
+        'post_date' => $postDate,
+    ]);
+
+    app(TransactionFeeFolder::class)->fold($fee);
+
+    Livewire::actingAs($user)
+        ->test(TransactionList::class)
+        ->assertSee(MoneyCast::format(-1436))
+        ->assertDontSee('Int Tran Fee')
+        ->assertDontSee(MoneyCast::format(-1394));
 });

--- a/tests/Feature/Livewire/TransactionModalTest.php
+++ b/tests/Feature/Livewire/TransactionModalTest.php
@@ -1546,6 +1546,23 @@ test('basiq transaction shows notes field with notes label', function () {
         ->assertSee(__('Notes'));
 });
 
+test('csv transaction with notes shows the notes field and folded-fee note', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $transaction = Transaction::factory()->for($user)->for($account)->fromCsv()->create([
+        'direction' => TransactionDirection::Debit,
+        'notes' => 'Includes intl transaction fee -$0.06 (folded)',
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('edit-transaction', id: $transaction->id)
+        ->assertSet('isBasiqTransaction', false)
+        ->assertSet('transactionType', 'expense')
+        ->assertSet('notes', 'Includes intl transaction fee -$0.06 (folded)')
+        ->assertSee(__('Notes'));
+});
+
 test('switching from transfer to expense hides notes field', function () {
     $user = User::factory()->create();
 

--- a/tests/Feature/Livewire/UserRuleManagerTest.php
+++ b/tests/Feature/Livewire/UserRuleManagerTest.php
@@ -293,3 +293,44 @@ test('can move rule down within group', function () {
     expect($ruleA->fresh()->order)->toBe(1)
         ->and($ruleB->fresh()->order)->toBe(0);
 });
+
+// ─── Action Value Validation ─────────────────────────────
+
+test('can save a rule with a fold_into_parent action and empty value', function () {
+    $group = UserRuleGroup::factory()->for($this->user)->create();
+
+    Livewire::actingAs($this->user)
+        ->test(UserRuleManager::class)
+        ->call('openAddRuleModal', $group->id)
+        ->set('ruleName', 'Fold Fees')
+        ->set('triggers.0.field', RuleTriggerField::Description->value)
+        ->set('triggers.0.operator', RuleTriggerOperator::StartsWith->value)
+        ->set('triggers.0.value', 'Int Tran Fee')
+        ->set('actions.0.type', RuleActionType::FoldIntoParent->value)
+        ->set('actions.0.value', '')
+        ->call('saveRule')
+        ->assertHasNoErrors();
+
+    $rule = UserRule::where('user_id', $this->user->id)->first();
+
+    expect($rule)->not->toBeNull()
+        ->and($rule->actions[0]['type'])->toBe(RuleActionType::FoldIntoParent->value);
+});
+
+test('a value-requiring action with empty value fails validation', function () {
+    $group = UserRuleGroup::factory()->for($this->user)->create();
+
+    Livewire::actingAs($this->user)
+        ->test(UserRuleManager::class)
+        ->call('openAddRuleModal', $group->id)
+        ->set('ruleName', 'Bad Rule')
+        ->set('triggers.0.field', RuleTriggerField::Description->value)
+        ->set('triggers.0.operator', RuleTriggerOperator::Contains->value)
+        ->set('triggers.0.value', 'NETFLIX')
+        ->set('actions.0.type', RuleActionType::SetCategory->value)
+        ->set('actions.0.value', '')
+        ->call('saveRule')
+        ->assertHasErrors(['actions.0.value']);
+
+    expect(UserRule::where('user_id', $this->user->id)->count())->toBe(0);
+});

--- a/tests/Feature/Services/PipelineStages/UserRulesStageTest.php
+++ b/tests/Feature/Services/PipelineStages/UserRulesStageTest.php
@@ -22,6 +22,7 @@ use App\Models\UserRule;
 use App\Models\UserRuleGroup;
 use App\Services\PipelineStages\UserRulesStage;
 use App\Services\TransactionAnalysisPipeline;
+use Carbon\CarbonImmutable;
 
 beforeEach(function () {
     $this->user = User::factory()->create();
@@ -338,4 +339,77 @@ test('stage is registered in pipeline via AppServiceProvider', function () {
     $stageKeys = array_map(fn ($stage) => $stage->key(), $stages);
 
     expect($stageKeys)->toContain('user-rules');
+});
+
+// ─── Fold Into Parent ──────────────────────────────────────────────────
+
+test('auto-apply fold rule folds an intl fee into its parent and writes an audit entry', function () {
+    $postDate = CarbonImmutable::parse('2026-07-05');
+
+    $parent = createStageTransaction($this->user, $this->account, [
+        'description' => 'VISA -JetBrains CZ FRGN AMT 051280 #8357',
+        'amount' => -1394,
+        'post_date' => $postDate,
+    ]);
+    $fee = createStageTransaction($this->user, $this->account, [
+        'description' => 'Int Tran Fee - JetBrains CZ - 951280',
+        'amount' => -42,
+        'post_date' => $postDate,
+    ]);
+
+    createRuleWithGroup($this->user, [
+        ['field' => 'description', 'operator' => 'starts_with', 'value' => 'Int Tran Fee'],
+    ], [
+        ['type' => 'fold_into_parent', 'value' => ''],
+    ], [], ['is_auto_apply' => true]);
+
+    $this->stage->execute($this->context);
+
+    $audit = PipelineAuditEntry::where('pipeline_run_id', $this->pipelineRun->id)
+        ->where('stage', 'user-rules')
+        ->where('action', 'auto_applied')
+        ->first();
+
+    expect(Transaction::withTrashed()->find($fee->id)->trashed())->toBeTrue()
+        ->and(Transaction::where('parent_transaction_id', $parent->id)->value('amount'))->toBe(-1436)
+        ->and($audit)->not->toBeNull();
+});
+
+test('orphan fee writes no audit entry and folds on a later run once the parent arrives', function () {
+    $postDate = CarbonImmutable::parse('2026-07-05');
+
+    $fee = createStageTransaction($this->user, $this->account, [
+        'description' => 'Int Tran Fee - JetBrains CZ - 951280',
+        'amount' => -42,
+        'post_date' => $postDate,
+    ]);
+
+    createRuleWithGroup($this->user, [
+        ['field' => 'description', 'operator' => 'starts_with', 'value' => 'Int Tran Fee'],
+    ], [
+        ['type' => 'fold_into_parent', 'value' => ''],
+    ], [], ['is_auto_apply' => true]);
+
+    $this->stage->execute($this->context);
+
+    expect(PipelineAuditEntry::where('stage', 'user-rules')->where('action', 'auto_applied')->count())->toBe(0)
+        ->and(Transaction::withTrashed()->find($fee->id)->trashed())->toBeFalse();
+
+    $parent = createStageTransaction($this->user, $this->account, [
+        'description' => 'VISA -JetBrains CZ FRGN AMT 051280 #8357',
+        'amount' => -1394,
+        'post_date' => $postDate,
+    ]);
+
+    $secondRun = PipelineRun::factory()->for($this->user)->create();
+    $secondContext = new PipelineContext(
+        user: $this->user,
+        pipelineRun: $secondRun,
+        isFirstSync: false,
+    );
+
+    app(UserRulesStage::class)->execute($secondContext);
+
+    expect(Transaction::withTrashed()->find($fee->id)->trashed())->toBeTrue()
+        ->and(Transaction::where('parent_transaction_id', $parent->id)->value('amount'))->toBe(-1436);
 });

--- a/tests/Feature/Services/RuleActionExecutorTest.php
+++ b/tests/Feature/Services/RuleActionExecutorTest.php
@@ -225,3 +225,20 @@ test('effective action types return true', function () {
 
     expect($applied)->toBeTrue();
 });
+
+test('a failed fold marks the rule unapplied even when a sibling action takes effect', function () {
+    $category = Category::factory()->create(['is_hidden' => false]);
+    $fee = createActionTransaction($this->user, $this->account, [
+        'description' => 'Int Tran Fee - JetBrains CZ - 951280',
+        'amount' => -42,
+    ]);
+
+    $applied = $this->executor->execute($fee, [
+        ['type' => 'set_category', 'value' => (string) $category->id],
+        ['type' => 'fold_into_parent', 'value' => ''],
+    ]);
+
+    expect($applied)->toBeFalse()
+        ->and($fee->fresh()->category_id)->toBe($category->id)
+        ->and(Transaction::withTrashed()->find($fee->id)->trashed())->toBeFalse();
+});

--- a/tests/Feature/Services/RuleActionExecutorTest.php
+++ b/tests/Feature/Services/RuleActionExecutorTest.php
@@ -12,9 +12,10 @@ use App\Models\PlannedTransaction;
 use App\Models\Transaction;
 use App\Models\User;
 use App\Services\RuleActionExecutor;
+use Carbon\CarbonImmutable;
 
 beforeEach(function () {
-    $this->executor = new RuleActionExecutor;
+    $this->executor = app(RuleActionExecutor::class);
     $this->user = User::factory()->create();
     $this->account = Account::factory()->for($this->user)->create();
 });
@@ -171,4 +172,56 @@ test('invalid action type is silently skipped', function () {
     ]);
 
     expect($transaction->fresh()->description)->toBe('ORIGINAL DESCRIPTION');
+});
+
+// ─── Fold Into Parent ──────────────────────────────────────────────────
+
+test('fold_into_parent folds a fee into its parent and returns true', function () {
+    $postDate = CarbonImmutable::parse('2026-07-05');
+
+    $parent = createActionTransaction($this->user, $this->account, [
+        'description' => 'VISA -JetBrains CZ FRGN AMT 051280 #8357',
+        'amount' => -1394,
+        'post_date' => $postDate,
+    ]);
+    $fee = createActionTransaction($this->user, $this->account, [
+        'description' => 'Int Tran Fee - JetBrains CZ - 951280',
+        'amount' => -42,
+        'post_date' => $postDate,
+    ]);
+
+    $applied = $this->executor->execute($fee, [
+        ['type' => 'fold_into_parent', 'value' => ''],
+    ]);
+
+    $merged = Transaction::where('parent_transaction_id', $parent->id)->first();
+
+    expect($applied)->toBeTrue()
+        ->and(Transaction::withTrashed()->find($fee->id)->trashed())->toBeTrue()
+        ->and($merged->amount)->toBe(-1436);
+});
+
+test('fold_into_parent returns false and leaves the fee when no parent matches', function () {
+    $fee = createActionTransaction($this->user, $this->account, [
+        'description' => 'Int Tran Fee - JetBrains CZ - 951280',
+        'amount' => -42,
+    ]);
+
+    $applied = $this->executor->execute($fee, [
+        ['type' => 'fold_into_parent', 'value' => ''],
+    ]);
+
+    expect($applied)->toBeFalse()
+        ->and(Transaction::withTrashed()->find($fee->id)->trashed())->toBeFalse();
+});
+
+test('effective action types return true', function () {
+    $category = Category::factory()->create(['is_hidden' => false]);
+    $transaction = createActionTransaction($this->user, $this->account);
+
+    $applied = $this->executor->execute($transaction, [
+        ['type' => 'set_category', 'value' => (string) $category->id],
+    ]);
+
+    expect($applied)->toBeTrue();
 });

--- a/tests/Feature/Services/TransactionFeeFolderTest.php
+++ b/tests/Feature/Services/TransactionFeeFolderTest.php
@@ -1,0 +1,204 @@
+<?php
+
+/** @noinspection PhpUnhandledExceptionInspection */
+
+/** @noinspection StaticClosureCanBeUsedInspection */
+
+declare(strict_types=1);
+
+use App\Enums\TransactionDirection;
+use App\Models\Account;
+use App\Models\PlannedTransaction;
+use App\Models\Transaction;
+use App\Models\User;
+use App\Services\TransactionFeeFolder;
+use Carbon\CarbonImmutable;
+
+beforeEach(function () {
+    $this->folder = app(TransactionFeeFolder::class);
+    $this->user = User::factory()->create();
+    $this->account = Account::factory()->for($this->user)->create();
+});
+
+function makeFee(User $user, Account $account, array $overrides = []): Transaction
+{
+    return Transaction::factory()->create(array_merge([
+        'user_id' => $user->id,
+        'account_id' => $account->id,
+        'description' => 'Int Tran Fee - JetBrains              CZ - 951280',
+        'amount' => -42,
+        'direction' => TransactionDirection::Debit,
+        'post_date' => CarbonImmutable::parse('2026-07-05'),
+        'planned_transaction_id' => null,
+        'transfer_pair_id' => null,
+        'folded_into_transaction_id' => null,
+    ], $overrides));
+}
+
+function makeParent(User $user, Account $account, array $overrides = []): Transaction
+{
+    return Transaction::factory()->create(array_merge([
+        'user_id' => $user->id,
+        'account_id' => $account->id,
+        'description' => 'VISA -JetBrains                Prague       CZ FRGN AMT-9.570000 051280 #8357',
+        'amount' => -1394,
+        'direction' => TransactionDirection::Debit,
+        'post_date' => CarbonImmutable::parse('2026-07-05'),
+        'planned_transaction_id' => null,
+    ], $overrides));
+}
+
+// ─── Successful fold ─────────────────────────────────────────────────────
+
+test('folds a fee into its matching parent purchase', function () {
+    $parent = makeParent($this->user, $this->account);
+    $fee = makeFee($this->user, $this->account);
+
+    $merged = $this->folder->fold($fee);
+
+    expect($merged)->toBeInstanceOf(Transaction::class)
+        ->and($merged->amount)->toBe(-1436)
+        ->and($merged->parent_transaction_id)->toBe($parent->id)
+        ->and($merged->csv_hash)->toBeNull()
+        ->and($merged->notes)->toContain('Includes intl transaction fee -$0.42 (folded)');
+
+    $freshFee = Transaction::withTrashed()->find($fee->id);
+
+    expect($freshFee->trashed())->toBeTrue()
+        ->and($freshFee->folded_into_transaction_id)->toBe($merged->id);
+});
+
+test('merged child inherits the parent plan link', function () {
+    $planned = PlannedTransaction::factory()->create([
+        'user_id' => $this->user->id,
+        'account_id' => $this->account->id,
+    ]);
+    makeParent($this->user, $this->account, ['planned_transaction_id' => $planned->id]);
+    $fee = makeFee($this->user, $this->account);
+
+    $merged = $this->folder->fold($fee);
+
+    expect($merged->planned_transaction_id)->toBe($planned->id);
+});
+
+test('merged child appends the fold note to existing parent notes', function () {
+    makeParent($this->user, $this->account, ['notes' => 'Existing note']);
+    $fee = makeFee($this->user, $this->account);
+
+    $merged = $this->folder->fold($fee);
+
+    expect($merged->notes)->toBe("Existing note\nIncludes intl transaction fee -\$0.42 (folded)");
+});
+
+// ─── Matching failures (no side effects) ─────────────────────────────────
+
+test('returns null when the fee has no trailing reference digits', function () {
+    makeParent($this->user, $this->account);
+    $fee = makeFee($this->user, $this->account, ['description' => 'Int Tran Fee - JetBrains CZ']);
+
+    expect($this->folder->fold($fee))->toBeNull()
+        ->and(Transaction::withTrashed()->find($fee->id)->trashed())->toBeFalse();
+});
+
+test('returns null when no parent exists', function () {
+    $fee = makeFee($this->user, $this->account);
+
+    expect($this->folder->fold($fee))->toBeNull()
+        ->and(Transaction::withTrashed()->find($fee->id)->trashed())->toBeFalse();
+});
+
+test('returns null when two candidate parents match', function () {
+    makeParent($this->user, $this->account);
+    makeParent($this->user, $this->account, [
+        'description' => 'VISA -Other Shop CZ FRGN AMT 951280 #9999',
+        'amount' => -2000,
+    ]);
+    $fee = makeFee($this->user, $this->account);
+
+    expect($this->folder->fold($fee))->toBeNull()
+        ->and(Transaction::withTrashed()->find($fee->id)->trashed())->toBeFalse();
+});
+
+// ─── Guards ──────────────────────────────────────────────────────────────
+
+test('does not fold a fee already reconciled to a plan', function () {
+    $planned = PlannedTransaction::factory()->create([
+        'user_id' => $this->user->id,
+        'account_id' => $this->account->id,
+    ]);
+    makeParent($this->user, $this->account);
+    $fee = makeFee($this->user, $this->account, ['planned_transaction_id' => $planned->id]);
+
+    expect($this->folder->fold($fee))->toBeNull()
+        ->and(Transaction::withTrashed()->find($fee->id)->trashed())->toBeFalse();
+});
+
+test('does not fold a transfer-paired fee', function () {
+    $pair = Transaction::factory()->create([
+        'user_id' => $this->user->id,
+        'account_id' => $this->account->id,
+    ]);
+    makeParent($this->user, $this->account);
+    $fee = makeFee($this->user, $this->account, ['transfer_pair_id' => $pair->id]);
+
+    expect($this->folder->fold($fee))->toBeNull()
+        ->and(Transaction::withTrashed()->find($fee->id)->trashed())->toBeFalse();
+});
+
+test('does not re-fold an already folded fee', function () {
+    $parent = makeParent($this->user, $this->account);
+    $fee = makeFee($this->user, $this->account, ['folded_into_transaction_id' => $parent->id]);
+
+    expect($this->folder->fold($fee))->toBeNull();
+});
+
+test('does not match a parent on a different account', function () {
+    $otherAccount = Account::factory()->for($this->user)->create();
+    makeParent($this->user, $otherAccount);
+    $fee = makeFee($this->user, $this->account);
+
+    expect($this->folder->fold($fee))->toBeNull();
+});
+
+test('does not match a parent posted on a different day', function () {
+    makeParent($this->user, $this->account, ['post_date' => CarbonImmutable::parse('2026-07-06')]);
+    $fee = makeFee($this->user, $this->account);
+
+    expect($this->folder->fold($fee))->toBeNull();
+});
+
+test('does not match a parent with a different direction', function () {
+    makeParent($this->user, $this->account, [
+        'direction' => TransactionDirection::Credit,
+        'amount' => 1394,
+    ]);
+    $fee = makeFee($this->user, $this->account);
+
+    expect($this->folder->fold($fee))->toBeNull();
+});
+
+test('does not match a candidate smaller than or equal to the fee', function () {
+    makeParent($this->user, $this->account, ['amount' => -42]);
+    $fee = makeFee($this->user, $this->account);
+
+    expect($this->folder->fold($fee))->toBeNull();
+});
+
+// ─── Relationships ───────────────────────────────────────────────────────
+
+test('foldedFees and foldedInto expose the fold relationship', function () {
+    makeParent($this->user, $this->account);
+    $fee = makeFee($this->user, $this->account);
+
+    $merged = $this->folder->fold($fee);
+
+    $foldedFees = $merged->foldedFees()->get();
+
+    expect($foldedFees)->toHaveCount(1)
+        ->and($foldedFees->first()->id)->toBe($fee->id)
+        ->and($foldedFees->first()->trashed())->toBeTrue();
+
+    $freshFee = Transaction::withTrashed()->find($fee->id);
+
+    expect($freshFee->foldedInto->id)->toBe($merged->id);
+});


### PR DESCRIPTION
Closes #329 (targets `develop`, so close manually after squash-merge).

## Why

The bank emits a separate `Int Tran Fee - <merchant> <CC> - <ref>` debit alongside every foreign-currency card purchase. These clutter the list and make the parent purchase understate its true cost.

## What

A new **Fold into parent transaction** rule action. When a user rule (trigger: description starts with `Int Tran Fee`) auto-applies during the post-import analysis pipeline, the fee is folded into its parent:

- **`TransactionFeeFolder`** (new service) matches the parent code-side: trailing 5 ref digits appearing before ` #<card>`, same account/direction/`post_date` (zero-day tolerance), parent strictly larger in magnitude, exactly one candidate.
- The fee is soft-deleted (hidden from list + all aggregates via existing scopes); a merged version-chain child of the parent carries the **signed combined total**, with `csv_hash` nulled so re-imports can never rewrite it. Plan link, category and description carry over via `createChild`.
- Runs event-driven inside **`UserRulesStage`**, which now runs **before** recurring detection so fee rows never seed recurring suggestions and detection sees merged amounts. `MatchPlannedTransactionsStage` stays last.
- **Orphan-fee retry**: audit entries are gated on rule effectiveness, so a fee whose parent hasn't been imported yet folds on the next pipeline run.
- **`ImportCsvTransactionsJob`** never restores a folded (trashed) fee on re-import.
- Rule manager UI shows a description (no value input) for the new action; validation makes `value` conditionally required per action type.

## Schema

Adds nullable `folded_into_transaction_id` FK to `transactions` (set on the fee, points at the merged child; `nullOnDelete`). Migration only — no backfill.

## Verification

- `ddev exec vendor/bin/pint --dirty` + `ddev exec vendor/bin/phpstan analyse` clean.
- `ddev exec php artisan migrate` applied.
- Full suite: **1851 passed (4600 assertions)**.
- New `TransactionFeeFolderTest` (14 cases: fold, plan-link carry-over, no-ref/zero/two-candidate, all guards, relationships) plus extended `RuleActionExecutor`, `UserRulesStage` (end-to-end fold + orphan retry), `ImportCsvTransactionsJob` (no-restore), `TransactionList` (merged amount shown; fee + superseded parent hidden), and `UserRuleManager` (fold saves with empty value; value-requiring action still fails).

## Notes

- Fold is CSV/Basiq-agnostic (runs wherever the pipeline runs); the rule simply won't match differing formats.
- No unfold UI (deferred); deleting the merged child leaves the fee trashed but recoverable via `folded_into_transaction_id`.