### PR TITLE
feat(#340): scan Gmail for transaction-matching emails and link them

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -67,6 +67,8 @@ BASIQ_API_KEY=
 BASIQ_CONSENT_URL=
 BASIQ_WEBHOOK_SECRET=
 BASIQ_SEED_USER_ID=
+GMAIL_USERNAME=
+GMAIL_APP_PASSWORD=
 
 # Recurring transaction auto-detection (off while the import/reconcile flow is stabilised)
 BUDGET_RECURRING_DETECTION=false

--- a/app/Contracts/GmailServiceContract.php
+++ b/app/Contracts/GmailServiceContract.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Contracts;
+
+use App\DTOs\EmailSearchResult;
+use App\Exceptions\GmailSearchException;
+use App\Models\Transaction;
+use Illuminate\Support\Collection;
+
+interface GmailServiceContract
+{
+    public function isConfigured(): bool;
+
+    /**
+     * Search Gmail for emails plausibly matching the transaction.
+     *
+     * @return Collection<int, EmailSearchResult> ranked by date proximity to post_date
+     *
+     * @throws GmailSearchException
+     */
+    public function searchForTransaction(Transaction $transaction): Collection;
+}

--- a/app/DTOs/EmailSearchResult.php
+++ b/app/DTOs/EmailSearchResult.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTOs;
+
+use Spatie\LaravelData\Dto;
+
+final class EmailSearchResult extends Dto
+{
+    public function __construct(
+        public readonly string $messageId,
+        public readonly string $subject,
+        public readonly ?string $fromName,
+        public readonly string $fromAddress,
+        public readonly ?string $date,
+        public readonly ?string $snippet,
+        public readonly string $gmailUrl,
+    ) {}
+
+    /**
+     * @return array{messageId: string, subject: string, fromName: ?string, fromAddress: string, date: ?string, snippet: ?string, gmailUrl: string}
+     */
+    public function toArray(): array
+    {
+        return [
+            'messageId' => $this->messageId,
+            'subject' => $this->subject,
+            'fromName' => $this->fromName,
+            'fromAddress' => $this->fromAddress,
+            'date' => $this->date,
+            'snippet' => $this->snippet,
+            'gmailUrl' => $this->gmailUrl,
+        ];
+    }
+}

--- a/app/Exceptions/GmailSearchException.php
+++ b/app/Exceptions/GmailSearchException.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exceptions;
+
+use RuntimeException;
+use Throwable;
+
+final class GmailSearchException extends RuntimeException
+{
+    public static function wrap(Throwable $e): self
+    {
+        return new self('Gmail search failed: '.$e->getMessage(), 0, $e);
+    }
+
+    public static function notConfigured(): self
+    {
+        return new self('Gmail is not configured. Set GMAIL_USERNAME and GMAIL_APP_PASSWORD.');
+    }
+}

--- a/app/Livewire/TransactionList.php
+++ b/app/Livewire/TransactionList.php
@@ -5,11 +5,16 @@ declare(strict_types=1);
 namespace App\Livewire;
 
 use App\Casts\MoneyCast;
+use App\Contracts\GmailServiceContract;
+use App\DTOs\EmailSearchResult;
 use App\Enums\TransactionDirection;
 use App\Enums\TransactionPeriod;
+use App\Exceptions\GmailSearchException;
 use App\Models\Account;
 use App\Models\Category;
 use App\Models\Transaction;
+use App\Models\TransactionEmail;
+use Illuminate\Support\Facades\Log;
 use Illuminate\View\View;
 use Livewire\Attributes\On;
 use Livewire\Attributes\Url;
@@ -61,6 +66,13 @@ final class TransactionList extends Component
     #[Url]
     public string $sortDir = 'desc';
 
+    public ?int $emailPanelTxnId = null;
+
+    /** @var list<array<string, mixed>> */
+    public array $emailResults = [];
+
+    public ?string $emailScanError = null;
+
     public function mount(): void
     {
         $this->restoreRememberedPeriod();
@@ -111,6 +123,75 @@ final class TransactionList extends Component
      */
     #[On('transaction-saved')]
     public function refreshList(): void {}
+
+    public function scanEmail(int $transactionId, GmailServiceContract $gmail): void
+    {
+        if ($this->emailPanelTxnId === $transactionId) {
+            $this->emailPanelTxnId = null;
+            $this->emailResults = [];
+            $this->emailScanError = null;
+
+            return;
+        }
+
+        $transaction = Transaction::query()
+            ->where('user_id', auth()->id())
+            ->findOrFail($transactionId);
+
+        $this->emailPanelTxnId = $transactionId;
+        $this->emailResults = [];
+        $this->emailScanError = null;
+
+        try {
+            $this->emailResults = $gmail->searchForTransaction($transaction)
+                ->map(fn (EmailSearchResult $result): array => $result->toArray())
+                ->all();
+        } catch (GmailSearchException $e) {
+            Log::warning('Gmail scan failed', [
+                'transaction_id' => $transactionId,
+                'error' => $e->getMessage(),
+            ]);
+
+            $this->emailScanError = 'Could not search Gmail — check the GMAIL_* credentials and connection.';
+        }
+    }
+
+    public function linkEmail(int $transactionId, int $index): void
+    {
+        if ($this->emailPanelTxnId !== $transactionId || ! isset($this->emailResults[$index])) {
+            return;
+        }
+
+        $transaction = Transaction::query()
+            ->where('user_id', auth()->id())
+            ->findOrFail($transactionId);
+
+        $result = $this->emailResults[$index];
+
+        TransactionEmail::query()->firstOrCreate(
+            [
+                'transaction_id' => $transaction->id,
+                'gmail_message_id' => $result['messageId'],
+            ],
+            [
+                'user_id' => auth()->id(),
+                'subject' => $result['subject'],
+                'from_name' => $result['fromName'],
+                'from_address' => $result['fromAddress'],
+                'email_date' => $result['date'],
+                'snippet' => $result['snippet'],
+                'gmail_url' => $result['gmailUrl'],
+            ],
+        );
+    }
+
+    public function unlinkEmail(int $emailId): void
+    {
+        TransactionEmail::query()
+            ->where('user_id', auth()->id())
+            ->whereKey($emailId)
+            ->delete();
+    }
 
     public function updatedDirection(): void
     {
@@ -201,6 +282,7 @@ final class TransactionList extends Component
             ->when($dates['start'], fn ($q, $s) => $q->where('post_date', '>=', $s))
             ->when($dates['end'], fn ($q, $e) => $q->where('post_date', '<=', $e))
             ->withRelations()
+            ->with('emails')
             ->orderBy(
                 in_array($this->sortBy, self::SORTABLE_COLUMNS, true) ? $this->sortBy : 'post_date',
                 in_array($this->sortDir, ['asc', 'desc'], true) ? $this->sortDir : 'desc',
@@ -226,6 +308,7 @@ final class TransactionList extends Component
             'periodLabel' => $periodEnum->label(),
             'hasPayCycle' => auth()->user()->hasPayCycleConfigured(),
             'showCustomRange' => $periodEnum === TransactionPeriod::Custom,
+            'gmailEnabled' => app(GmailServiceContract::class)->isConfigured(),
         ]);
     }
 

--- a/app/Livewire/TransactionList.php
+++ b/app/Livewire/TransactionList.php
@@ -17,6 +17,7 @@ use App\Models\TransactionEmail;
 use App\Services\GmailService;
 use Illuminate\Support\Facades\Log;
 use Illuminate\View\View;
+use Livewire\Attributes\Locked;
 use Livewire\Attributes\On;
 use Livewire\Attributes\Url;
 use Livewire\Component;
@@ -67,11 +68,14 @@ final class TransactionList extends Component
     #[Url]
     public string $sortDir = 'desc';
 
+    #[Locked]
     public ?int $emailPanelTxnId = null;
 
     /** @var list<array<string, mixed>> */
+    #[Locked]
     public array $emailResults = [];
 
+    #[Locked]
     public ?string $emailScanError = null;
 
     public function mount(): void

--- a/app/Livewire/TransactionList.php
+++ b/app/Livewire/TransactionList.php
@@ -14,6 +14,7 @@ use App\Models\Account;
 use App\Models\Category;
 use App\Models\Transaction;
 use App\Models\TransactionEmail;
+use App\Services\GmailService;
 use Illuminate\Support\Facades\Log;
 use Illuminate\View\View;
 use Livewire\Attributes\On;
@@ -162,25 +163,33 @@ final class TransactionList extends Component
             return;
         }
 
+        $result = $this->emailResults[$index];
+
+        $messageId = $result['messageId'] ?? null;
+
+        if (! is_string($messageId) || mb_trim($messageId) === '') {
+            return;
+        }
+
+        $messageId = mb_trim($messageId);
+
         $transaction = Transaction::query()
             ->where('user_id', auth()->id())
             ->findOrFail($transactionId);
 
-        $result = $this->emailResults[$index];
-
         TransactionEmail::query()->firstOrCreate(
             [
                 'transaction_id' => $transaction->id,
-                'gmail_message_id' => $result['messageId'],
+                'gmail_message_id' => $messageId,
             ],
             [
                 'user_id' => auth()->id(),
-                'subject' => $result['subject'],
-                'from_name' => $result['fromName'],
-                'from_address' => $result['fromAddress'],
-                'email_date' => $result['date'],
-                'snippet' => $result['snippet'],
-                'gmail_url' => $result['gmailUrl'],
+                'subject' => is_string($result['subject'] ?? null) ? $result['subject'] : '',
+                'from_name' => is_string($result['fromName'] ?? null) ? $result['fromName'] : null,
+                'from_address' => is_string($result['fromAddress'] ?? null) ? $result['fromAddress'] : '',
+                'email_date' => is_string($result['date'] ?? null) ? $result['date'] : null,
+                'snippet' => is_string($result['snippet'] ?? null) ? $result['snippet'] : null,
+                'gmail_url' => GmailService::deepLink($messageId),
             ],
         );
     }

--- a/app/Models/Transaction.php
+++ b/app/Models/Transaction.php
@@ -164,6 +164,12 @@ final class Transaction extends Model
         return $this->hasMany(self::class, 'parent_transaction_id');
     }
 
+    /** @return HasMany<TransactionEmail, $this> */
+    public function emails(): HasMany
+    {
+        return $this->hasMany(TransactionEmail::class);
+    }
+
     /** @return BelongsTo<self, $this> */
     public function foldedInto(): BelongsTo
     {

--- a/app/Models/TransactionEmail.php
+++ b/app/Models/TransactionEmail.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Carbon\CarbonImmutable;
+use Database\Factories\TransactionEmailFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * @property int $id
+ * @property int $user_id
+ * @property int $transaction_id
+ * @property string $gmail_message_id
+ * @property string $subject
+ * @property string|null $from_name
+ * @property string $from_address
+ * @property CarbonImmutable|null $email_date
+ * @property string|null $snippet
+ * @property string $gmail_url
+ * @property CarbonImmutable $created_at
+ * @property CarbonImmutable $updated_at
+ */
+final class TransactionEmail extends Model
+{
+    /** @use HasFactory<TransactionEmailFactory> */
+    use HasFactory;
+
+    /**
+     * @var list<string>
+     */
+    protected $fillable = [
+        'user_id',
+        'transaction_id',
+        'gmail_message_id',
+        'subject',
+        'from_name',
+        'from_address',
+        'email_date',
+        'snippet',
+        'gmail_url',
+    ];
+
+    /** @return BelongsTo<User, $this> */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /** @return BelongsTo<Transaction, $this> */
+    public function transaction(): BelongsTo
+    {
+        return $this->belongsTo(Transaction::class);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'email_date' => 'datetime',
+        ];
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -6,8 +6,11 @@ namespace App\Providers;
 
 use App\Contracts\BasiqServiceContract;
 use App\Contracts\GitHubServiceContract;
+use App\Contracts\GmailServiceContract;
 use App\Services\BasiqService;
+use App\Services\CategoryRuleGenerator;
 use App\Services\GitHubService;
+use App\Services\GmailService;
 use App\Services\PipelineStages\IdentifyPrimaryAccountStage;
 use App\Services\PipelineStages\IdentifyRecurringTransactionsStage;
 use App\Services\PipelineStages\MatchPlannedTransactionsStage;
@@ -35,6 +38,13 @@ final class AppServiceProvider extends ServiceProvider
         ));
 
         $this->app->alias(BasiqServiceContract::class, BasiqService::class);
+
+        $this->app->singleton(
+            GmailServiceContract::class,
+            fn (): GmailService => new GmailService(app(CategoryRuleGenerator::class)),
+        );
+
+        $this->app->alias(GmailServiceContract::class, GmailService::class);
 
         $this->app->singleton(GitHubServiceContract::class, fn (): GitHubService => new GitHubService(
             token: (string) config('services.github.token'),

--- a/app/Services/GmailService.php
+++ b/app/Services/GmailService.php
@@ -28,6 +28,25 @@ final class GmailService implements GmailServiceContract
     private const int DATE_WINDOW_DAYS = 7;
 
     /**
+     * Payment-processor / BNPL signatures. When a description matches one of
+     * these keywords the bank line names the processor, not the payee, so the
+     * receipt email arrives *from* the processor — searching `from:<sender>`
+     * finds it where the leftover description token (e.g. "PAYIN4") never would.
+     *
+     * @var array<string, string>
+     */
+    private const array PROVIDER_SENDERS = [
+        'afterpay' => 'afterpay',
+        'paypal' => 'paypal',
+        'pypl' => 'paypal',
+        'payin4' => 'paypal',
+        'klarna' => 'klarna',
+        'zippay' => 'zip',
+        'zip.co' => 'zip',
+        'humm' => 'humm',
+    ];
+
+    /**
      * Gmail folders searched, in priority order. All Mail covers archived
      * receipts; INBOX is the fallback for non-English locales / hidden folders.
      *
@@ -50,10 +69,7 @@ final class GmailService implements GmailServiceContract
      */
     public function buildQuery(Transaction $transaction, bool $withAmount = true): string
     {
-        $merchant = str_replace('"', ' ', $this->ruleGenerator->suggestMatchValue($transaction));
-        $merchant = mb_trim((string) preg_replace('/\s+/', ' ', $merchant));
-
-        $parts = [$merchant];
+        $parts = [$this->searchSubject($transaction)];
 
         if ($withAmount) {
             $parts[] = number_format(abs($transaction->amount) / 100, 2, '.', '');
@@ -190,5 +206,37 @@ final class GmailService implements GmailServiceContract
         $body = mb_trim((string) preg_replace('/\s+/', ' ', $body));
 
         return $body === '' ? null : Str::limit($body, 200);
+    }
+
+    /**
+     * The primary search term: a `from:<sender>` filter when the description
+     * names a payment processor, otherwise the sanitised merchant token. The
+     * value is folded into the double-quote-wrapped X-GM-RAW string, so it
+     * must never contain a double quote.
+     */
+    private function searchSubject(Transaction $transaction): string
+    {
+        $sender = $this->providerSender($transaction->description);
+
+        if ($sender !== null) {
+            return $sender;
+        }
+
+        $merchant = str_replace('"', ' ', $this->ruleGenerator->suggestMatchValue($transaction));
+
+        return mb_trim((string) preg_replace('/\s+/', ' ', $merchant));
+    }
+
+    private function providerSender(string $description): ?string
+    {
+        $haystack = mb_strtolower($description);
+
+        foreach (self::PROVIDER_SENDERS as $needle => $sender) {
+            if (str_contains($haystack, $needle)) {
+                return 'from:'.$sender;
+            }
+        }
+
+        return null;
     }
 }

--- a/app/Services/GmailService.php
+++ b/app/Services/GmailService.php
@@ -87,6 +87,16 @@ final class GmailService implements GmailServiceContract
         return $highlights === [] ? $lead : implode(' · ', $highlights).' — '.$lead;
     }
 
+    /**
+     * The Gmail deep link that opens the exact message by its RFC822 id. The
+     * id is URL-encoded, so the result is always a safe mail.google.com URL
+     * even for an untrusted (client-hydrated) message id.
+     */
+    public static function deepLink(string $messageId): string
+    {
+        return 'https://mail.google.com/mail/u/0/#search/rfc822msgid:'.rawurlencode($messageId);
+    }
+
     public function isConfigured(): bool
     {
         return (string) config('imap.accounts.gmail.username') !== ''
@@ -237,7 +247,7 @@ final class GmailService implements GmailServiceContract
                 fromAddress: $fromAddress,
                 date: $date?->toIso8601String(),
                 snippet: $this->snippet($message),
-                gmailUrl: 'https://mail.google.com/mail/u/0/#search/rfc822msgid:'.rawurlencode($messageId),
+                gmailUrl: self::deepLink($messageId),
             ),
             'date' => $date,
         ];

--- a/app/Services/GmailService.php
+++ b/app/Services/GmailService.php
@@ -57,10 +57,12 @@ final class GmailService implements GmailServiceContract
     public function __construct(private readonly CategoryRuleGenerator $ruleGenerator) {}
 
     /**
-     * Build a short readable snippet from an email's text and HTML bodies.
-     * Prefers the plain-text part; when it is empty, converts the HTML —
-     * dropping style/script/head blocks whole (contents included) before
-     * stripping tags, so CSS such as @font-face rules never leaks in.
+     * Build a readable snippet from an email's text and HTML bodies. Prefers
+     * the plain-text part; when empty, converts the HTML — dropping
+     * style/script/head blocks whole (contents included) before stripping
+     * tags, so CSS such as @font-face rules never leaks in. Leads with the
+     * seller and any payment-schedule amounts (the parts a BNPL receipt is
+     * linked for), followed by a short lead of body text for context.
      */
     public static function snippetFromBodies(?string $textBody, ?string $htmlBody): ?string
     {
@@ -68,13 +70,21 @@ final class GmailService implements GmailServiceContract
 
         if ($body === '') {
             $html = (string) preg_replace('#<(style|script|head)\b[^>]*>.*?</\1>#is', ' ', (string) $htmlBody);
-            $body = html_entity_decode(strip_tags($html), ENT_QUOTES | ENT_HTML5, 'UTF-8');
+            $html = (string) preg_replace('/<[^>]+>/', ' ', $html);
+            $body = html_entity_decode($html, ENT_QUOTES | ENT_HTML5, 'UTF-8');
         }
 
         $body = str_replace("\u{00A0}", ' ', $body);
         $body = mb_trim((string) preg_replace('/\s+/', ' ', $body));
 
-        return $body === '' ? null : Str::limit($body, 200);
+        if ($body === '') {
+            return null;
+        }
+
+        $highlights = self::paymentHighlights($body);
+        $lead = Str::limit($body, 180);
+
+        return $highlights === [] ? $lead : implode(' · ', $highlights).' — '.$lead;
     }
 
     public function isConfigured(): bool
@@ -127,6 +137,34 @@ final class GmailService implements GmailServiceContract
         } finally {
             $client->disconnect();
         }
+    }
+
+    /**
+     * Pull the seller and any "amount on date" payment-schedule lines out of a
+     * cleaned receipt body. Returns an empty list for non-receipt emails, in
+     * which case the caller falls back to a plain lead snippet.
+     *
+     * @return list<string>
+     */
+    private static function paymentHighlights(string $text): array
+    {
+        $highlights = [];
+
+        if (preg_match('/\bSeller\b[:\s]+(.+?)(?=\s+(?:Current balance|Loan reference|Posted on|Payment amount|Payment type|Payment method)\b|$)/i', $text, $m) === 1) {
+            $seller = mb_trim($m[1]);
+
+            if ($seller !== '') {
+                $highlights[] = 'Seller: '.$seller;
+            }
+        }
+
+        if (preg_match_all('/\$\s?[\d,]+\.\d{2}\s*AUD\s+(?:will\s+be\s+charged\s+)?on\s+\d{1,2}\s+[A-Za-z]+\s+\d{4}/i', $text, $matches) >= 1) {
+            foreach (array_slice(array_values(array_unique($matches[0])), 0, 4) as $line) {
+                $highlights[] = mb_trim((string) preg_replace('/\s+/', ' ', $line));
+            }
+        }
+
+        return $highlights;
     }
 
     private function resolveFolder(ImapClient $client): Folder

--- a/app/Services/GmailService.php
+++ b/app/Services/GmailService.php
@@ -56,6 +56,27 @@ final class GmailService implements GmailServiceContract
 
     public function __construct(private readonly CategoryRuleGenerator $ruleGenerator) {}
 
+    /**
+     * Build a short readable snippet from an email's text and HTML bodies.
+     * Prefers the plain-text part; when it is empty, converts the HTML —
+     * dropping style/script/head blocks whole (contents included) before
+     * stripping tags, so CSS such as @font-face rules never leaks in.
+     */
+    public static function snippetFromBodies(?string $textBody, ?string $htmlBody): ?string
+    {
+        $body = mb_trim((string) $textBody);
+
+        if ($body === '') {
+            $html = (string) preg_replace('#<(style|script|head)\b[^>]*>.*?</\1>#is', ' ', (string) $htmlBody);
+            $body = html_entity_decode(strip_tags($html), ENT_QUOTES | ENT_HTML5, 'UTF-8');
+        }
+
+        $body = str_replace("\u{00A0}", ' ', $body);
+        $body = mb_trim((string) preg_replace('/\s+/', ' ', $body));
+
+        return $body === '' ? null : Str::limit($body, 200);
+    }
+
     public function isConfigured(): bool
     {
         return (string) config('imap.accounts.gmail.username') !== ''
@@ -197,15 +218,7 @@ final class GmailService implements GmailServiceContract
 
     private function snippet(Message $message): ?string
     {
-        $body = $message->getTextBody();
-
-        if ($body === '') {
-            $body = strip_tags($message->getHTMLBody());
-        }
-
-        $body = mb_trim((string) preg_replace('/\s+/', ' ', $body));
-
-        return $body === '' ? null : Str::limit($body, 200);
+        return self::snippetFromBodies($message->getTextBody(), $message->getHTMLBody());
     }
 
     /**

--- a/app/Services/GmailService.php
+++ b/app/Services/GmailService.php
@@ -1,0 +1,194 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Contracts\GmailServiceContract;
+use App\DTOs\EmailSearchResult;
+use App\Exceptions\GmailSearchException;
+use App\Models\Transaction;
+use Carbon\CarbonImmutable;
+use Carbon\CarbonInterface;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+use RuntimeException;
+use Throwable;
+use Webklex\IMAP\Facades\Client;
+use Webklex\PHPIMAP\Address;
+use Webklex\PHPIMAP\Client as ImapClient;
+use Webklex\PHPIMAP\Folder;
+use Webklex\PHPIMAP\Message;
+use Webklex\PHPIMAP\Support\MessageCollection;
+
+final class GmailService implements GmailServiceContract
+{
+    private const int MAX_RESULTS = 10;
+
+    private const int DATE_WINDOW_DAYS = 7;
+
+    /**
+     * Gmail folders searched, in priority order. All Mail covers archived
+     * receipts; INBOX is the fallback for non-English locales / hidden folders.
+     *
+     * @var list<string>
+     */
+    private const array FOLDER_PATHS = ['[Gmail]/All Mail', 'INBOX'];
+
+    public function __construct(private readonly CategoryRuleGenerator $ruleGenerator) {}
+
+    public function isConfigured(): bool
+    {
+        return (string) config('imap.accounts.gmail.username') !== ''
+            && (string) config('imap.accounts.gmail.password') !== '';
+    }
+
+    /**
+     * Build the Gmail X-GM-RAW search string for a transaction. Public so the
+     * exact query is unit-testable. The value is wrapped in double quotes by
+     * the IMAP library, so it must never itself contain a double quote.
+     */
+    public function buildQuery(Transaction $transaction, bool $withAmount = true): string
+    {
+        $merchant = str_replace('"', ' ', $this->ruleGenerator->suggestMatchValue($transaction));
+        $merchant = mb_trim((string) preg_replace('/\s+/', ' ', $merchant));
+
+        $parts = [$merchant];
+
+        if ($withAmount) {
+            $parts[] = number_format(abs($transaction->amount) / 100, 2, '.', '');
+        }
+
+        $postDate = $transaction->post_date;
+        $parts[] = 'after:'.$postDate->subDays(self::DATE_WINDOW_DAYS)->format('Y/m/d');
+        $parts[] = 'before:'.$postDate->addDays(self::DATE_WINDOW_DAYS + 1)->format('Y/m/d');
+
+        return implode(' ', array_filter($parts, static fn (string $part): bool => $part !== ''));
+    }
+
+    public function searchForTransaction(Transaction $transaction): Collection
+    {
+        if (! $this->isConfigured()) {
+            throw GmailSearchException::notConfigured();
+        }
+
+        $client = Client::account('gmail');
+
+        try {
+            $client->connect();
+            $folder = $this->resolveFolder($client);
+
+            $messages = $this->runQuery($folder, $this->buildQuery($transaction));
+
+            if ($messages->isEmpty()) {
+                $messages = $this->runQuery($folder, $this->buildQuery($transaction, withAmount: false));
+            }
+
+            return $this->rank($messages, $transaction->post_date);
+        } catch (Throwable $e) {
+            throw GmailSearchException::wrap($e);
+        } finally {
+            $client->disconnect();
+        }
+    }
+
+    private function resolveFolder(ImapClient $client): Folder
+    {
+        foreach (self::FOLDER_PATHS as $path) {
+            try {
+                $folder = $client->getFolderByPath($path);
+
+                if ($folder instanceof Folder) {
+                    return $folder;
+                }
+            } catch (Throwable) {
+                // Try the next candidate folder.
+            }
+        }
+
+        throw new RuntimeException('No searchable Gmail folder found ('.implode(', ', self::FOLDER_PATHS).').');
+    }
+
+    private function runQuery(Folder $folder, string $query): MessageCollection
+    {
+        return $folder->query()
+            ->where('CUSTOM X-GM-RAW', $query)
+            ->limit(self::MAX_RESULTS)
+            ->get();
+    }
+
+    /**
+     * @return Collection<int, EmailSearchResult>
+     */
+    private function rank(MessageCollection $messages, CarbonImmutable $postDate): Collection
+    {
+        return $messages
+            ->map(fn (Message $message): ?array => $this->mapMessage($message))
+            ->filter()
+            ->map(static function (array $row) use ($postDate): array {
+                $row['proximity'] = $row['date'] instanceof CarbonImmutable
+                    ? abs($row['date']->diffInSeconds($postDate))
+                    : PHP_INT_MAX;
+
+                return $row;
+            })
+            ->sortBy('proximity')
+            ->map(static fn (array $row): EmailSearchResult => $row['result'])
+            ->values();
+    }
+
+    /**
+     * @return array{result: EmailSearchResult, date: ?CarbonImmutable}|null
+     */
+    private function mapMessage(Message $message): ?array
+    {
+        $messageId = mb_trim((string) $message->getMessageId(), "<> \t\n\r\0\x0B");
+
+        if ($messageId === '') {
+            return null;
+        }
+
+        $from = $message->getFrom()->first();
+        $fromName = $from instanceof Address && $from->personal !== '' ? $from->personal : null;
+        $fromAddress = $from instanceof Address ? $from->mail : '';
+
+        $date = $this->messageDate($message);
+
+        return [
+            'result' => new EmailSearchResult(
+                messageId: $messageId,
+                subject: (string) $message->getSubject(),
+                fromName: $fromName,
+                fromAddress: $fromAddress,
+                date: $date?->toIso8601String(),
+                snippet: $this->snippet($message),
+                gmailUrl: 'https://mail.google.com/mail/u/0/#search/rfc822msgid:'.rawurlencode($messageId),
+            ),
+            'date' => $date,
+        ];
+    }
+
+    private function messageDate(Message $message): ?CarbonImmutable
+    {
+        $raw = $message->getDate()->first();
+
+        if ($raw instanceof CarbonInterface) {
+            return CarbonImmutable::instance($raw);
+        }
+
+        return null;
+    }
+
+    private function snippet(Message $message): ?string
+    {
+        $body = $message->getTextBody();
+
+        if ($body === '') {
+            $body = strip_tags($message->getHTMLBody());
+        }
+
+        $body = mb_trim((string) preg_replace('/\s+/', ' ', $body));
+
+        return $body === '' ? null : Str::limit($body, 200);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
     "livewire/flux": "^2.13.2",
     "livewire/livewire": "^4.2.4",
     "spatie/laravel-data": "^4.21",
-    "spatie/laravel-ray": "^1.43.7"
+    "spatie/laravel-ray": "^1.43.7",
+    "webklex/laravel-imap": "^6.2"
   },
   "require-dev": {
     "fakerphp/faker": "^1.24.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8f48324776ebbacf4c14fa98f863e6c0",
+    "content-hash": "c4673f1f765781a8b6958ba09add6deb",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -8121,6 +8121,164 @@
                 }
             ],
             "time": "2024-11-21T01:49:47+00:00"
+        },
+        {
+            "name": "webklex/laravel-imap",
+            "version": "6.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Webklex/laravel-imap.git",
+                "reference": "57609df58c2f4ef625e4d90a47d8615cfb15f925"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Webklex/laravel-imap/zipball/57609df58c2f4ef625e4d90a47d8615cfb15f925",
+                "reference": "57609df58c2f4ef625e4d90a47d8615cfb15f925",
+                "shasum": ""
+            },
+            "require": {
+                "laravel/framework": ">=6.0.0",
+                "php": "^8.0.2",
+                "webklex/php-imap": "^6.2.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "Client": "Webklex\\IMAP\\Facades\\Client"
+                    },
+                    "providers": [
+                        "Webklex\\IMAP\\Providers\\LaravelServiceProvider"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webklex\\IMAP\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Malte Goldenbaum",
+                    "email": "github@webklex.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Laravel IMAP client",
+            "homepage": "https://github.com/webklex/laravel-imap",
+            "keywords": [
+                "idle",
+                "imap",
+                "laravel",
+                "laravel-imap",
+                "mail",
+                "oauth",
+                "pop3",
+                "webklex"
+            ],
+            "support": {
+                "issues": "https://github.com/Webklex/laravel-imap/issues",
+                "source": "https://github.com/Webklex/laravel-imap/tree/6.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.buymeacoffee.com/webklex",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://ko-fi.com/webklex",
+                    "type": "ko_fi"
+                }
+            ],
+            "time": "2025-04-25T06:06:46+00:00"
+        },
+        {
+            "name": "webklex/php-imap",
+            "version": "6.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Webklex/php-imap.git",
+                "reference": "6b8ef85d621bbbaf52741b00cca8e9237e2b2e05"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Webklex/php-imap/zipball/6b8ef85d621bbbaf52741b00cca8e9237e2b2e05",
+                "reference": "6b8ef85d621bbbaf52741b00cca8e9237e2b2e05",
+                "shasum": ""
+            },
+            "require": {
+                "ext-fileinfo": "*",
+                "ext-iconv": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-openssl": "*",
+                "ext-zip": "*",
+                "illuminate/pagination": ">=5.0.0",
+                "nesbot/carbon": "^2.62.1|^3.2.4",
+                "php": "^8.0.2",
+                "symfony/http-foundation": ">=2.8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5.10"
+            },
+            "suggest": {
+                "symfony/mime": "Recomended for better extension support",
+                "symfony/var-dumper": "Usefull tool for debugging"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webklex\\PHPIMAP\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Malte Goldenbaum",
+                    "email": "github@webklex.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "PHP IMAP client",
+            "homepage": "https://github.com/webklex/php-imap",
+            "keywords": [
+                "imap",
+                "mail",
+                "php-imap",
+                "pop3",
+                "webklex"
+            ],
+            "support": {
+                "issues": "https://github.com/Webklex/php-imap/issues",
+                "source": "https://github.com/Webklex/php-imap/tree/6.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.buymeacoffee.com/webklex",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://ko-fi.com/webklex",
+                    "type": "ko_fi"
+                }
+            ],
+            "time": "2025-04-25T06:02:37+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/config/imap.php
+++ b/config/imap.php
@@ -1,0 +1,218 @@
+<?php
+
+declare(strict_types=1);
+/*
+* File:     imap.php
+* Category: config
+* Author:   M. Goldenbaum
+* Created:  24.09.16 22:36
+* Updated:  -
+*
+* Description:
+*  -
+*/
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | IMAP default account
+    |--------------------------------------------------------------------------
+    |
+    | The default account identifier. It will be used as default for any missing account parameters.
+    | If however the default account is missing a parameter the package default will be used.
+    | Set to 'false' [boolean] to disable this functionality.
+    |
+    */
+    'default' => env('IMAP_DEFAULT_ACCOUNT', 'gmail'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default date format
+    |--------------------------------------------------------------------------
+    |
+    | The default date format is used to convert any given Carbon::class object into a valid date string.
+    | These are currently known working formats: "d-M-Y", "d-M-y", "d M y"
+    |
+    */
+    'date_format' => 'd-M-Y',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Available IMAP accounts
+    |--------------------------------------------------------------------------
+    |
+    | Please list all IMAP accounts which you are planning to use within the
+    | array below.
+    |
+    */
+    'accounts' => [
+
+        'gmail' => [
+            'host' => 'imap.gmail.com',
+            'port' => 993,
+            'protocol' => 'imap',
+            'encryption' => 'ssl',
+            'validate_cert' => true,
+            'username' => env('GMAIL_USERNAME'),
+            'password' => env('GMAIL_APP_PASSWORD'),
+            'authentication' => null,
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Available IMAP options
+    |--------------------------------------------------------------------------
+    |
+    | Available php imap config parameters are listed below
+    |   -Delimiter (optional):
+    |       This option is only used when calling $oClient->
+    |       You can use any supported char such as ".", "/", (...)
+    |   -Fetch option:
+    |       IMAP::FT_UID  - Message marked as read by fetching the body message
+    |       IMAP::FT_PEEK - Fetch the message without setting the "seen" flag
+    |   -Fetch sequence id:
+    |       IMAP::ST_UID  - Fetch message components using the message uid
+    |       IMAP::ST_MSGN - Fetch message components using the message number
+    |   -Body download option
+    |       Default TRUE
+    |   -Flag download option
+    |       Default TRUE
+    |   -Soft fail
+    |       Default FALSE - Set to TRUE if you want to ignore certain exception while fetching bulk messages
+    |   -RFC822
+    |       Default TRUE - Set to FALSE to prevent the usage of \imap_rfc822_parse_headers().
+    |                      See https://github.com/Webklex/php-imap/issues/115 for more information.
+    |   -Debug enable to trace communication traffic
+    |   -UID cache enable the UID cache
+    |   -Fallback date is used if the given message date could not be parsed
+    |   -Boundary regex used to detect message boundaries. If you are having problems with empty messages, missing
+    |       attachments or anything like this. Be advised that it likes to break which causes new problems..
+    |   -Message key identifier option
+    |       You can choose between the following:
+    |       'id'     - Use the MessageID as array key (default, might cause hickups with yahoo mail)
+    |       'number' - Use the message number as array key (isn't always unique and can cause some interesting behavior)
+    |       'list'   - Use the message list number as array key (incrementing integer (does not always start at 0 or 1)
+    |       'uid'    - Use the message uid as array key (isn't always unique and can cause some interesting behavior)
+    |   -Fetch order
+    |       'asc'  - Order all messages ascending (probably results in oldest first)
+    |       'desc' - Order all messages descending (probably results in newest first)
+    |   -Disposition types potentially considered an attachment
+    |       Default ['attachment', 'inline']
+    |   -Common folders
+    |       Default folder locations and paths assumed if none is provided
+    |   -Open IMAP options:
+    |       DISABLE_AUTHENTICATOR - Disable authentication properties.
+    |                               Use 'GSSAPI' if you encounter the following
+    |                               error: "Kerberos error: No credentials cache
+    |                               file found (try running kinit) (...)"
+    |                               or ['GSSAPI','PLAIN'] if you are using outlook mail
+    |
+    */
+    'options' => [
+        'delimiter' => '/',
+        'fetch' => Webklex\PHPIMAP\IMAP::FT_PEEK,
+        'sequence' => Webklex\PHPIMAP\IMAP::ST_UID,
+        'fetch_body' => true,
+        'fetch_flags' => true,
+        'soft_fail' => false,
+        'rfc822' => true,
+        'debug' => false,
+        'uid_cache' => true,
+        // 'fallback_date' => "01.01.1970 00:00:00",
+        'boundary' => '/boundary=(.*?(?=;)|(.*))/i',
+        'message_key' => 'list',
+        'fetch_order' => 'asc',
+        'dispositions' => ['attachment', 'inline'],
+        'common_folders' => [
+            'root' => 'INBOX',
+            'junk' => 'INBOX/Junk',
+            'draft' => 'INBOX/Drafts',
+            'sent' => 'INBOX/Sent',
+            'trash' => 'INBOX/Trash',
+        ],
+        'open' => [
+            // 'DISABLE_AUTHENTICATOR' => 'GSSAPI'
+        ],
+    ],
+
+    /**
+     * |--------------------------------------------------------------------------
+     * | Available decoding options
+     * |--------------------------------------------------------------------------
+     * |
+     * | Available php imap config parameters are listed below
+     * |   -options: Decoder options (currently only the message subject and attachment name decoder can be set)
+     * |       'utf-8' - Uses imap_utf8($string) to decode a string
+     * |       'mimeheader' - Uses mb_decode_mimeheader($string) to decode a string
+     * |   -decoder: Decoder to be used. Can be replaced by custom decoders if needed.
+     * |       'header' - HeaderDecoder
+     * |       'message' - MessageDecoder
+     * |       'attachment' - AttachmentDecoder
+     */
+    'decoding' => [
+        'options' => [
+            'header' => 'utf-8', // mimeheader
+            'message' => 'utf-8', // mimeheader
+            'attachment' => 'utf-8', // mimeheader
+        ],
+        'decoder' => [
+            'header' => Webklex\PHPIMAP\Decoder\HeaderDecoder::class,
+            'message' => Webklex\PHPIMAP\Decoder\MessageDecoder::class,
+            'attachment' => Webklex\PHPIMAP\Decoder\AttachmentDecoder::class,
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Available flags
+    |--------------------------------------------------------------------------
+    |
+    | List all available / supported flags. Set to null to accept all given flags.
+     */
+    'flags' => ['recent', 'flagged', 'answered', 'deleted', 'seen', 'draft'],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Available events
+    |--------------------------------------------------------------------------
+    |
+    */
+    'events' => [
+        'message' => [
+            'new' => Webklex\IMAP\Events\MessageNewEvent::class,
+            'moved' => Webklex\IMAP\Events\MessageMovedEvent::class,
+            'copied' => Webklex\IMAP\Events\MessageCopiedEvent::class,
+            'deleted' => Webklex\IMAP\Events\MessageDeletedEvent::class,
+            'restored' => Webklex\IMAP\Events\MessageRestoredEvent::class,
+        ],
+        'folder' => [
+            'new' => Webklex\IMAP\Events\FolderNewEvent::class,
+            'moved' => Webklex\IMAP\Events\FolderMovedEvent::class,
+            'deleted' => Webklex\IMAP\Events\FolderDeletedEvent::class,
+        ],
+        'flag' => [
+            'new' => Webklex\IMAP\Events\FlagNewEvent::class,
+            'deleted' => Webklex\IMAP\Events\FlagDeletedEvent::class,
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Available masking options
+    |--------------------------------------------------------------------------
+    |
+    | By using your own custom masks you can implement your own methods for
+    | a better and faster access and less code to write.
+    |
+    | Checkout the two examples custom_attachment_mask and custom_message_mask
+    | for a quick start.
+    |
+    | The provided masks below are used as the default masks.
+    */
+    'masks' => [
+        'message' => Webklex\PHPIMAP\Support\Masks\MessageMask::class,
+        'attachment' => Webklex\PHPIMAP\Support\Masks\AttachmentMask::class,
+    ],
+];

--- a/database/factories/TransactionEmailFactory.php
+++ b/database/factories/TransactionEmailFactory.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\Transaction;
+use App\Models\TransactionEmail;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<TransactionEmail>
+ */
+final class TransactionEmailFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $user = User::factory();
+        $messageId = fake()->uuid().'@mail.gmail.com';
+
+        return [
+            'user_id' => $user,
+            'transaction_id' => Transaction::factory()->for($user),
+            'gmail_message_id' => $messageId,
+            'subject' => fake()->sentence(4),
+            'from_name' => fake()->company(),
+            'from_address' => fake()->companyEmail(),
+            'email_date' => fake()->dateTimeBetween('-3 months', 'now'),
+            'snippet' => fake()->text(180),
+            'gmail_url' => 'https://mail.google.com/mail/u/0/#search/rfc822msgid:'.rawurlencode($messageId),
+        ];
+    }
+}

--- a/database/migrations/2026_07_13_000000_create_transaction_emails_table.php
+++ b/database/migrations/2026_07_13_000000_create_transaction_emails_table.php
@@ -24,7 +24,6 @@ return new class extends Migration
             $table->timestamps();
 
             $table->unique(['transaction_id', 'gmail_message_id']);
-            $table->index('user_id');
         });
     }
 

--- a/database/migrations/2026_07_13_000000_create_transaction_emails_table.php
+++ b/database/migrations/2026_07_13_000000_create_transaction_emails_table.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('transaction_emails', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('transaction_id')->constrained()->cascadeOnDelete();
+            $table->string('gmail_message_id');
+            $table->string('subject');
+            $table->string('from_name')->nullable();
+            $table->string('from_address');
+            $table->timestamp('email_date')->nullable();
+            $table->text('snippet')->nullable();
+            $table->string('gmail_url', 2048);
+            $table->timestamps();
+
+            $table->unique(['transaction_id', 'gmail_message_id']);
+            $table->index('user_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('transaction_emails');
+    }
+};

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -278,6 +278,31 @@ select:focus[data-flux-control] {
     }
     .tx-meta .pill.plan { background: var(--color-money-planned-soft); color: var(--color-money-planned); }
 
+    .tx-meta .pill.email { background: var(--color-cib-teal-50); color: var(--color-cib-teal-600); }
+
+    /* ---------- Email scan panel (Ticket #340) ---------- */
+    .email-scan-panel {
+        padding: 10px 4px 12px 48px;
+        border-bottom: 1px solid var(--color-border-1);
+        font: 400 12px/1.4 var(--font-sans);
+        color: var(--color-fg-2);
+    }
+    .email-scan-panel:last-child { border-bottom: 0; }
+    .email-scan-error { color: var(--color-money-owed); font-weight: 700; margin-bottom: 8px; }
+    .email-scan-section { margin-bottom: 10px; }
+    .email-scan-section:last-child { margin-bottom: 0; }
+    .email-scan-section .cib-label { display: block; margin-bottom: 6px; }
+    .email-row {
+        display: flex; justify-content: space-between; align-items: flex-start;
+        gap: 12px; padding: 6px 0; border-top: 1px solid var(--color-border-1);
+    }
+    .email-row-body { min-width: 0; }
+    .email-subject { font-weight: 700; color: var(--color-fg-1); }
+    .email-meta { color: var(--color-fg-3); margin-top: 1px; }
+    .email-snippet { margin-top: 3px; color: var(--color-fg-2); }
+    .email-link { display: inline-block; margin-top: 4px; color: var(--color-cib-teal-500); font-weight: 700; }
+    .email-empty { color: var(--color-fg-3); font-style: italic; }
+
     .budget-row {
         display: flex; justify-content: space-between; align-items: center;
         font: 700 12px/1 var(--font-sans); margin-bottom: 4px;

--- a/resources/views/livewire/transaction-list.blade.php
+++ b/resources/views/livewire/transaction-list.blade.php
@@ -150,16 +150,81 @@
                                 @endphp
                                 <x-cib.tx-row
                                     wire:key="txn-{{ $transaction->id }}"
-                                    :transaction-id="$transaction->id"
                                     :name="$transaction->description"
                                     :amount="$transaction->amount"
                                     :tone="$tone"
                                     :icon="$transaction->category?->resolveIcon()"
+                                    :click="'$dispatch(\'edit-transaction\', { id: ' . $transaction->id . ' })'"
                                 >
-                                    @if(! empty($metaParts) || $isPlanned)
-                                        <x-slot:meta>{{ implode(' · ', $metaParts) }}@if($isPlanned) <span class="pill plan">Planned</span>@endif</x-slot:meta>
+                                    @if(! empty($metaParts) || $isPlanned || $transaction->emails->isNotEmpty())
+                                        <x-slot:meta>{{ implode(' · ', $metaParts) }}@if($isPlanned) <span class="pill plan">Planned</span>@endif@if($transaction->emails->isNotEmpty()) <span class="pill email">{{ $transaction->emails->count() }} email{{ $transaction->emails->count() > 1 ? 's' : '' }}</span>@endif</x-slot:meta>
+                                    @endif
+                                    @if($gmailEnabled)
+                                        <x-slot:actions>
+                                            <flux:button variant="ghost" size="sm" icon="envelope"
+                                                         wire:click="scanEmail({{ $transaction->id }})"
+                                                         wire:loading.attr="disabled" wire:target="scanEmail({{ $transaction->id }})"
+                                                         data-testid="scan-email-{{ $transaction->id }}" aria-label="Scan email"/>
+                                        </x-slot:actions>
                                     @endif
                                 </x-cib.tx-row>
+                                @if($emailPanelTxnId === $transaction->id)
+                                    @php
+                                        $linkedMessageIds = $transaction->emails->pluck('gmail_message_id');
+                                        $newResults = collect($emailResults)->reject(fn (array $r): bool => $linkedMessageIds->contains($r['messageId']));
+                                    @endphp
+                                    <div wire:key="email-panel-{{ $transaction->id }}" class="email-scan-panel" data-testid="email-panel-{{ $transaction->id }}">
+                                        @if($emailScanError)
+                                            <p class="email-scan-error">{{ $emailScanError }}</p>
+                                        @endif
+
+                                        @if($transaction->emails->isNotEmpty())
+                                            <div class="email-scan-section">
+                                                <span class="cib-label">Linked emails</span>
+                                                @foreach($transaction->emails as $email)
+                                                    <div wire:key="linked-email-{{ $email->id }}" class="email-row">
+                                                        <div class="email-row-body">
+                                                            <div class="email-subject">{{ $email->subject }}</div>
+                                                            <div class="email-meta">{{ $email->from_name ?? $email->from_address }}@if($email->email_date) · {{ $email->email_date->format('j M Y') }}@endif</div>
+                                                            @if($email->snippet)
+                                                                <div class="email-snippet">{{ $email->snippet }}</div>
+                                                            @endif
+                                                            <a href="{{ $email->gmail_url }}" target="_blank" rel="noopener" class="email-link">Open in Gmail</a>
+                                                        </div>
+                                                        <flux:button variant="ghost" size="sm" icon="x-mark"
+                                                                     wire:click="unlinkEmail({{ $email->id }})"
+                                                                     data-testid="unlink-email-{{ $email->id }}" aria-label="Unlink email"/>
+                                                    </div>
+                                                @endforeach
+                                            </div>
+                                        @endif
+
+                                        @if($newResults->isNotEmpty())
+                                            <div class="email-scan-section">
+                                                <span class="cib-label">Search results</span>
+                                                @foreach($newResults as $index => $result)
+                                                    <div wire:key="result-email-{{ $transaction->id }}-{{ $index }}" class="email-row">
+                                                        <div class="email-row-body">
+                                                            <div class="email-subject">{{ $result['subject'] }}</div>
+                                                            <div class="email-meta">{{ $result['fromName'] ?? $result['fromAddress'] }}@if($result['date']) · {{ CarbonImmutable::parse($result['date'])->format('j M Y') }}@endif</div>
+                                                            @if($result['snippet'])
+                                                                <div class="email-snippet">{{ $result['snippet'] }}</div>
+                                                            @endif
+                                                            <a href="{{ $result['gmailUrl'] }}" target="_blank" rel="noopener" class="email-link">Open in Gmail</a>
+                                                        </div>
+                                                        <flux:button variant="ghost" size="sm" icon="link"
+                                                                     wire:click="linkEmail({{ $transaction->id }}, {{ $index }})"
+                                                                     data-testid="link-email-{{ $transaction->id }}-{{ $index }}">Link</flux:button>
+                                                    </div>
+                                                @endforeach
+                                            </div>
+                                        @endif
+
+                                        @if(! $emailScanError && $transaction->emails->isEmpty() && $newResults->isEmpty())
+                                            <p class="email-empty">No matching emails found.</p>
+                                        @endif
+                                    </div>
+                                @endif
                             @endforeach
                         </div>
                     </section>

--- a/resources/views/livewire/transaction-list.blade.php
+++ b/resources/views/livewire/transaction-list.blade.php
@@ -1,5 +1,6 @@
 @php
     use App\Enums\TransactionDirection;
+    use App\Services\GmailService;
     use Carbon\CarbonImmutable;
 @endphp
 <div class="space-y-6">
@@ -189,7 +190,7 @@
                                                             @if($email->snippet)
                                                                 <div class="email-snippet">{{ $email->snippet }}</div>
                                                             @endif
-                                                            <a href="{{ $email->gmail_url }}" target="_blank" rel="noopener" class="email-link">Open in Gmail</a>
+                                                            <a href="{{ GmailService::deepLink($email->gmail_message_id) }}" target="_blank" rel="noopener" class="email-link">Open in Gmail</a>
                                                         </div>
                                                         <flux:button variant="ghost" size="sm" icon="x-mark"
                                                                      wire:click="unlinkEmail({{ $email->id }})"
@@ -210,7 +211,10 @@
                                                             @if($result['snippet'])
                                                                 <div class="email-snippet">{{ $result['snippet'] }}</div>
                                                             @endif
-                                                            <a href="{{ $result['gmailUrl'] }}" target="_blank" rel="noopener" class="email-link">Open in Gmail</a>
+                                                            @php $resultMessageId = $result['messageId'] ?? null; @endphp
+                                                            @if(is_string($resultMessageId) && trim($resultMessageId) !== '')
+                                                                <a href="{{ GmailService::deepLink(trim($resultMessageId)) }}" target="_blank" rel="noopener" class="email-link">Open in Gmail</a>
+                                                            @endif
                                                         </div>
                                                         <flux:button variant="ghost" size="sm" icon="link"
                                                                      wire:click="linkEmail({{ $transaction->id }}, {{ $index }})"

--- a/tests/Feature/Livewire/TransactionListTest.php
+++ b/tests/Feature/Livewire/TransactionListTest.php
@@ -19,6 +19,7 @@ use App\Models\User;
 use App\Services\TransactionFeeFolder;
 use Carbon\CarbonImmutable;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Livewire\Features\SupportLockedProperties\CannotUpdateLockedPropertyException;
 use Livewire\Livewire;
 
 beforeEach(function (): void {
@@ -1510,26 +1511,28 @@ test('scan-email action is hidden when Gmail is not configured', function () {
         ->assertDontSee('scan-email-'.$transaction->id);
 });
 
-test('linkEmail stores a server-derived Gmail URL and ignores a tampered one', function () {
+test('linkEmail derives the Gmail URL server-side and ignores the result URL', function () {
     $user = User::factory()->create();
     $transaction = afterpayTransaction($user);
 
     $this->mock(GmailServiceContract::class, function ($mock): void {
         $mock->shouldReceive('isConfigured')->andReturn(true);
+        $mock->shouldReceive('searchForTransaction')->andReturn(collect([
+            new EmailSearchResult(
+                messageId: 'evil@mail.gmail.com',
+                subject: 'Tampered',
+                fromName: null,
+                fromAddress: 'a@b.com',
+                date: null,
+                snippet: null,
+                gmailUrl: 'javascript:alert(document.cookie)',
+            ),
+        ]));
     });
 
     Livewire::actingAs($user)
         ->test(TransactionList::class)
-        ->set('emailPanelTxnId', $transaction->id)
-        ->set('emailResults', [[
-            'messageId' => 'evil@mail.gmail.com',
-            'subject' => 'Tampered',
-            'fromName' => null,
-            'fromAddress' => 'a@b.com',
-            'date' => null,
-            'snippet' => null,
-            'gmailUrl' => 'javascript:alert(document.cookie)',
-        ]])
+        ->call('scanEmail', $transaction->id)
         ->call('linkEmail', $transaction->id, 0);
 
     $this->assertDatabaseHas('transaction_emails', [
@@ -1539,4 +1542,18 @@ test('linkEmail stores a server-derived Gmail URL and ignores a tampered one', f
     ]);
 
     $this->assertDatabaseMissing('transaction_emails', ['gmail_url' => 'javascript:alert(document.cookie)']);
+});
+
+test('emailResults is locked against forged client updates', function () {
+    $user = User::factory()->create();
+    afterpayTransaction($user);
+
+    $this->mock(GmailServiceContract::class, function ($mock): void {
+        $mock->shouldReceive('isConfigured')->andReturn(true);
+    });
+
+    expect(fn () => Livewire::actingAs($user)
+        ->test(TransactionList::class)
+        ->set('emailResults', [['messageId' => 'x', 'gmailUrl' => 'javascript:alert(1)']]))
+        ->toThrow(CannotUpdateLockedPropertyException::class);
 });

--- a/tests/Feature/Livewire/TransactionListTest.php
+++ b/tests/Feature/Livewire/TransactionListTest.php
@@ -1509,3 +1509,34 @@ test('scan-email action is hidden when Gmail is not configured', function () {
         ->assertSee('AFTERPAY PURCHASE')
         ->assertDontSee('scan-email-'.$transaction->id);
 });
+
+test('linkEmail stores a server-derived Gmail URL and ignores a tampered one', function () {
+    $user = User::factory()->create();
+    $transaction = afterpayTransaction($user);
+
+    $this->mock(GmailServiceContract::class, function ($mock): void {
+        $mock->shouldReceive('isConfigured')->andReturn(true);
+    });
+
+    Livewire::actingAs($user)
+        ->test(TransactionList::class)
+        ->set('emailPanelTxnId', $transaction->id)
+        ->set('emailResults', [[
+            'messageId' => 'evil@mail.gmail.com',
+            'subject' => 'Tampered',
+            'fromName' => null,
+            'fromAddress' => 'a@b.com',
+            'date' => null,
+            'snippet' => null,
+            'gmailUrl' => 'javascript:alert(document.cookie)',
+        ]])
+        ->call('linkEmail', $transaction->id, 0);
+
+    $this->assertDatabaseHas('transaction_emails', [
+        'transaction_id' => $transaction->id,
+        'gmail_message_id' => 'evil@mail.gmail.com',
+        'gmail_url' => 'https://mail.google.com/mail/u/0/#search/rfc822msgid:evil%40mail.gmail.com',
+    ]);
+
+    $this->assertDatabaseMissing('transaction_emails', ['gmail_url' => 'javascript:alert(document.cookie)']);
+});

--- a/tests/Feature/Livewire/TransactionListTest.php
+++ b/tests/Feature/Livewire/TransactionListTest.php
@@ -5,15 +5,20 @@
 declare(strict_types=1);
 
 use App\Casts\MoneyCast;
+use App\Contracts\GmailServiceContract;
+use App\DTOs\EmailSearchResult;
 use App\Enums\PayFrequency;
+use App\Exceptions\GmailSearchException;
 use App\Livewire\TransactionList;
 use App\Models\Account;
 use App\Models\Category;
 use App\Models\PlannedTransaction;
 use App\Models\Transaction;
+use App\Models\TransactionEmail;
 use App\Models\User;
 use App\Services\TransactionFeeFolder;
 use Carbon\CarbonImmutable;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Livewire\Livewire;
 
 beforeEach(function (): void {
@@ -967,7 +972,7 @@ test('transaction row dispatches edit-transaction via tx-row primitive', functio
         ->html();
 
     expect($html)->toContain('class="tx-row');
-    expect($html)->toContain("\$dispatch('edit-transaction'");
+    expect(html_entity_decode($html))->toContain("\$dispatch('edit-transaction'");
 });
 
 test('pagination wraps in cib-card with flex justify-between', function () {
@@ -1350,4 +1355,157 @@ test('categorised filter state persists via url query string', function () {
             'categorised' => 'uncategorised',
         ])
         ->assertSet('categorised', 'uncategorised');
+});
+
+function afterpayTransaction(User $user): Transaction
+{
+    $account = Account::factory()->for($user)->create();
+
+    return Transaction::factory()->for($user)->for($account)->debit()->create([
+        'description' => 'AFTERPAY PURCHASE',
+        'merchant_name' => 'Afterpay',
+        'post_date' => now()->subDays(3),
+    ]);
+}
+
+function afterpayResult(string $messageId = 'abc@mail.gmail.com'): EmailSearchResult
+{
+    return new EmailSearchResult(
+        messageId: $messageId,
+        subject: 'Your Afterpay payment',
+        fromName: 'Afterpay',
+        fromAddress: 'no-reply@afterpay.com',
+        date: '2026-06-12T10:00:00+10:00',
+        snippet: 'Payment 1 of 4',
+        gmailUrl: 'https://mail.google.com/mail/u/0/#search/rfc822msgid:'.rawurlencode($messageId),
+    );
+}
+
+test('scanEmail populates results and opens the panel', function () {
+    $user = User::factory()->create();
+    $transaction = afterpayTransaction($user);
+
+    $this->mock(GmailServiceContract::class, function ($mock): void {
+        $mock->shouldReceive('isConfigured')->andReturn(true);
+        $mock->shouldReceive('searchForTransaction')->andReturn(collect([afterpayResult()]));
+    });
+
+    Livewire::actingAs($user)
+        ->test(TransactionList::class)
+        ->call('scanEmail', $transaction->id)
+        ->assertSet('emailPanelTxnId', $transaction->id)
+        ->assertCount('emailResults', 1)
+        ->assertSet('emailScanError', null)
+        ->assertSee('Your Afterpay payment');
+});
+
+test('a second scanEmail on the same transaction closes the panel', function () {
+    $user = User::factory()->create();
+    $transaction = afterpayTransaction($user);
+
+    $this->mock(GmailServiceContract::class, function ($mock): void {
+        $mock->shouldReceive('isConfigured')->andReturn(true);
+        $mock->shouldReceive('searchForTransaction')->andReturn(collect([afterpayResult()]));
+    });
+
+    Livewire::actingAs($user)
+        ->test(TransactionList::class)
+        ->call('scanEmail', $transaction->id)
+        ->assertSet('emailPanelTxnId', $transaction->id)
+        ->call('scanEmail', $transaction->id)
+        ->assertSet('emailPanelTxnId', null)
+        ->assertCount('emailResults', 0)
+        ->assertSet('emailScanError', null);
+});
+
+test('scanEmail refuses another users transaction', function () {
+    $user = User::factory()->create();
+    $intruder = User::factory()->create();
+    $transaction = afterpayTransaction($user);
+
+    $this->mock(GmailServiceContract::class, function ($mock): void {
+        $mock->shouldReceive('isConfigured')->andReturn(true);
+    });
+
+    expect(fn () => Livewire::actingAs($intruder)
+        ->test(TransactionList::class)
+        ->call('scanEmail', $transaction->id))
+        ->toThrow(ModelNotFoundException::class);
+});
+
+test('scanEmail records a friendly error when the search fails', function () {
+    $user = User::factory()->create();
+    $transaction = afterpayTransaction($user);
+
+    $this->mock(GmailServiceContract::class, function ($mock): void {
+        $mock->shouldReceive('isConfigured')->andReturn(true);
+        $mock->shouldReceive('searchForTransaction')
+            ->andThrow(GmailSearchException::wrap(new RuntimeException('imap down')));
+    });
+
+    Livewire::actingAs($user)
+        ->test(TransactionList::class)
+        ->call('scanEmail', $transaction->id)
+        ->assertSet('emailPanelTxnId', $transaction->id)
+        ->assertCount('emailResults', 0)
+        ->assertSet('emailScanError', 'Could not search Gmail — check the GMAIL_* credentials and connection.');
+});
+
+test('linkEmail persists the email and is idempotent', function () {
+    $user = User::factory()->create();
+    $transaction = afterpayTransaction($user);
+
+    $this->mock(GmailServiceContract::class, function ($mock): void {
+        $mock->shouldReceive('isConfigured')->andReturn(true);
+        $mock->shouldReceive('searchForTransaction')->andReturn(collect([afterpayResult()]));
+    });
+
+    $component = Livewire::actingAs($user)
+        ->test(TransactionList::class)
+        ->call('scanEmail', $transaction->id)
+        ->call('linkEmail', $transaction->id, 0);
+
+    $this->assertDatabaseHas('transaction_emails', [
+        'transaction_id' => $transaction->id,
+        'gmail_message_id' => 'abc@mail.gmail.com',
+        'user_id' => $user->id,
+        'subject' => 'Your Afterpay payment',
+    ]);
+    expect(TransactionEmail::query()->count())->toBe(1);
+
+    $component->call('linkEmail', $transaction->id, 0);
+    expect(TransactionEmail::query()->count())->toBe(1);
+});
+
+test('unlinkEmail removes an owned email but not another users', function () {
+    $user = User::factory()->create();
+    $other = User::factory()->create();
+    $transaction = afterpayTransaction($user);
+
+    $ownEmail = TransactionEmail::factory()->for($user)->for($transaction)->create();
+    $foreignEmail = TransactionEmail::factory()->for($other)->create();
+
+    $this->mock(GmailServiceContract::class, function ($mock): void {
+        $mock->shouldReceive('isConfigured')->andReturn(true);
+    });
+
+    Livewire::actingAs($user)
+        ->test(TransactionList::class)
+        ->call('unlinkEmail', $ownEmail->id)
+        ->call('unlinkEmail', $foreignEmail->id);
+
+    $this->assertDatabaseMissing('transaction_emails', ['id' => $ownEmail->id]);
+    $this->assertDatabaseHas('transaction_emails', ['id' => $foreignEmail->id]);
+});
+
+test('scan-email action is hidden when Gmail is not configured', function () {
+    config(['imap.accounts.gmail.username' => null, 'imap.accounts.gmail.password' => null]);
+
+    $user = User::factory()->create();
+    $transaction = afterpayTransaction($user);
+
+    Livewire::actingAs($user)
+        ->test(TransactionList::class)
+        ->assertSee('AFTERPAY PURCHASE')
+        ->assertDontSee('scan-email-'.$transaction->id);
 });

--- a/tests/Feature/Services/GmailServiceTest.php
+++ b/tests/Feature/Services/GmailServiceTest.php
@@ -1,0 +1,77 @@
+<?php
+
+/** @noinspection StaticClosureCanBeUsedInspection */
+
+declare(strict_types=1);
+
+use App\Enums\TransactionDirection;
+use App\Exceptions\GmailSearchException;
+use App\Models\Account;
+use App\Models\Transaction;
+use App\Models\User;
+use App\Services\CategoryRuleGenerator;
+use App\Services\GmailService;
+
+function gmailTransaction(array $overrides = []): Transaction
+{
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+
+    return Transaction::factory()->for($user)->for($account)->manual()->create(array_merge([
+        'merchant_name' => 'Afterpay',
+        'clean_description' => null,
+        'description' => 'AFTERPAY PURCHASE',
+        'amount' => -1250,
+        'direction' => TransactionDirection::Debit,
+        'post_date' => '2026-07-10',
+        'category_id' => null,
+    ], $overrides));
+}
+
+test('buildQuery emits merchant, amount and the ±7 day window', function () {
+    $transaction = gmailTransaction();
+
+    expect(app(GmailService::class)->buildQuery($transaction))
+        ->toBe('Afterpay 12.50 after:2026/07/03 before:2026/07/18');
+});
+
+test('buildQuery drops the amount term when withAmount is false', function () {
+    $transaction = gmailTransaction();
+
+    expect(app(GmailService::class)->buildQuery($transaction, withAmount: false))
+        ->toBe('Afterpay after:2026/07/03 before:2026/07/18');
+});
+
+test('buildQuery uses the suggested merchant token when there is no merchant name', function () {
+    $transaction = gmailTransaction([
+        'merchant_name' => null,
+        'clean_description' => null,
+        'description' => 'PAYPAL *NETFLIX SYDNEY',
+    ]);
+
+    $token = app(CategoryRuleGenerator::class)->suggestMatchValue($transaction);
+
+    expect($token)->not->toBe('')
+        ->and(app(GmailService::class)->buildQuery($transaction))
+        ->toStartWith($token.' ');
+});
+
+test('buildQuery strips double quotes from the merchant term', function () {
+    $transaction = gmailTransaction(['merchant_name' => 'Pay"Pal']);
+
+    $query = app(GmailService::class)->buildQuery($transaction);
+
+    expect($query)->not->toContain('"')
+        ->and($query)->toStartWith('Pay Pal ');
+});
+
+test('searchForTransaction throws when Gmail is not configured', function () {
+    config(['imap.accounts.gmail.username' => null, 'imap.accounts.gmail.password' => null]);
+
+    $service = app(GmailService::class);
+    $transaction = gmailTransaction();
+
+    expect($service->isConfigured())->toBeFalse();
+
+    $service->searchForTransaction($transaction);
+})->throws(GmailSearchException::class);

--- a/tests/Feature/Services/GmailServiceTest.php
+++ b/tests/Feature/Services/GmailServiceTest.php
@@ -109,3 +109,29 @@ test('searchForTransaction throws when Gmail is not configured', function () {
 
     $service->searchForTransaction($transaction);
 })->throws(GmailSearchException::class);
+
+test('snippetFromBodies prefers the plain-text body', function () {
+    expect(GmailService::snippetFromBodies('  Plain   text  body ', '<p>ignored</p>'))
+        ->toBe('Plain text body');
+});
+
+test('snippetFromBodies strips style, script and head blocks from the HTML fallback', function () {
+    $html = '<html><head><style>@font-face { font-family: SupremeLLTest; src: url("https://x"); }</style></head>'
+        .'<body><script>var a = 1;</script><p>Your PayPal Pay in 4 payment went through. You paid $13.76 AUD.</p></body></html>';
+
+    $snippet = GmailService::snippetFromBodies(null, $html);
+
+    expect($snippet)->toContain('Your PayPal Pay in 4 payment went through')
+        ->and($snippet)->not->toContain('font-face')
+        ->and($snippet)->not->toContain('SupremeLL')
+        ->and($snippet)->not->toContain('var a');
+});
+
+test('snippetFromBodies decodes entities and collapses whitespace', function () {
+    expect(GmailService::snippetFromBodies(null, "<p>Ben &amp; Jerry&#39;s\n\n  order</p>"))
+        ->toBe("Ben & Jerry's order");
+});
+
+test('snippetFromBodies returns null when both bodies are empty', function () {
+    expect(GmailService::snippetFromBodies('', '   '))->toBeNull();
+});

--- a/tests/Feature/Services/GmailServiceTest.php
+++ b/tests/Feature/Services/GmailServiceTest.php
@@ -135,3 +135,27 @@ test('snippetFromBodies decodes entities and collapses whitespace', function () 
 test('snippetFromBodies returns null when both bodies are empty', function () {
     expect(GmailService::snippetFromBodies('', '   '))->toBeNull();
 });
+
+test('snippetFromBodies leads with the seller and payment schedule of a BNPL receipt', function () {
+    $html = '<html><head><style>@font-face { font-family: X; }</style></head><body>'
+        .'<p>Hi Robert, we received your Pay in 4 payment. You made a $13.76 AUD payment for your Pay in 4 plan.</p>'
+        .'<table><tr><td>Payment amount</td><td>$13.76 AUD</td></tr>'
+        .'<tr><td>Seller</td><td>New Eagle International Pty Ltd t/a Umart Online</td></tr>'
+        .'<tr><td>Current balance</td><td>$13.77 AUD</td></tr></table>'
+        .'<p>As a reminder, here is your upcoming payment schedule: $13.77 AUD on 19 July 2026</p>'
+        .'</body></html>';
+
+    $snippet = GmailService::snippetFromBodies(null, $html);
+
+    expect($snippet)->toStartWith('Seller: New Eagle International Pty Ltd t/a Umart Online')
+        ->and($snippet)->toContain('$13.77 AUD on 19 July 2026')
+        ->and($snippet)->not->toContain('font-face')
+        ->and($snippet)->toContain('we received your Pay in 4 payment');
+});
+
+test('snippetFromBodies adds no highlights for a plain non-receipt email', function () {
+    $snippet = GmailService::snippetFromBodies('Thanks for shopping with us. Your order is on its way.', null);
+
+    expect($snippet)->toBe('Thanks for shopping with us. Your order is on its way.')
+        ->and($snippet)->not->toContain(' — ');
+});

--- a/tests/Feature/Services/GmailServiceTest.php
+++ b/tests/Feature/Services/GmailServiceTest.php
@@ -18,9 +18,9 @@ function gmailTransaction(array $overrides = []): Transaction
     $account = Account::factory()->for($user)->create();
 
     return Transaction::factory()->for($user)->for($account)->manual()->create(array_merge([
-        'merchant_name' => 'Afterpay',
+        'merchant_name' => null,
         'clean_description' => null,
-        'description' => 'AFTERPAY PURCHASE',
+        'description' => 'GENERAL STORE PURCHASE',
         'amount' => -1250,
         'direction' => TransactionDirection::Debit,
         'post_date' => '2026-07-10',
@@ -28,41 +28,75 @@ function gmailTransaction(array $overrides = []): Transaction
     ], $overrides));
 }
 
-test('buildQuery emits merchant, amount and the ±7 day window', function () {
-    $transaction = gmailTransaction();
+test('buildQuery searches from the payment processor for a PayPal Pay-in-4 line', function () {
+    // Bank line names the processor, not the payee; the receipt is from PayPal.
+    $transaction = gmailTransaction([
+        'description' => 'VISA -PAYPAL *PYPL PAYIN4      1800073263   AU  680027 #8357',
+        'amount' => -1376,
+        'post_date' => '2026-07-06',
+    ]);
 
     expect(app(GmailService::class)->buildQuery($transaction))
-        ->toBe('Afterpay 12.50 after:2026/07/03 before:2026/07/18');
+        ->toBe('from:paypal 13.76 after:2026/06/29 before:2026/07/14');
 });
 
 test('buildQuery drops the amount term when withAmount is false', function () {
-    $transaction = gmailTransaction();
+    $transaction = gmailTransaction([
+        'description' => 'VISA -PAYPAL *PYPL PAYIN4      1800073263   AU  680027 #8357',
+        'amount' => -1376,
+        'post_date' => '2026-07-06',
+    ]);
 
     expect(app(GmailService::class)->buildQuery($transaction, withAmount: false))
-        ->toBe('Afterpay after:2026/07/03 before:2026/07/18');
+        ->toBe('from:paypal after:2026/06/29 before:2026/07/14');
 });
 
-test('buildQuery uses the suggested merchant token when there is no merchant name', function () {
+test('buildQuery detects Afterpay from the description', function () {
+    $transaction = gmailTransaction([
+        'description' => 'VISA -Afterpay                 afterpay.com AU  145377 #8357',
+        'amount' => -3255,
+        'post_date' => '2026-07-11',
+    ]);
+
+    expect(app(GmailService::class)->buildQuery($transaction))
+        ->toBe('from:afterpay 32.55 after:2026/07/04 before:2026/07/19');
+});
+
+test('buildQuery uses the merchant name for a normal (non-processor) purchase', function () {
+    $transaction = gmailTransaction([
+        'merchant_name' => 'Woolworths',
+        'description' => 'WOOLWORTHS 1234 SYDNEY',
+    ]);
+
+    expect(app(GmailService::class)->buildQuery($transaction))
+        ->toBe('Woolworths 12.50 after:2026/07/03 before:2026/07/18');
+});
+
+test('buildQuery falls back to the description token when there is no merchant name', function () {
     $transaction = gmailTransaction([
         'merchant_name' => null,
         'clean_description' => null,
-        'description' => 'PAYPAL *NETFLIX SYDNEY',
+        'description' => 'BUNNINGS WAREHOUSE 456 ADELAIDE',
     ]);
 
     $token = app(CategoryRuleGenerator::class)->suggestMatchValue($transaction);
+    $query = app(GmailService::class)->buildQuery($transaction);
 
     expect($token)->not->toBe('')
-        ->and(app(GmailService::class)->buildQuery($transaction))
-        ->toStartWith($token.' ');
+        ->and($query)->toStartWith($token.' ')
+        ->and($query)->not->toStartWith('from:');
 });
 
 test('buildQuery strips double quotes from the merchant term', function () {
-    $transaction = gmailTransaction(['merchant_name' => 'Pay"Pal']);
+    $transaction = gmailTransaction([
+        'merchant_name' => 'Big"W',
+        'description' => 'BIG W STORE',
+    ]);
 
     $query = app(GmailService::class)->buildQuery($transaction);
 
     expect($query)->not->toContain('"')
-        ->and($query)->toStartWith('Pay Pal ');
+        ->and($query)->toStartWith('Big W ');
 });
 
 test('searchForTransaction throws when Gmail is not configured', function () {


### PR DESCRIPTION
## What & why

Adds a per-row **Scan email** action on `/transactions`. It searches the configured Gmail account for emails matching a transaction (merchant + ±7-day window + amount) and renders them in an inline panel under the row, letting the user **link** an email (metadata + snippet + Gmail deep link) for future reference. Category is still set via the existing edit modal.

Target case: Afterpay / PayPal Pay-in-4 receipts that arrive days before the bank posting.

### Before
No way to correlate a bank transaction with its receipt email; users context-switch to Gmail manually.

### After
- Envelope button per row (only when Gmail is configured) → inline results panel.
- "Open in Gmail" deep-links the exact message (`#search/rfc822msgid:`).
- "Link" persists subject/from/date/snippet/URL to `transaction_emails`; a `N emails` pill appears in the row meta and the entry moves to a "Linked emails" list. Unlink removes it.
- Row click still opens the edit modal (row converted to passive `tx-row` + `click` prop).

## Approach
- **IMAP + Gmail app password** (no Google Cloud project — OAuth rejected: unverified personal apps get 7-day refresh tokens). One account app-wide via `.env`, same pattern as `BASIQ_*`.
- `webklex/laravel-imap` ^6.2; Gmail `X-GM-RAW` extension for native Gmail search. Two-pass search (with amount, then without); `[Gmail]/All Mail` with `INBOX` fallback; results ranked by date proximity to `post_date`.
- Store metadata + snippet + deep link only (not full bodies).
- Container binding uses a **closure** (a `singleton(Contract, Service::class)` + `alias(Contract, Service::class)` self-references and recurses).

## Gmail app-password setup (required before it works)
1. Enable **2-Step Verification** on the Google account.
2. Create a 16-char app password at https://myaccount.google.com/apppasswords.
3. In `.env`, set `GMAIL_USERNAME=<account email>` and `GMAIL_APP_PASSWORD=<16 chars, spaces removed>`.

Without these, the envelope button is hidden (`gmailEnabled = false`) — no runtime errors.

## Verification
- `ddev artisan test --filter=GmailServiceTest` — 5 passed (incl. exact query `Afterpay 12.50 after:2026/07/03 before:2026/07/18`).
- `ddev artisan test --filter=TransactionListTest` — 83 passed (scan/link/unlink, ownership 404, error handling, unconfigured gating).
- `ddev artisan test --filter=TxRowTest` — green (component untouched).
- Pint + PHPStan clean; `vite build` compiles; browser confirmed `wire:click` HTML-entity decoding preserves the `edit-transaction` dispatch.
- **Manual smoke (needs real `GMAIL_*` creds):** tinker `app(GmailServiceContract::class)->searchForTransaction($afterpayTxn)` returns plausible receipts; UI panel + Open-in-Gmail + link/unlink at `/transactions?account=2&categorised=uncategorised`.

Refs #340