### PR TITLE
feat(#338): offer categorise-matching when editing a transaction category

### DIFF
--- a/app/Livewire/TransactionModal.php
+++ b/app/Livewire/TransactionModal.php
@@ -455,26 +455,26 @@ final class TransactionModal extends Component
         [$transaction, $parsed] = $resolved;
 
         if ($transaction->source === TransactionSource::Basiq) {
-            $transaction->createChild([
+            $child = $transaction->createChild([
                 'category_id' => $this->categoryId,
                 'notes' => $this->notes !== '' ? $this->notes : null,
                 'clean_description' => $this->cleanDescription !== '' ? $this->cleanDescription : null,
             ]);
-
-            return true;
+        } else {
+            $child = $transaction->createChild([
+                'account_id' => $this->accountId,
+                'category_id' => $this->categoryId,
+                'amount' => $parsed->amount,
+                'direction' => $this->transactionType === 'expense'
+                    ? TransactionDirection::Debit
+                    : TransactionDirection::Credit,
+                'description' => $parsed->description,
+                'post_date' => $this->date,
+                'notes' => $this->notes !== '' ? $this->notes : null,
+            ]);
         }
 
-        $transaction->createChild([
-            'account_id' => $this->accountId,
-            'category_id' => $this->categoryId,
-            'amount' => $parsed->amount,
-            'direction' => $this->transactionType === 'expense'
-                ? TransactionDirection::Debit
-                : TransactionDirection::Credit,
-            'description' => $parsed->description,
-            'post_date' => $this->date,
-            'notes' => $this->notes !== '' ? $this->notes : null,
-        ]);
+        $this->applyCategoriseMatching($child);
 
         return true;
     }
@@ -614,14 +614,21 @@ final class TransactionModal extends Component
             }
         });
 
-        // Generate and apply the categorisation rule after the plan transaction
-        // commits: it can touch many transactions, so keeping it outside avoids
-        // holding row locks for the length of an interactive modal save.
-        if ($isPlainSource && $this->categoriseMatching && $this->categoryId !== null) {
-            app(CategoryRuleGenerator::class)->generateAndApply($transaction, $this->categoryId, $this->categoriseMatchValue);
-        }
+        $this->applyCategoriseMatching($transaction);
 
         return true;
+    }
+
+    private function applyCategoriseMatching(Transaction $source): void
+    {
+        if (! $this->categoriseMatching
+            || $this->categoryId === null
+            || $this->transactionType === 'transfer'
+            || $source->transfer_pair_id !== null) {
+            return;
+        }
+
+        app(CategoryRuleGenerator::class)->generateAndApply($source, $this->categoryId, $this->categoriseMatchValue);
     }
 
     /**

--- a/resources/views/livewire/transaction-modal.blade.php
+++ b/resources/views/livewire/transaction-modal.blade.php
@@ -165,7 +165,7 @@
                 :placeholder="__('No category')"
             />
 
-            @if($editingTransactionId && $mode === 'plan' && $transactionType !== 'transfer')
+            @if($editingTransactionId && $transactionType !== 'transfer')
                 <flux:field variant="inline">
                     <flux:checkbox wire:model.live="categoriseMatching"/>
                     <flux:label>{{ __('Also categorise matching transactions') }}</flux:label>

--- a/tests/Feature/Livewire/TransactionModalTest.php
+++ b/tests/Feature/Livewire/TransactionModalTest.php
@@ -3406,3 +3406,174 @@ test('a manual entry with no matching plan is left entered (unlinked)', function
     expect($tx)->not->toBeNull()
         ->and($tx->planned_transaction_id)->toBeNull();
 });
+
+test('editing a transaction with categorise-matching ticked creates a rule and categorises matching transactions', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $category = Category::factory()->create(['is_hidden' => false]);
+
+    $source = Transaction::factory()->for($user)->for($account)->manual()->create([
+        'merchant_name' => 'Netflix',
+        'amount' => 1599,
+        'direction' => TransactionDirection::Debit,
+        'description' => 'NETFLIX',
+        'post_date' => '2026-03-15',
+        'category_id' => null,
+    ]);
+    $sibling = Transaction::factory()->for($user)->for($account)->manual()->create([
+        'merchant_name' => 'Netflix',
+        'amount' => 1599,
+        'direction' => TransactionDirection::Debit,
+        'description' => 'NETFLIX',
+        'post_date' => '2026-02-15',
+        'category_id' => null,
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('edit-transaction', id: $source->id)
+        ->set('descriptionInput', '15.99 NETFLIX')
+        ->set('categoryId', $category->id)
+        ->set('categoriseMatching', true)
+        ->call('save')
+        ->assertHasNoErrors()
+        ->assertSet('showModal', false);
+
+    $rule = UserRule::query()->where('user_id', $user->id)->first();
+
+    expect($rule)->not->toBeNull()
+        ->and($rule->is_auto_apply)->toBeTrue()
+        ->and($rule->actions)->toBe([['type' => 'set_category', 'value' => (string) $category->id]]);
+
+    $child = Transaction::query()
+        ->where('parent_transaction_id', $source->id)
+        ->first();
+
+    expect($child)->not->toBeNull()
+        ->and($child->category_id)->toBe($category->id)
+        ->and($sibling->fresh()->category_id)->toBe($category->id);
+});
+
+test('editing a transaction without ticking categorise-matching creates no rule and leaves siblings untouched', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $category = Category::factory()->create(['is_hidden' => false]);
+
+    $source = Transaction::factory()->for($user)->for($account)->manual()->create([
+        'merchant_name' => 'Netflix',
+        'amount' => 1599,
+        'direction' => TransactionDirection::Debit,
+        'description' => 'NETFLIX',
+        'post_date' => '2026-03-15',
+        'category_id' => null,
+    ]);
+    $sibling = Transaction::factory()->for($user)->for($account)->manual()->create([
+        'merchant_name' => 'Netflix',
+        'amount' => 1599,
+        'direction' => TransactionDirection::Debit,
+        'description' => 'NETFLIX',
+        'post_date' => '2026-02-15',
+        'category_id' => null,
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('edit-transaction', id: $source->id)
+        ->set('descriptionInput', '15.99 NETFLIX')
+        ->set('categoryId', $category->id)
+        ->call('save')
+        ->assertHasNoErrors()
+        ->assertSet('showModal', false);
+
+    expect(UserRule::query()->where('user_id', $user->id)->count())->toBe(0)
+        ->and($sibling->fresh()->category_id)->toBeNull();
+});
+
+test('editing a basiq transaction with categorise-matching ticked creates a rule and categorises matching transactions', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $category = Category::factory()->create(['is_hidden' => false]);
+
+    $source = Transaction::factory()->for($user)->for($account)->fromBasiq()->create([
+        'merchant_name' => 'Netflix',
+        'amount' => 1599,
+        'direction' => TransactionDirection::Debit,
+        'post_date' => '2026-03-15',
+        'category_id' => null,
+    ]);
+    $sibling = Transaction::factory()->for($user)->for($account)->fromBasiq()->create([
+        'merchant_name' => 'Netflix',
+        'amount' => 1599,
+        'direction' => TransactionDirection::Debit,
+        'post_date' => '2026-02-15',
+        'category_id' => null,
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('edit-transaction', id: $source->id)
+        ->set('categoryId', $category->id)
+        ->set('categoriseMatching', true)
+        ->set('categoriseMatchValue', '')
+        ->call('save')
+        ->assertHasNoErrors()
+        ->assertSet('showModal', false);
+
+    $rule = UserRule::query()->where('user_id', $user->id)->first();
+
+    expect($rule)->not->toBeNull()
+        ->and($rule->triggers[0])->toBe([
+            'field' => 'merchant_name',
+            'operator' => 'equals',
+            'value' => 'Netflix',
+        ])
+        ->and($sibling->fresh()->category_id)->toBe($category->id);
+});
+
+test('the categorise-matching checkbox shows when editing in enter mode and not when adding', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+
+    $source = Transaction::factory()->for($user)->for($account)->manual()->create([
+        'merchant_name' => 'Netflix',
+        'amount' => 1599,
+        'direction' => TransactionDirection::Debit,
+        'description' => 'NETFLIX',
+        'post_date' => '2026-03-15',
+        'category_id' => null,
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('edit-transaction', id: $source->id)
+        ->assertSee('Also categorise matching transactions');
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('open-transaction-modal', date: '2026-03-15')
+        ->assertDontSee('Also categorise matching transactions');
+
+    $debit = Transaction::factory()->for($user)->create([
+        'account_id' => $account->id,
+        'amount' => 10000,
+        'direction' => TransactionDirection::Debit,
+        'description' => 'original',
+        'post_date' => '2026-03-15',
+        'source' => TransactionSource::Manual,
+    ]);
+    $credit = Transaction::factory()->for($user)->create([
+        'account_id' => Account::factory()->for($user)->create()->id,
+        'amount' => 10000,
+        'direction' => TransactionDirection::Credit,
+        'description' => 'original',
+        'post_date' => '2026-03-15',
+        'source' => TransactionSource::Manual,
+        'transfer_pair_id' => $debit->id,
+    ]);
+    $debit->update(['transfer_pair_id' => $credit->id]);
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('edit-transaction', id: $debit->id)
+        ->assertDontSee('Also categorise matching transactions');
+});

--- a/tests/Feature/Services/CategoryRuleGeneratorTest.php
+++ b/tests/Feature/Services/CategoryRuleGeneratorTest.php
@@ -200,3 +200,17 @@ test('suggestMatchValue prefers the merchant name, else the longest description 
     expect($generator->suggestMatchValue($withMerchant))->toBe('Netflix')
         ->and($generator->suggestMatchValue($csvOnly))->toBe('NETFLIX.COM');
 });
+
+test('it suggests the distinctive payee token for an external transfer description', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+
+    $source = Transaction::factory()->for($user)->for($account)->manual()->create([
+        'merchant_name' => null,
+        'clean_description' => null,
+        'description' => 'Ext Tfr  - NET#4789778169 to 554078 Sekisui House MAST WBC - 260 Queen Street',
+        'direction' => TransactionDirection::Debit,
+    ]);
+
+    expect(app(CategoryRuleGenerator::class)->suggestMatchValue($source))->toBe('SEKISUI');
+});


### PR DESCRIPTION
## Problem

The "Also categorise matching transactions" checkbox only appeared when converting a transaction to a plan (`mode === 'plan'`). Editing an ordinary transaction and setting its category — the most common categorisation moment, e.g. an uncategorised rent debit — offered no way to apply the category to all matching transactions.

## Solution

Show the same opt-in checkbox when editing any non-transfer transaction (enter mode, manual/CSV and Basiq), and fire the existing `CategoryRuleGenerator::generateAndApply()` from `updateTransaction()` when ticked.

- Blade: drop the `mode === 'plan'` gate on the checkbox; it stays edit-only and transfer-excluded.
- `TransactionModal`: extract the rule callsite into a private `applyCategoriseMatching()` helper that reproduces the `isPlainSource` guard, and call it from both `convertEnteredToPlanned()` (behaviour unchanged) and `updateTransaction()`. The helper receives the newly created child, so the rule is named and triggered from the post-edit state.

## On the user's suggestion

The suggestion is correct, and the rule-based implementation already in the codebase is *better* than a one-off bulk `UPDATE`: `generateAndApply` creates a persistent `is_auto_apply` UserRule, so past siblings are categorised immediately **and** future imports of the same merchant are auto-categorised by the normal rules pipeline. For the rent example, `suggestMatchValue()` yields `SEKISUI` (MerchantSignature drops `NET#4789778169`, `554078`, `260`; longest non-generic token wins), which matches all rent transactions and is user-editable in the modal before saving.

## Verification

- `op lint.dirty` → pass
- `op analyse` → No errors
- `op test.filter TransactionModalTest` → 144 passed (baseline 140 + 4 new)
- `op test.filter CategoryRuleGeneratorTest` → 7 passed (baseline 6 + 1 new)

New coverage: ticked edit creates an auto-apply rule and categorises siblings; unticked edit changes nothing; Basiq edit with an empty match value uses the `merchant_name equals` fallback; checkbox visibility (enter-mode edit yes, add no, transfer no); and the `SEKISUI` suggestion pin.

Refs #338
