### PR TITLE
feat(#332): remember the last period selection on the transactions page

### DIFF
--- a/app/Livewire/TransactionList.php
+++ b/app/Livewire/TransactionList.php
@@ -58,6 +58,8 @@ final class TransactionList extends Component
 
     public function mount(): void
     {
+        $this->restoreRememberedPeriod();
+
         if (! in_array($this->direction, self::VALID_DIRECTIONS, true)) {
             $this->direction = 'all';
         }
@@ -132,6 +134,7 @@ final class TransactionList extends Component
     public function updatedPeriod(): void
     {
         $this->resetPage();
+        session()->put('transactions.period', $this->period);
     }
 
     public function updatedSearch(): void
@@ -142,11 +145,13 @@ final class TransactionList extends Component
     public function updatedFrom(): void
     {
         $this->resetPage();
+        session()->put('transactions.from', $this->from);
     }
 
     public function updatedTo(): void
     {
         $this->resetPage();
+        session()->put('transactions.to', $this->to);
     }
 
     public function render(): View
@@ -202,5 +207,30 @@ final class TransactionList extends Component
             'hasPayCycle' => auth()->user()->hasPayCycleConfigured(),
             'showCustomRange' => $periodEnum === TransactionPeriod::Custom,
         ]);
+    }
+
+    private function restoreRememberedPeriod(): void
+    {
+        if (request()->query('period') !== null) {
+            return;
+        }
+
+        $period = session()->get('transactions.period');
+
+        if (! is_string($period)) {
+            return;
+        }
+
+        $this->period = $period;
+
+        if (request()->query('from') === null) {
+            $from = session()->get('transactions.from');
+            $this->from = is_string($from) ? $from : null;
+        }
+
+        if (request()->query('to') === null) {
+            $to = session()->get('transactions.to');
+            $this->to = is_string($to) ? $to : null;
+        }
     }
 }

--- a/tests/Feature/Livewire/TransactionListTest.php
+++ b/tests/Feature/Livewire/TransactionListTest.php
@@ -1156,40 +1156,61 @@ test('a folded fee shows the merged amount and hides the fee and superseded pare
         ->assertDontSee(MoneyCast::format(-1394));
 });
 
-test('list refreshes when transaction-saved event is dispatched', function () {
+// ── Period persistence (session) ────────────────────────────────────────────
+
+test('changing period stores it in the session', function () {
     $user = User::factory()->create();
-    $account = Account::factory()->for($user)->create();
 
-    $component = Livewire::actingAs($user)->test(TransactionList::class);
+    Livewire::actingAs($user)
+        ->test(TransactionList::class)
+        ->set('period', '6m');
 
-    $component->assertDontSee('NEW COFFEE PURCHASE');
-
-    Transaction::factory()->for($user)->debit()->create([
-        'account_id' => $account->id,
-        'description' => 'NEW COFFEE PURCHASE',
-        'post_date' => now()->subDays(1),
-    ]);
-
-    $component->dispatch('transaction-saved')->assertSee('NEW COFFEE PURCHASE');
+    expect(session()->get('transactions.period'))->toBe('6m');
 });
 
-test('list reflects an edited transaction after transaction-saved', function () {
+test('period restores from session when no query param present', function () {
     $user = User::factory()->create();
-    $account = Account::factory()->for($user)->create();
 
-    $txn = Transaction::factory()->for($user)->debit()->create([
-        'account_id' => $account->id,
-        'description' => 'ORIGINAL DESC',
-        'post_date' => now()->subDays(1),
-    ]);
+    session()->put('transactions.period', '6m');
 
-    $component = Livewire::actingAs($user)
+    Livewire::actingAs($user)
         ->test(TransactionList::class)
-        ->assertSee('ORIGINAL DESC');
+        ->assertSet('period', '6m');
+});
 
-    $txn->update(['description' => 'EDITED DESC']);
+test('explicit period query param beats remembered session value', function () {
+    $user = User::factory()->create();
 
-    $component->dispatch('transaction-saved')
-        ->assertSee('EDITED DESC')
-        ->assertDontSee('ORIGINAL DESC');
+    session()->put('transactions.period', '6m');
+
+    Livewire::actingAs($user)
+        ->withQueryParams(['period' => '7d'])
+        ->test(TransactionList::class)
+        ->assertSet('period', '7d');
+});
+
+test('invalid remembered period normalizes to this-month', function () {
+    $user = User::factory()->create();
+
+    session()->put('transactions.period', 'garbage');
+
+    Livewire::actingAs($user)
+        ->test(TransactionList::class)
+        ->assertSet('period', 'this-month');
+});
+
+test('custom range from and to restore from session', function () {
+    $user = User::factory()->create();
+
+    session()->put('transactions.period', 'custom');
+    session()->put('transactions.from', '2026-06-01');
+    session()->put('transactions.to', '2026-06-10');
+
+    Livewire::actingAs($user)
+        ->test(TransactionList::class)
+        ->assertSet('period', 'custom')
+        ->assertSet('from', '2026-06-01')
+        ->assertSet('to', '2026-06-10')
+        ->assertSeeHtml('wire:model.live="from"')
+        ->assertSeeHtml('wire:model.live="to"');
 });

--- a/tests/Feature/Livewire/TransactionListTest.php
+++ b/tests/Feature/Livewire/TransactionListTest.php
@@ -1156,6 +1156,44 @@ test('a folded fee shows the merged amount and hides the fee and superseded pare
         ->assertDontSee(MoneyCast::format(-1394));
 });
 
+test('list refreshes when transaction-saved event is dispatched', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+
+    $component = Livewire::actingAs($user)->test(TransactionList::class);
+
+    $component->assertDontSee('NEW COFFEE PURCHASE');
+
+    Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'description' => 'NEW COFFEE PURCHASE',
+        'post_date' => now()->subDays(1),
+    ]);
+
+    $component->dispatch('transaction-saved')->assertSee('NEW COFFEE PURCHASE');
+});
+
+test('list reflects an edited transaction after transaction-saved', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+
+    $txn = Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'description' => 'ORIGINAL DESC',
+        'post_date' => now()->subDays(1),
+    ]);
+
+    $component = Livewire::actingAs($user)
+        ->test(TransactionList::class)
+        ->assertSee('ORIGINAL DESC');
+
+    $txn->update(['description' => 'EDITED DESC']);
+
+    $component->dispatch('transaction-saved')
+        ->assertSee('EDITED DESC')
+        ->assertDontSee('ORIGINAL DESC');
+});
+
 // ── Period persistence (session) ────────────────────────────────────────────
 
 test('changing period stores it in the session', function () {

--- a/tests/Feature/Livewire/TransactionListTest.php
+++ b/tests/Feature/Livewire/TransactionListTest.php
@@ -1214,3 +1214,16 @@ test('custom range from and to restore from session', function () {
         ->assertSeeHtml('wire:model.live="from"')
         ->assertSeeHtml('wire:model.live="to"');
 });
+
+test('changing custom range dates stores them in the session', function () {
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(TransactionList::class)
+        ->set('period', 'custom')
+        ->set('from', '2026-06-01')
+        ->set('to', '2026-06-10');
+
+    expect(session()->get('transactions.from'))->toBe('2026-06-01');
+    expect(session()->get('transactions.to'))->toBe('2026-06-10');
+});


### PR DESCRIPTION
## Summary

The period selector on the Transactions page always reset to "This Month" on every visit. Users who prefer "Last 6 Months", "Last Year", or a custom date range had to re-select it every time they returned.

## What changed

**`app/Livewire/TransactionList.php`**

- Added `restoreRememberedPeriod()` (private) called at the very top of `mount()`, before the existing legacy-mapping and `TransactionPeriod::tryFrom` normalization.
- Precedence is explicit: **URL query param > session > default `'this-month'`**. If `?period=` is in the URL, the session value is ignored entirely.
- Invalid/legacy session values (e.g. the old `'30d'`) fall through to the existing normalization code and resolve to `'this-month'` — same behavior as stale URL params.
- `updatedPeriod()`, `updatedFrom()`, `updatedTo()` now each persist their new value to `session()` (`transactions.period`, `transactions.from`, `transactions.to`) after `resetPage()`.
- All `session()->get()` results are guarded with `is_string()` — required for PHPStan level 6 (`get()` returns `mixed`).

**`tests/Feature/Livewire/TransactionListTest.php`**

Five new tests (TDD — written before implementation, confirmed failing first):

- `changing period stores it in the session`
- `period restores from session when no query param present`
- `explicit period query param beats remembered session value`
- `invalid remembered period normalizes to this-month`
- `custom range from and to restore from session`

## Verification

- `op test.filter TransactionListTest` — new tests failed before implementation ✓, 69 passed after ✓
- `op lint.dirty` — Pint fixed ordered_class_elements, unary_operator_spaces, not_operator_with_successor_space ✓
- `op analyse` — PHPStan level 6: no errors ✓
- `op test` — 1858 passed (4616 assertions) ✓

## Rebase note

This PR, PR #335 (issue #331), and the issue #333 PR all branch off the same `develop` base and touch `app/Livewire/TransactionList.php` and `tests/Feature/Livewire/TransactionListTest.php`. Whichever merges second or third will need a trivial rebase.

Refs #332