### PR TITLE
feat(#333): add categorised/uncategorised filter to the transactions page

### DIFF
--- a/app/Livewire/TransactionList.php
+++ b/app/Livewire/TransactionList.php
@@ -26,11 +26,16 @@ final class TransactionList extends Component
 
     private const array VALID_PLANNED_FILTERS = ['all', 'planned', 'unplanned'];
 
+    private const array VALID_CATEGORISED_FILTERS = ['all', 'categorised', 'uncategorised'];
+
     #[Url]
     public string $direction = 'all';
 
     #[Url]
     public string $planned = 'all';
+
+    #[Url]
+    public string $categorised = 'all';
 
     #[Url]
     public ?int $account = null;
@@ -66,6 +71,10 @@ final class TransactionList extends Component
 
         if (! in_array($this->planned, self::VALID_PLANNED_FILTERS, true)) {
             $this->planned = 'all';
+        }
+
+        if (! in_array($this->categorised, self::VALID_CATEGORISED_FILTERS, true)) {
+            $this->categorised = 'all';
         }
 
         $this->period = match ($this->period) {
@@ -116,6 +125,15 @@ final class TransactionList extends Component
     {
         if (! in_array($this->planned, self::VALID_PLANNED_FILTERS, true)) {
             $this->planned = 'all';
+        }
+
+        $this->resetPage();
+    }
+
+    public function updatedCategorised(): void
+    {
+        if (! in_array($this->categorised, self::VALID_CATEGORISED_FILTERS, true)) {
+            $this->categorised = 'all';
         }
 
         $this->resetPage();
@@ -173,6 +191,8 @@ final class TransactionList extends Component
             ->when($this->category, fn ($q, $id) => $q->where('category_id', $id))
             ->when($this->planned === 'planned', fn ($q) => $q->whereNotNull('planned_transaction_id'))
             ->when($this->planned === 'unplanned', fn ($q) => $q->whereNull('planned_transaction_id'))
+            ->when($this->categorised === 'categorised', fn ($q) => $q->whereNotNull('category_id'))
+            ->when($this->categorised === 'uncategorised', fn ($q) => $q->whereNull('category_id'))
             ->when($this->search, fn ($q, $term) => $q->where(function ($q) use ($term) {
                 $q->where('description', 'like', "%{$term}%")
                     ->orWhere('clean_description', 'like', "%{$term}%")

--- a/resources/views/livewire/transaction-list.blade.php
+++ b/resources/views/livewire/transaction-list.blade.php
@@ -75,6 +75,16 @@
             :selected="$planned"
             wire-model="planned"
         />
+
+        <x-cib.filter-toggle
+            :options="[
+                ['value' => 'all', 'label' => 'All'],
+                ['value' => 'categorised', 'label' => 'Categorised'],
+                ['value' => 'uncategorised', 'label' => 'Uncategorised'],
+            ]"
+            :selected="$categorised"
+            wire-model="categorised"
+        />
     </div>
 
     <flux:input wire:model.live.debounce.300ms="search" placeholder="Search transactions..." icon="magnifying-glass" size="sm"/>

--- a/tests/Feature/Livewire/TransactionListTest.php
+++ b/tests/Feature/Livewire/TransactionListTest.php
@@ -886,7 +886,7 @@ test('account filter renders via x-cib.filter-toggle when multiple accounts', fu
         ->test(TransactionList::class)
         ->html();
 
-    expect(mb_substr_count($html, 'class="type-toggle'))->toBe(3);
+    expect(mb_substr_count($html, 'class="type-toggle'))->toBe(4);
 });
 
 test('account filter hidden when only one account', function () {
@@ -897,7 +897,7 @@ test('account filter hidden when only one account', function () {
         ->test(TransactionList::class)
         ->html();
 
-    expect(mb_substr_count($html, 'class="type-toggle'))->toBe(2);
+    expect(mb_substr_count($html, 'class="type-toggle'))->toBe(3);
 });
 
 test('empty state uses x-cib.empty-state primitive with banknotes icon', function () {
@@ -1264,4 +1264,90 @@ test('changing custom range dates stores them in the session', function () {
 
     expect(session()->get('transactions.from'))->toBe('2026-06-01');
     expect(session()->get('transactions.to'))->toBe('2026-06-10');
+});
+
+test('categorised filter shows only transactions with a category', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $category = Category::factory()->create();
+
+    Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'category_id' => $category->id,
+        'description' => 'WOOLWORTHS CATEGORISED',
+        'post_date' => now()->subDays(5),
+    ]);
+
+    Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'category_id' => null,
+        'description' => 'COLES UNCATEGORISED',
+        'post_date' => now()->subDays(5),
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(TransactionList::class, ['categorised' => 'categorised'])
+        ->assertSee('WOOLWORTHS CATEGORISED')
+        ->assertDontSee('COLES UNCATEGORISED');
+});
+
+test('uncategorised filter shows only transactions without a category', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $category = Category::factory()->create();
+
+    Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'category_id' => $category->id,
+        'description' => 'WOOLWORTHS CATEGORISED',
+        'post_date' => now()->subDays(5),
+    ]);
+
+    Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'category_id' => null,
+        'description' => 'COLES UNCATEGORISED',
+        'post_date' => now()->subDays(5),
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(TransactionList::class, ['categorised' => 'uncategorised'])
+        ->assertSee('COLES UNCATEGORISED')
+        ->assertDontSee('WOOLWORTHS CATEGORISED');
+});
+
+test('invalid categorised value normalizes to all', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $category = Category::factory()->create();
+
+    Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'category_id' => $category->id,
+        'description' => 'WOOLWORTHS CATEGORISED',
+        'post_date' => now()->subDays(5),
+    ]);
+
+    Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'category_id' => null,
+        'description' => 'COLES UNCATEGORISED',
+        'post_date' => now()->subDays(5),
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(TransactionList::class, ['categorised' => 'garbage'])
+        ->assertSet('categorised', 'all')
+        ->assertSee('WOOLWORTHS CATEGORISED')
+        ->assertSee('COLES UNCATEGORISED');
+});
+
+test('categorised filter state persists via url query string', function () {
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(TransactionList::class, [
+            'categorised' => 'uncategorised',
+        ])
+        ->assertSet('categorised', 'uncategorised');
 });


### PR DESCRIPTION
## Summary

Adds an All / Categorised / Uncategorised filter toggle to the Transactions page so users can quickly show only transactions that have a category assigned, or only those that don't.

## What changed

**`app/Livewire/TransactionList.php`**
- Added `VALID_CATEGORISED_FILTERS` const mirroring `VALID_PLANNED_FILTERS`
- Added `#[Url] public string $categorised = 'all';` property
- Mount normalises invalid values to `'all'`
- Added `updatedCategorised()` hook (validates, resets page)
- Added two `when()` clauses after the planned filters: `whereNotNull('category_id')` / `whereNull('category_id')`

**`resources/views/livewire/transaction-list.blade.php`**
- Added `<x-cib.filter-toggle>` with All / Categorised / Uncategorised options inside the existing filter flex div

**`tests/Feature/Livewire/TransactionListTest.php`**
- 4 new tests: categorised filter, uncategorised filter, invalid-value normalization, URL persistence
- Updated toggle-count assertions (2 tests) to reflect the additional toggle

## Verification

- `op test.filter TransactionListTest`: 4 new tests failed before implementation (TDD red), 68 passed after (green, 140 assertions)
- `op lint.dirty`: pass
- `op analyse`: No errors (PHPStan level 6)
- `op test`: 1857 passed (4615 assertions)

## Note on rebasing

This PR, #335 (#331), and #336 (#332) all branch off the same `develop` base and touch `TransactionList.php` / `TransactionListTest.php`. Whichever PRs merge second or third will need a trivial rebase onto the updated `develop`.

Refs #333