### PR TITLE
fix(#331): refresh transaction list when the modal saves

### DIFF
--- a/app/Livewire/TransactionList.php
+++ b/app/Livewire/TransactionList.php
@@ -11,6 +11,7 @@ use App\Models\Account;
 use App\Models\Category;
 use App\Models\Transaction;
 use Illuminate\View\View;
+use Livewire\Attributes\On;
 use Livewire\Attributes\Url;
 use Livewire\Component;
 use Livewire\WithPagination;
@@ -91,6 +92,16 @@ final class TransactionList extends Component
         }
 
         $this->resetPage();
+    }
+
+    /**
+     * The modal saved or deleted a transaction/plan; re-render so the fresh
+     * render() query picks up the change.
+     */
+    #[On('transaction-saved')]
+    public function refreshList(): void
+    {
+        //
     }
 
     public function updatedDirection(): void

--- a/app/Livewire/TransactionList.php
+++ b/app/Livewire/TransactionList.php
@@ -99,10 +99,7 @@ final class TransactionList extends Component
      * render() query picks up the change.
      */
     #[On('transaction-saved')]
-    public function refreshList(): void
-    {
-        //
-    }
+    public function refreshList(): void {}
 
     public function updatedDirection(): void
     {

--- a/tests/Feature/Livewire/TransactionListTest.php
+++ b/tests/Feature/Livewire/TransactionListTest.php
@@ -1155,3 +1155,41 @@ test('a folded fee shows the merged amount and hides the fee and superseded pare
         ->assertDontSee('Int Tran Fee')
         ->assertDontSee(MoneyCast::format(-1394));
 });
+
+test('list refreshes when transaction-saved event is dispatched', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+
+    $component = Livewire::actingAs($user)->test(TransactionList::class);
+
+    $component->assertDontSee('NEW COFFEE PURCHASE');
+
+    Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'description' => 'NEW COFFEE PURCHASE',
+        'post_date' => now()->subDays(1),
+    ]);
+
+    $component->dispatch('transaction-saved')->assertSee('NEW COFFEE PURCHASE');
+});
+
+test('list reflects an edited transaction after transaction-saved', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+
+    $txn = Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'description' => 'ORIGINAL DESC',
+        'post_date' => now()->subDays(1),
+    ]);
+
+    $component = Livewire::actingAs($user)
+        ->test(TransactionList::class)
+        ->assertSee('ORIGINAL DESC');
+
+    $txn->update(['description' => 'EDITED DESC']);
+
+    $component->dispatch('transaction-saved')
+        ->assertSee('EDITED DESC')
+        ->assertDontSee('ORIGINAL DESC');
+});


### PR DESCRIPTION
## Summary

`TransactionModal` dispatches `transaction-saved` on every save/delete path (save, deleteTransaction, deletePlannedTransaction). `CalendarView`, `Dashboard`, and `PayCycleCalendar` all listen for this event — but `TransactionList` had no `#[On('transaction-saved')]` listener, so the list never re-rendered after a modal operation without a manual page refresh.

## What Changed

**`app/Livewire/TransactionList.php`**
- Added `use Livewire\Attributes\On;` import (alphabetical before `Url`).
- Added `#[On('transaction-saved')] public function refreshList(): void {}` after `sort()`. Because `render()` queries the DB directly, an empty body is sufficient — the event-triggered Livewire request re-runs `render()` and picks up the change.

**`tests/Feature/Livewire/TransactionListTest.php`**
- `list refreshes when transaction-saved event is dispatched` — dispatching the event surfaces a transaction created after component mount.
- `list reflects an edited transaction after transaction-saved` — dispatching shows the new description and hides the old one.

Tests were written first (TDD) and confirmed failing before implementation.

## Verification

- `op test.filter TransactionListTest` pre-implementation: 2 failed (EventHandlerDoesNotExist), 64 passed ✓
- `op test.filter TransactionListTest` post-implementation: **66 passed** ✓
- `op lint.dirty`: **pass** ✓
- `op analyse`: **0 errors** ✓
- `op test` (full suite): **1855 passed** ✓

## Note on Rebase

This branch and PRs #332/#333 all branch off the same `develop` base and touch `TransactionList.php` / `TransactionListTest.php`. Whichever merges 2nd/3rd may need a trivial rebase.

Refs #331