### PR TITLE
feat(#342): split a transaction across multiple categories

### DIFF
--- a/app/DTOs/EmailSearchResult.php
+++ b/app/DTOs/EmailSearchResult.php
@@ -8,6 +8,9 @@ use Spatie\LaravelData\Dto;
 
 final class EmailSearchResult extends Dto
 {
+    /**
+     * @param  array<string, mixed>|null  $details
+     */
     public function __construct(
         public readonly string $messageId,
         public readonly string $subject,
@@ -16,10 +19,11 @@ final class EmailSearchResult extends Dto
         public readonly ?string $date,
         public readonly ?string $snippet,
         public readonly string $gmailUrl,
+        public readonly ?array $details = null,
     ) {}
 
     /**
-     * @return array{messageId: string, subject: string, fromName: ?string, fromAddress: string, date: ?string, snippet: ?string, gmailUrl: string}
+     * @return array{messageId: string, subject: string, fromName: ?string, fromAddress: string, date: ?string, snippet: ?string, gmailUrl: string, details: array<string, mixed>|null}
      */
     public function toArray(): array
     {
@@ -31,6 +35,7 @@ final class EmailSearchResult extends Dto
             'date' => $this->date,
             'snippet' => $this->snippet,
             'gmailUrl' => $this->gmailUrl,
+            'details' => $this->details,
         ];
     }
 }

--- a/app/Livewire/CategoryEditor.php
+++ b/app/Livewire/CategoryEditor.php
@@ -7,6 +7,8 @@ namespace App\Livewire;
 use App\Casts\MoneyCast;
 use App\Models\Category;
 use App\Models\Transaction;
+use App\Support\Transactions\CategoryAttribution;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use Illuminate\View\View;
 use Livewire\Component;
@@ -116,10 +118,10 @@ final class CategoryEditor extends Component
 
         $this->deletingCategoryId = $category->id;
         $this->deletingCategoryName = $category->fullPath();
-        $this->deletingTransactionCount = $category->transactions()
-            ->where('user_id', auth()->id())
-            ->current()
-            ->count();
+        $this->deletingTransactionCount = (int) CategoryAttribution::query(auth()->id())
+            ->where('category_id', $category->id)
+            ->distinct()
+            ->count('transaction_id');
         $this->showDeleteConfirm = true;
     }
 
@@ -147,9 +149,14 @@ final class CategoryEditor extends Component
         $search = $this->search;
         $isSearching = $search !== '';
 
+        $counts = CategoryAttribution::query(auth()->id())
+            ->whereNotNull('category_id')
+            ->groupBy('category_id')
+            ->select('category_id', DB::raw('COUNT(DISTINCT transaction_id) as aggregate'))
+            ->pluck('aggregate', 'category_id');
+
         $categories = Category::query()
             ->with(['parent.parent'])
-            ->withCount(['transactions' => fn ($q) => $q->where('user_id', auth()->id())->current()])
             ->when(! $this->showHidden, fn ($q) => $q->visible())
             ->when($isSearching, fn ($q) => $q->where(function ($q) use ($search) {
                 $q->where('name', 'like', "%{$search}%")
@@ -164,16 +171,17 @@ final class CategoryEditor extends Component
                 'name' => $category->name,
                 'full_path' => $category->fullPath(),
                 'depth' => $category->depth(),
-                'transactions_count' => $category->transactions_count,
+                'transactions_count' => (int) ($counts[$category->id] ?? 0),
                 'is_hidden' => $category->is_hidden,
                 'parent_id' => $category->parent_id,
             ]);
 
         $transactions = $this->selectedCategoryId
             ? Transaction::query()
-                ->where('category_id', $this->selectedCategoryId)
                 ->where('user_id', auth()->id())
                 ->current()
+                ->where(fn ($q) => $q->where('category_id', $this->selectedCategoryId)
+                    ->orWhereHas('splits', fn ($s) => $s->where('category_id', $this->selectedCategoryId)))
                 ->with('account:id,name')
                 ->orderByDesc('post_date')
                 ->limit(50)

--- a/app/Livewire/Dashboard.php
+++ b/app/Livewire/Dashboard.php
@@ -7,7 +7,7 @@ namespace App\Livewire;
 use App\Enums\TransactionDirection;
 use App\Models\Budget;
 use App\Models\PlannedTransaction;
-use App\Models\Transaction;
+use App\Support\Transactions\CategoryAttribution;
 use Carbon\CarbonImmutable;
 use Illuminate\Support\Collection;
 use Illuminate\View\View;
@@ -109,10 +109,8 @@ final class Dashboard extends Component
                     ];
                 }
 
-                $query = Transaction::query()
-                    ->where('user_id', $budget->user_id)
-                    ->current()
-                    ->where('direction', TransactionDirection::Debit)
+                $query = CategoryAttribution::query($budget->user_id)
+                    ->where('direction', TransactionDirection::Debit->value)
                     ->where('category_id', $budget->category_id);
 
                 if ($bounds !== null) {

--- a/app/Livewire/TransactionList.php
+++ b/app/Livewire/TransactionList.php
@@ -14,7 +14,10 @@ use App\Models\Account;
 use App\Models\Category;
 use App\Models\Transaction;
 use App\Models\TransactionEmail;
+use App\Models\TransactionSplit;
 use App\Services\GmailService;
+use App\Support\AmountParser;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\View\View;
 use Livewire\Attributes\Locked;
@@ -77,6 +80,15 @@ final class TransactionList extends Component
 
     #[Locked]
     public ?string $emailScanError = null;
+
+    #[Locked]
+    public ?int $splitPanelTxnId = null;
+
+    /** @var list<array<string, mixed>> */
+    public array $splitLines = [];
+
+    #[Locked]
+    public ?string $splitError = null;
 
     public function mount(): void
     {
@@ -206,6 +218,195 @@ final class TransactionList extends Component
             ->delete();
     }
 
+    public function toggleSplit(int $transactionId): void
+    {
+        if ($this->splitPanelTxnId === $transactionId) {
+            $this->closeSplitPanel();
+
+            return;
+        }
+
+        $transaction = Transaction::query()
+            ->where('user_id', auth()->id())
+            ->with('splits')
+            ->findOrFail($transactionId);
+
+        if ($transaction->transfer_pair_id !== null) {
+            return;
+        }
+
+        $this->splitPanelTxnId = $transactionId;
+        $this->splitError = null;
+
+        if ($transaction->splits->isNotEmpty()) {
+            $this->splitLines = $transaction->splits
+                ->map(static fn (TransactionSplit $split): array => [
+                    'category_id' => $split->category_id,
+                    'amount' => number_format(abs((int) $split->amount) / 100, 2, '.', ''),
+                    'notes' => $split->notes ?? '',
+                ])
+                ->all();
+
+            return;
+        }
+
+        $this->splitLines = [
+            [
+                'category_id' => $transaction->category_id,
+                'amount' => number_format(abs((int) $transaction->amount) / 100, 2, '.', ''),
+                'notes' => '',
+            ],
+            ['category_id' => null, 'amount' => '0.00', 'notes' => ''],
+        ];
+    }
+
+    public function addSplitLine(): void
+    {
+        if ($this->splitPanelTxnId === null) {
+            return;
+        }
+
+        $this->splitLines[] = ['category_id' => null, 'amount' => '0.00', 'notes' => ''];
+    }
+
+    public function removeSplitLine(int $index): void
+    {
+        if (! isset($this->splitLines[$index])) {
+            return;
+        }
+
+        unset($this->splitLines[$index]);
+        $this->splitLines = array_values($this->splitLines);
+    }
+
+    public function assignRemainderToLast(): void
+    {
+        if ($this->splitPanelTxnId === null || $this->splitLines === []) {
+            return;
+        }
+
+        $transaction = Transaction::query()
+            ->where('user_id', auth()->id())
+            ->find($this->splitPanelTxnId);
+
+        if ($transaction === null) {
+            return;
+        }
+
+        $lastIndex = array_key_last($this->splitLines);
+        $others = 0;
+
+        foreach ($this->splitLines as $index => $line) {
+            if ($index === $lastIndex) {
+                continue;
+            }
+
+            $others += AmountParser::parse((string) ($line['amount'] ?? ''))->amount;
+        }
+
+        $remainder = abs((int) $transaction->amount) - $others;
+        $this->splitLines[$lastIndex]['amount'] = number_format(max(0, $remainder) / 100, 2, '.', '');
+    }
+
+    public function saveSplit(): void
+    {
+        $this->splitError = null;
+
+        if ($this->splitPanelTxnId === null) {
+            return;
+        }
+
+        $transaction = Transaction::query()
+            ->where('user_id', auth()->id())
+            ->findOrFail($this->splitPanelTxnId);
+
+        if ($transaction->transfer_pair_id !== null) {
+            $this->splitError = 'Transfers cannot be split.';
+
+            return;
+        }
+
+        $sign = (int) $transaction->amount < 0 ? -1 : 1;
+
+        $lines = [];
+
+        foreach ($this->splitLines as $line) {
+            $categoryId = $line['category_id'] ?? null;
+            $cents = AmountParser::parse((string) ($line['amount'] ?? ''))->amount;
+
+            if ($categoryId === null) {
+                $this->splitError = 'Every split line needs a category.';
+
+                return;
+            }
+
+            if ($cents <= 0) {
+                $this->splitError = 'Every split line needs an amount greater than zero.';
+
+                return;
+            }
+
+            $notes = is_string($line['notes'] ?? null) ? mb_trim($line['notes']) : '';
+
+            $lines[] = [
+                'category_id' => (int) $categoryId,
+                'amount' => $sign * $cents,
+                'notes' => $notes === '' ? null : $notes,
+            ];
+        }
+
+        if (count($lines) < 2) {
+            $this->splitError = 'A split needs at least two lines.';
+
+            return;
+        }
+
+        if (array_sum(array_column($lines, 'amount')) !== (int) $transaction->amount) {
+            $this->splitError = 'Split lines must add up to the transaction total.';
+
+            return;
+        }
+
+        $categoryIds = array_column($lines, 'category_id');
+
+        if (Category::query()->whereIn('id', $categoryIds)->count() !== count(array_unique($categoryIds))) {
+            $this->splitError = 'One or more categories are invalid.';
+
+            return;
+        }
+
+        DB::transaction(static function () use ($transaction, $lines): void {
+            $transaction->splits()->delete();
+
+            foreach ($lines as $position => $line) {
+                $transaction->splits()->create([
+                    'category_id' => $line['category_id'],
+                    'amount' => $line['amount'],
+                    'notes' => $line['notes'],
+                    'position' => $position,
+                ]);
+            }
+        });
+
+        $this->closeSplitPanel();
+        $this->dispatch('transaction-saved');
+    }
+
+    public function unsplit(int $transactionId): void
+    {
+        $transaction = Transaction::query()
+            ->where('user_id', auth()->id())
+            ->findOrFail($transactionId);
+
+        $transaction->splits()->delete();
+
+        if ($this->splitPanelTxnId === $transactionId) {
+            $this->closeSplitPanel();
+        }
+
+        $this->dispatch('transaction-saved');
+    }
+
     public function updatedDirection(): void
     {
         if (! in_array($this->direction, self::VALID_DIRECTIONS, true)) {
@@ -282,11 +483,17 @@ final class TransactionList extends Component
             ->current()
             ->when($directionEnum, fn ($q, $dir) => $q->where('direction', $dir))
             ->when($this->account, fn ($q, $id) => $q->where('account_id', $id))
-            ->when($this->category, fn ($q, $id) => $q->where('category_id', $id))
+            ->when($this->category, fn ($q, $id) => $q->where(fn ($q) => $q
+                ->where('category_id', $id)
+                ->orWhereHas('splits', fn ($s) => $s->where('category_id', $id))))
             ->when($this->planned === 'planned', fn ($q) => $q->whereNotNull('planned_transaction_id'))
             ->when($this->planned === 'unplanned', fn ($q) => $q->whereNull('planned_transaction_id'))
-            ->when($this->categorised === 'categorised', fn ($q) => $q->whereNotNull('category_id'))
-            ->when($this->categorised === 'uncategorised', fn ($q) => $q->whereNull('category_id'))
+            ->when($this->categorised === 'categorised', fn ($q) => $q->where(fn ($q) => $q
+                ->whereNotNull('category_id')
+                ->orWhereHas('splits')))
+            ->when($this->categorised === 'uncategorised', fn ($q) => $q
+                ->whereNull('category_id')
+                ->whereDoesntHave('splits'))
             ->when($this->search, fn ($q, $term) => $q->where(function ($q) use ($term) {
                 $q->where('description', 'like', "%{$term}%")
                     ->orWhere('clean_description', 'like', "%{$term}%")
@@ -295,7 +502,7 @@ final class TransactionList extends Component
             ->when($dates['start'], fn ($q, $s) => $q->where('post_date', '>=', $s))
             ->when($dates['end'], fn ($q, $e) => $q->where('post_date', '<=', $e))
             ->withRelations()
-            ->with('emails')
+            ->with(['emails', 'splits.category'])
             ->orderBy(
                 in_array($this->sortBy, self::SORTABLE_COLUMNS, true) ? $this->sortBy : 'post_date',
                 in_array($this->sortDir, ['asc', 'desc'], true) ? $this->sortDir : 'desc',
@@ -322,7 +529,15 @@ final class TransactionList extends Component
             'hasPayCycle' => auth()->user()->hasPayCycleConfigured(),
             'showCustomRange' => $periodEnum === TransactionPeriod::Custom,
             'gmailEnabled' => app(GmailServiceContract::class)->isConfigured(),
+            'splitCategories' => Category::visibleSortedByFullPath(),
         ]);
+    }
+
+    private function closeSplitPanel(): void
+    {
+        $this->splitPanelTxnId = null;
+        $this->splitLines = [];
+        $this->splitError = null;
     }
 
     private function restoreRememberedPeriod(): void

--- a/app/Livewire/TransactionList.php
+++ b/app/Livewire/TransactionList.php
@@ -241,7 +241,7 @@ final class TransactionList extends Component
         if ($transaction->splits->isNotEmpty()) {
             $this->splitLines = $transaction->splits
                 ->map(static fn (TransactionSplit $split): array => [
-                    'category_id' => $split->category_id,
+                    'category_id' => $split->category_id === null ? '' : (string) $split->category_id,
                     'amount' => number_format(abs((int) $split->amount) / 100, 2, '.', ''),
                     'notes' => $split->notes ?? '',
                 ])
@@ -251,12 +251,8 @@ final class TransactionList extends Component
         }
 
         $this->splitLines = [
-            [
-                'category_id' => $transaction->category_id,
-                'amount' => number_format(abs((int) $transaction->amount) / 100, 2, '.', ''),
-                'notes' => '',
-            ],
-            ['category_id' => null, 'amount' => '0.00', 'notes' => ''],
+            ['category_id' => $transaction->category_id === null ? '' : (string) $transaction->category_id, 'amount' => '', 'notes' => ''],
+            ['category_id' => '', 'amount' => '', 'notes' => ''],
         ];
     }
 
@@ -266,7 +262,7 @@ final class TransactionList extends Component
             return;
         }
 
-        $this->splitLines[] = ['category_id' => null, 'amount' => '0.00', 'notes' => ''];
+        $this->splitLines[] = ['category_id' => '', 'amount' => '', 'notes' => ''];
     }
 
     public function removeSplitLine(int $index): void
@@ -334,7 +330,7 @@ final class TransactionList extends Component
             $categoryId = $line['category_id'] ?? null;
             $cents = AmountParser::parse((string) ($line['amount'] ?? ''))->amount;
 
-            if ($categoryId === null) {
+            if ($categoryId === null || $categoryId === '' || ! is_numeric($categoryId)) {
                 $this->splitError = 'Every split line needs a category.';
 
                 return;

--- a/app/Livewire/TransactionList.php
+++ b/app/Livewire/TransactionList.php
@@ -25,6 +25,9 @@ use Livewire\Attributes\On;
 use Livewire\Attributes\Url;
 use Livewire\Component;
 use Livewire\WithPagination;
+use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\NotFoundExceptionInterface;
+use Throwable;
 
 final class TransactionList extends Component
 {
@@ -90,6 +93,10 @@ final class TransactionList extends Component
     #[Locked]
     public ?string $splitError = null;
 
+    /**
+     * @throws ContainerExceptionInterface
+     * @throws NotFoundExceptionInterface
+     */
     public function mount(): void
     {
         $this->restoreRememberedPeriod();
@@ -305,6 +312,9 @@ final class TransactionList extends Component
         $this->splitLines[$lastIndex]['amount'] = number_format(max(0, $remainder) / 100, 2, '.', '');
     }
 
+    /**
+     * @throws Throwable
+     */
     public function saveSplit(): void
     {
         $this->splitError = null;
@@ -331,7 +341,7 @@ final class TransactionList extends Component
             $categoryId = $line['category_id'] ?? null;
             $cents = AmountParser::parse((string) ($line['amount'] ?? ''))->amount;
 
-            if ($categoryId === null || $categoryId === '' || ! is_numeric($categoryId)) {
+            if ($categoryId === '' || ! is_numeric($categoryId)) {
                 $this->splitError = 'Every split line needs a category.';
 
                 return;
@@ -344,6 +354,12 @@ final class TransactionList extends Component
             }
 
             $notes = is_string($line['notes'] ?? null) ? mb_trim($line['notes']) : '';
+
+            if (mb_strlen($notes) > 255) {
+                $this->splitError = 'Split notes must be 255 characters or fewer.';
+
+                return;
+            }
 
             $lines[] = [
                 'category_id' => (int) $categoryId,
@@ -537,6 +553,10 @@ final class TransactionList extends Component
         $this->splitError = null;
     }
 
+    /**
+     * @throws NotFoundExceptionInterface
+     * @throws ContainerExceptionInterface
+     */
     private function restoreRememberedPeriod(): void
     {
         if (request()->query('period') !== null) {

--- a/app/Livewire/TransactionList.php
+++ b/app/Livewire/TransactionList.php
@@ -206,6 +206,7 @@ final class TransactionList extends Component
                 'email_date' => is_string($result['date'] ?? null) ? $result['date'] : null,
                 'snippet' => is_string($result['snippet'] ?? null) ? $result['snippet'] : null,
                 'gmail_url' => GmailService::deepLink($messageId),
+                'details' => is_array($result['details'] ?? null) ? $result['details'] : null,
             ],
         );
     }

--- a/app/Models/Budget.php
+++ b/app/Models/Budget.php
@@ -6,6 +6,7 @@ namespace App\Models;
 
 use App\Casts\MoneyCast;
 use App\Enums\BudgetPeriod;
+use App\Support\Transactions\CategoryAttribution;
 use Carbon\CarbonImmutable;
 use Database\Factories\BudgetFactory;
 use Illuminate\Database\Eloquent\Builder;
@@ -73,7 +74,15 @@ final class Budget extends Model
 
     public function remaining(): int
     {
-        return $this->limit_amount - $this->transactions()->where('user_id', $this->user_id)->current()->sum('amount');
+        if ($this->category_id === null) {
+            return $this->limit_amount;
+        }
+
+        $spent = (int) CategoryAttribution::query($this->user_id)
+            ->where('category_id', $this->category_id)
+            ->sum('amount');
+
+        return $this->limit_amount - $spent;
     }
 
     /**

--- a/app/Models/Transaction.php
+++ b/app/Models/Transaction.php
@@ -42,6 +42,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  * @property int|null $parent_transaction_id
  * @property int|null $folded_into_transaction_id
  * @property string|null $notes
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, TransactionSplit> $splits
  * @property CarbonImmutable $created_at
  * @property CarbonImmutable $updated_at
  * @property CarbonImmutable|null $deleted_at
@@ -168,6 +169,31 @@ final class Transaction extends Model
     public function emails(): HasMany
     {
         return $this->hasMany(TransactionEmail::class);
+    }
+
+    /** @return HasMany<TransactionSplit, $this> */
+    public function splits(): HasMany
+    {
+        return $this->hasMany(TransactionSplit::class)->orderBy('position')->orderBy('id');
+    }
+
+    public function isSplit(): bool
+    {
+        return $this->relationLoaded('splits')
+            ? $this->splits->isNotEmpty()
+            : $this->splits()->exists();
+    }
+
+    public function splitTotal(): int
+    {
+        return $this->relationLoaded('splits')
+            ? (int) $this->splits->sum('amount')
+            : (int) $this->splits()->sum('amount');
+    }
+
+    public function splitRemainder(): int
+    {
+        return (int) $this->amount - $this->splitTotal();
     }
 
     /** @return BelongsTo<self, $this> */

--- a/app/Models/TransactionEmail.php
+++ b/app/Models/TransactionEmail.php
@@ -21,6 +21,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property CarbonImmutable|null $email_date
  * @property string|null $snippet
  * @property string $gmail_url
+ * @property array<string, mixed>|null $details
  * @property CarbonImmutable $created_at
  * @property CarbonImmutable $updated_at
  */
@@ -42,6 +43,7 @@ final class TransactionEmail extends Model
         'email_date',
         'snippet',
         'gmail_url',
+        'details',
     ];
 
     /** @return BelongsTo<User, $this> */
@@ -63,6 +65,7 @@ final class TransactionEmail extends Model
     {
         return [
             'email_date' => 'datetime',
+            'details' => 'array',
         ];
     }
 }

--- a/app/Models/TransactionSplit.php
+++ b/app/Models/TransactionSplit.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Casts\MoneyCast;
+use Carbon\CarbonImmutable;
+use Database\Factories\TransactionSplitFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * @property int $id
+ * @property int $transaction_id
+ * @property int|null $category_id
+ * @property int $amount
+ * @property string|null $notes
+ * @property int $position
+ * @property CarbonImmutable $created_at
+ * @property CarbonImmutable $updated_at
+ */
+final class TransactionSplit extends Model
+{
+    /** @use HasFactory<TransactionSplitFactory> */
+    use HasFactory;
+
+    /**
+     * @var list<string>
+     */
+    protected $fillable = [
+        'transaction_id',
+        'category_id',
+        'amount',
+        'notes',
+        'position',
+    ];
+
+    /** @return BelongsTo<Transaction, $this> */
+    public function transaction(): BelongsTo
+    {
+        return $this->belongsTo(Transaction::class);
+    }
+
+    /** @return BelongsTo<Category, $this> */
+    public function category(): BelongsTo
+    {
+        return $this->belongsTo(Category::class);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'amount' => MoneyCast::class,
+        ];
+    }
+}

--- a/app/Services/GmailService.php
+++ b/app/Services/GmailService.php
@@ -8,6 +8,7 @@ use App\Contracts\GmailServiceContract;
 use App\DTOs\EmailSearchResult;
 use App\Exceptions\GmailSearchException;
 use App\Models\Transaction;
+use App\Support\Email\ReceiptParser;
 use Carbon\CarbonImmutable;
 use Carbon\CarbonInterface;
 use Illuminate\Support\Collection;
@@ -238,6 +239,8 @@ final class GmailService implements GmailServiceContract
         $fromAddress = $from instanceof Address ? $from->mail : '';
 
         $date = $this->messageDate($message);
+        $textBody = $message->getTextBody();
+        $htmlBody = $message->getHTMLBody();
 
         return [
             'result' => new EmailSearchResult(
@@ -246,8 +249,9 @@ final class GmailService implements GmailServiceContract
                 fromName: $fromName,
                 fromAddress: $fromAddress,
                 date: $date?->toIso8601String(),
-                snippet: $this->snippet($message),
+                snippet: self::snippetFromBodies($textBody, $htmlBody),
                 gmailUrl: self::deepLink($messageId),
+                details: ReceiptParser::parse($textBody, $htmlBody),
             ),
             'date' => $date,
         ];
@@ -262,11 +266,6 @@ final class GmailService implements GmailServiceContract
         }
 
         return null;
-    }
-
-    private function snippet(Message $message): ?string
-    {
-        return self::snippetFromBodies($message->getTextBody(), $message->getHTMLBody());
     }
 
     /**

--- a/app/Services/Reports/ReportAggregator.php
+++ b/app/Services/Reports/ReportAggregator.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace App\Services\Reports;
 
+use App\Models\Category;
 use App\Models\PlannedTransaction;
 use App\Models\Transaction;
 use App\Models\User;
+use App\Support\Transactions\CategoryAttribution;
 use Carbon\CarbonImmutable;
 use Carbon\CarbonInterface;
 
@@ -128,13 +130,18 @@ final class ReportAggregator
     private function actualAtoms(User $user, ?CarbonInterface $start, ?CarbonInterface $end): array
     {
         $monthExpr = $this->monthExpression();
+        $transferCategoryIds = $this->transferCategoryIds();
 
-        $rows = Transaction::query()
-            ->where('user_id', $user->id)
-            ->current()
-            ->excludingTransfers()
+        $rows = CategoryAttribution::query($user->id)
+            ->whereNull('transfer_pair_id')
             ->when($start, fn ($q, $s) => $q->where('post_date', '>=', $s))
             ->when($end, fn ($q, $e) => $q->where('post_date', '<=', $e))
+            ->when(
+                $transferCategoryIds !== [],
+                fn ($q) => $q->where(fn ($inner) => $inner
+                    ->whereNull('category_id')
+                    ->orWhereNotIn('category_id', $transferCategoryIds)),
+            )
             ->selectRaw("{$monthExpr} as ym, direction, category_id, SUM(ABS(amount)) as total, COUNT(*) as tx_count")
             ->groupByRaw($monthExpr)
             ->groupBy('direction', 'category_id')
@@ -144,15 +151,39 @@ final class ReportAggregator
 
         foreach ($rows as $row) {
             $atoms[] = [
-                'ym' => (string) $row->getAttribute('ym'),
-                'direction' => $row->direction->value,
+                'ym' => (string) $row->ym,
+                'direction' => (string) $row->direction,
                 'category_id' => $row->category_id === null ? null : (int) $row->category_id,
-                'total' => (int) $row->getAttribute('total'),
-                'count' => (int) $row->getAttribute('tx_count'),
+                'total' => (int) $row->total,
+                'count' => (int) $row->tx_count,
             ];
         }
 
         return $atoms;
+    }
+
+    /**
+     * Category ids treated as internal transfers: any category named "Transfer"
+     * and its direct children. Mirrors Transaction::scopeExcludingTransfers so
+     * attributed atoms exclude the same rows the Eloquent scope would.
+     *
+     * @return list<int>
+     */
+    private function transferCategoryIds(): array
+    {
+        $direct = Category::query()->where('name', 'Transfer')->pluck('id');
+
+        if ($direct->isEmpty()) {
+            return [];
+        }
+
+        return Category::query()
+            ->whereIn('parent_id', $direct->all())
+            ->pluck('id')
+            ->merge($direct)
+            ->map(static fn ($id): int => (int) $id)
+            ->values()
+            ->all();
     }
 
     /**

--- a/app/Support/Calendar/DayActivityLoader.php
+++ b/app/Support/Calendar/DayActivityLoader.php
@@ -27,6 +27,13 @@ final readonly class DayActivityLoader
         'plannedTransaction.category.parent.parent:id,icon,parent_id',
     ];
 
+    private const array SPLIT_EAGER_LOAD = [
+        'splits:id,transaction_id,category_id,amount,position',
+        'splits.category:id,name,icon,parent_id',
+        'splits.category.parent:id,icon,parent_id',
+        'splits.category.parent.parent:id,icon,parent_id',
+    ];
+
     /**
      * Load posted transactions and planned-transaction occurrences for the given date range,
      * grouped by ISO date. Transfers are excluded. Pips per day are sorted by amount desc.
@@ -44,7 +51,7 @@ final readonly class DayActivityLoader
             ->current()
             ->excludingTransfers()
             ->whereBetween('post_date', [$start, $end])
-            ->with([...self::CATEGORY_EAGER_LOAD, ...self::LINKED_PLAN_EAGER_LOAD])
+            ->with([...self::CATEGORY_EAGER_LOAD, ...self::LINKED_PLAN_EAGER_LOAD, ...self::SPLIT_EAGER_LOAD])
             ->orderBy('post_date')
             ->get();
 
@@ -120,13 +127,30 @@ final readonly class DayActivityLoader
 
                 if ($isCredit) {
                     $incomeCents += $absAmount;
-                }
-
-                if (! $isCredit) {
+                } else {
                     $postedCents += $absAmount;
                 }
 
                 $linkedPlan = $tx->plannedTransaction;
+
+                if ($linkedPlan === null && $tx->isSplit()) {
+                    foreach ($tx->splits as $split) {
+                        $splitName = $split->category?->name ?? ($tx->description !== '' ? $tx->description : 'Transaction'); // @phpstan-ignore nullsafe.neverNull
+                        $pips[] = new PayCyclePip(
+                            kind: $isCredit ? 'inc' : 'out',
+                            name: $splitName,
+                            amount: abs((int) $split->amount),
+                            icon: $split->category?->resolveIcon(),
+                            transactionId: $tx->id,
+                            plannedTransactionId: null,
+                            occurrenceDate: null,
+                            matched: false,
+                            tooltip: ($tx->description !== '' && $tx->description !== $splitName) ? $tx->description : null,
+                        );
+                    }
+
+                    continue;
+                }
 
                 if ($linkedPlan !== null) {
                     $name = $linkedPlan->category?->name ?? $linkedPlan->description; // @phpstan-ignore nullsafe.neverNull

--- a/app/Support/Calendar/DayActivityLoader.php
+++ b/app/Support/Calendar/DayActivityLoader.php
@@ -133,18 +133,18 @@ final readonly class DayActivityLoader
 
                 $linkedPlan = $tx->plannedTransaction;
 
-                if ($linkedPlan === null && $tx->isSplit()) {
+                if ($tx->isSplit()) {
                     foreach ($tx->splits as $split) {
                         $splitName = $split->category?->name ?? ($tx->description !== '' ? $tx->description : 'Transaction'); // @phpstan-ignore nullsafe.neverNull
                         $pips[] = new PayCyclePip(
                             kind: $isCredit ? 'inc' : 'out',
                             name: $splitName,
-                            amount: abs((int) $split->amount),
+                            amount: abs($split->amount),
                             icon: $split->category?->resolveIcon(),
                             transactionId: $tx->id,
                             plannedTransactionId: null,
                             occurrenceDate: null,
-                            matched: false,
+                            matched: $linkedPlan !== null,
                             tooltip: ($tx->description !== '' && $tx->description !== $splitName) ? $tx->description : null,
                         );
                     }

--- a/app/Support/Email/ReceiptParser.php
+++ b/app/Support/Email/ReceiptParser.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support\Email;
+
+/**
+ * Extracts the structured payment breakdown from a BNPL receipt email
+ * (currently Afterpay's "Payment confirmation" layout). Falls back to null
+ * for anything that is not a recognisable receipt, so callers keep showing a
+ * plain snippet.
+ *
+ * The returned shape is JSON-serialisable and rendered directly:
+ *
+ * @phpstan-type ReceiptLineItem array{merchant: string, reference: string|null, installment: string|null, amount: int}
+ * @phpstan-type Receipt array{total: int|null, date: string|null, method: string|null, last4: string|null, items: list<ReceiptLineItem>}
+ */
+final class ReceiptParser
+{
+    /**
+     * @return Receipt|null
+     */
+    public static function parse(?string $textBody, ?string $htmlBody): ?array
+    {
+        $text = self::flatten($textBody, $htmlBody);
+
+        if ($text === '') {
+            return null;
+        }
+
+        $items = self::lineItems($text);
+        $total = self::money($text, '/Total amount paid\s+\$([\d,]+\.\d{2})/i');
+
+        if ($items === [] && $total === null) {
+            return null;
+        }
+
+        [$method, $last4] = self::paymentMethod($text);
+
+        return [
+            'total' => $total,
+            'date' => self::paymentDate($text),
+            'method' => $method,
+            'last4' => $last4,
+            'items' => $items,
+        ];
+    }
+
+    private static function flatten(?string $textBody, ?string $htmlBody): string
+    {
+        $body = mb_trim((string) $textBody);
+
+        if ($body === '') {
+            $html = (string) preg_replace('#<(style|script|head)\b[^>]*>.*?</\1>#is', ' ', (string) $htmlBody);
+            $html = (string) preg_replace('/<[^>]+>/', ' ', $html);
+            $body = html_entity_decode($html, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+        }
+
+        $body = str_replace("\u{00A0}", ' ', $body);
+
+        return mb_trim((string) preg_replace('/\s+/', ' ', $body));
+    }
+
+    /**
+     * @return list<array{merchant: string, reference: string|null, installment: string|null, amount: int}>
+     */
+    private static function lineItems(string $text): array
+    {
+        $block = $text;
+
+        if (preg_match('/Repayments\b(.*)/isu', $text, $bm) === 1) {
+            $block = $bm[1];
+        }
+
+        $block = (string) preg_replace('/^.*?Payment method\b.*?\d{4}\b\s*/isu', '', $block);
+
+        if (preg_match_all(
+            '/([\p{L}\p{N}][\p{L}\p{N} &\'.\-]*?)\s*Order\s*#?(\S+)\s+(\d+)\s+of\s+(\d+)\s+\$([\d,]+\.\d{2})/iu',
+            $block,
+            $matches,
+            PREG_SET_ORDER,
+        ) === false || $matches === []) {
+            return [];
+        }
+
+        $items = [];
+        $seen = [];
+
+        foreach ($matches as $match) {
+            $merchant = mb_trim((string) preg_replace('/\s+/', ' ', $match[1]));
+            $reference = $match[2];
+            $amount = self::centsFromString($match[5]);
+            $key = $reference.'|'.$match[3].'|'.$amount;
+
+            if (isset($seen[$key])) {
+                continue;
+            }
+
+            $seen[$key] = true;
+
+            $items[] = [
+                'merchant' => $merchant === '' ? 'Order '.$reference : $merchant,
+                'reference' => $reference,
+                'installment' => $match[3].' of '.$match[4],
+                'amount' => $amount,
+            ];
+        }
+
+        return $items;
+    }
+
+    /**
+     * @return array{0: string|null, 1: string|null}
+     */
+    private static function paymentMethod(string $text): array
+    {
+        if (preg_match('/Payment method\s+([A-Za-z][A-Za-z ]{0,20}?)\s*[•*]{2,}\s*(\d{4})\b/iu', $text, $m) === 1) {
+            return [mb_trim($m[1]), $m[2]];
+        }
+
+        if (preg_match('/Payment method\s+([A-Za-z][A-Za-z ]{0,20}?)\s+(?:ending(?:\s+in)?\s+)?(\d{4})\b/i', $text, $m) === 1) {
+            return [mb_trim($m[1]), $m[2]];
+        }
+
+        return [null, null];
+    }
+
+    private static function paymentDate(string $text): ?string
+    {
+        if (preg_match('/Payment date\s+((?:[A-Za-z]{3,},?\s+)?\d{1,2}\s+[A-Za-z]+\s+\d{4})/i', $text, $m) === 1) {
+            return mb_trim($m[1]);
+        }
+
+        return null;
+    }
+
+    private static function money(string $text, string $pattern): ?int
+    {
+        if (preg_match($pattern, $text, $m) === 1) {
+            return self::centsFromString($m[1]);
+        }
+
+        return null;
+    }
+
+    private static function centsFromString(string $value): int
+    {
+        return (int) round(((float) str_replace(',', '', $value)) * 100);
+    }
+}

--- a/app/Support/Transactions/CategoryAttribution.php
+++ b/app/Support/Transactions/CategoryAttribution.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support\Transactions;
+
+use Illuminate\Database\Query\Builder;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Category-attribution atoms for a user's current transactions.
+ *
+ * Every money surface (budgets, reports, calendar, category counts) attributes
+ * spend to categories through this single primitive so a split transaction is
+ * counted once, against its allocation lines rather than its own category_id.
+ *
+ * A current, unsplit transaction contributes one atom under its own category_id.
+ * A split transaction contributes one atom per allocation line under the line's
+ * category_id; its own category_id is suppressed, so nothing is double-counted.
+ *
+ * Columns exposed on each atom: transaction_id, category_id, amount, direction,
+ * post_date, transfer_pair_id. Callers apply their own date/direction/category
+ * filters and aggregate. Portable across SQLite and MySQL.
+ */
+final class CategoryAttribution
+{
+    public static function atoms(int $userId): Builder
+    {
+        $notVersioned = static function (Builder $query): void {
+            $query->select(DB::raw('1'))
+                ->from('transactions as c')
+                ->whereColumn('c.parent_transaction_id', 't.id')
+                ->whereNull('c.deleted_at');
+        };
+
+        $unsplit = DB::table('transactions as t')
+            ->whereNull('t.deleted_at')
+            ->where('t.user_id', $userId)
+            ->whereNotExists($notVersioned)
+            ->whereNotExists(static function (Builder $query): void {
+                $query->select(DB::raw('1'))
+                    ->from('transaction_splits as s')
+                    ->whereColumn('s.transaction_id', 't.id');
+            })
+            ->select([
+                't.id as transaction_id',
+                't.category_id as category_id',
+                't.amount as amount',
+                't.direction as direction',
+                't.post_date as post_date',
+                't.transfer_pair_id as transfer_pair_id',
+            ]);
+
+        $split = DB::table('transaction_splits as s')
+            ->join('transactions as t', 't.id', '=', 's.transaction_id')
+            ->whereNull('t.deleted_at')
+            ->where('t.user_id', $userId)
+            ->whereNotExists($notVersioned)
+            ->select([
+                't.id as transaction_id',
+                's.category_id as category_id',
+                's.amount as amount',
+                't.direction as direction',
+                't.post_date as post_date',
+                't.transfer_pair_id as transfer_pair_id',
+            ]);
+
+        return $unsplit->unionAll($split);
+    }
+
+    public static function query(int $userId): Builder
+    {
+        return DB::query()->fromSub(self::atoms($userId), 'atoms');
+    }
+}

--- a/app/Support/Transactions/CategoryAttribution.php
+++ b/app/Support/Transactions/CategoryAttribution.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Support\Transactions;
 
+use App\Models\Transaction;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Facades\DB;
 
@@ -26,43 +27,36 @@ final class CategoryAttribution
 {
     public static function atoms(int $userId): Builder
     {
-        $notVersioned = static function (Builder $query): void {
-            $query->select(DB::raw('1'))
-                ->from('transactions as c')
-                ->whereColumn('c.parent_transaction_id', 't.id')
-                ->whereNull('c.deleted_at');
-        };
-
-        $unsplit = DB::table('transactions as t')
-            ->whereNull('t.deleted_at')
-            ->where('t.user_id', $userId)
-            ->whereNotExists($notVersioned)
+        $unsplit = Transaction::query()
+            ->current()
+            ->where('transactions.user_id', $userId)
+            ->toBase()
             ->whereNotExists(static function (Builder $query): void {
                 $query->select(DB::raw('1'))
                     ->from('transaction_splits as s')
-                    ->whereColumn('s.transaction_id', 't.id');
+                    ->whereColumn('s.transaction_id', 'transactions.id');
             })
             ->select([
-                't.id as transaction_id',
-                't.category_id as category_id',
-                't.amount as amount',
-                't.direction as direction',
-                't.post_date as post_date',
-                't.transfer_pair_id as transfer_pair_id',
+                'transactions.id as transaction_id',
+                'transactions.category_id as category_id',
+                'transactions.amount as amount',
+                'transactions.direction as direction',
+                'transactions.post_date as post_date',
+                'transactions.transfer_pair_id as transfer_pair_id',
             ]);
 
-        $split = DB::table('transaction_splits as s')
-            ->join('transactions as t', 't.id', '=', 's.transaction_id')
-            ->whereNull('t.deleted_at')
-            ->where('t.user_id', $userId)
-            ->whereNotExists($notVersioned)
+        $split = Transaction::query()
+            ->current()
+            ->where('transactions.user_id', $userId)
+            ->toBase()
+            ->join('transaction_splits as s', 's.transaction_id', '=', 'transactions.id')
             ->select([
-                't.id as transaction_id',
+                'transactions.id as transaction_id',
                 's.category_id as category_id',
                 's.amount as amount',
-                't.direction as direction',
-                't.post_date as post_date',
-                't.transfer_pair_id as transfer_pair_id',
+                'transactions.direction as direction',
+                'transactions.post_date as post_date',
+                'transactions.transfer_pair_id as transfer_pair_id',
             ]);
 
         return $unsplit->unionAll($split);

--- a/database/factories/TransactionSplitFactory.php
+++ b/database/factories/TransactionSplitFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\Category;
+use App\Models\Transaction;
+use App\Models\TransactionSplit;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<TransactionSplit>
+ */
+final class TransactionSplitFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'transaction_id' => Transaction::factory(),
+            'category_id' => Category::factory(),
+            'amount' => fake()->numberBetween(100, 25000),
+            'notes' => null,
+            'position' => 0,
+        ];
+    }
+}

--- a/database/migrations/2026_07_14_000000_create_transaction_splits_table.php
+++ b/database/migrations/2026_07_14_000000_create_transaction_splits_table.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('transaction_splits', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('transaction_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('category_id')->nullable()->constrained()->nullOnDelete();
+            $table->bigInteger('amount');
+            $table->string('notes')->nullable();
+            $table->unsignedSmallInteger('position')->default(0);
+            $table->timestamps();
+
+            $table->index(['transaction_id', 'position']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('transaction_splits');
+    }
+};

--- a/database/migrations/2026_07_14_000001_add_details_to_transaction_emails_table.php
+++ b/database/migrations/2026_07_14_000001_add_details_to_transaction_emails_table.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('transaction_emails', function (Blueprint $table) {
+            $table->json('details')->nullable()->after('snippet');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('transaction_emails', function (Blueprint $table) {
+            $table->dropColumn('details');
+        });
+    }
+};

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -305,6 +305,28 @@ select:focus[data-flux-control] {
     .email-link { display: inline-block; margin-top: 4px; color: var(--color-cib-teal-500); font-weight: 700; }
     .email-empty { color: var(--color-fg-3); font-style: italic; }
 
+    /* ---------- Email receipt breakdown (Ticket #342) ---------- */
+    .receipt { margin-top: 4px; }
+    .receipt-head {
+        display: flex; flex-wrap: wrap; align-items: baseline; gap: 4px 10px;
+        margin-bottom: 6px;
+    }
+    .receipt-total { font: 900 14px/1 var(--font-display); color: var(--color-fg-1); }
+    .receipt-date { color: var(--color-fg-3); }
+    .receipt-method { color: var(--color-fg-3); margin-left: auto; }
+    .receipt-items {
+        border-top: 1px solid var(--color-border-1);
+    }
+    .receipt-item {
+        display: grid;
+        grid-template-columns: minmax(0, 1fr) auto auto;
+        gap: 10px; align-items: baseline;
+        padding: 4px 0; border-bottom: 1px solid var(--color-border-1);
+    }
+    .receipt-merchant { font-weight: 700; color: var(--color-fg-1); min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .receipt-installment { color: var(--color-fg-3); font-size: 11px; }
+    .receipt-amount { font-weight: 700; color: var(--color-fg-2); text-align: right; }
+
     /* ---------- Split panel (Ticket #342) ---------- */
     .split-panel {
         padding: 10px 4px 12px 48px;

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -280,6 +280,8 @@ select:focus[data-flux-control] {
 
     .tx-meta .pill.email { background: var(--color-cib-teal-50); color: var(--color-cib-teal-600); }
 
+    .tx-meta .pill.split { background: var(--color-cib-cream-50); color: var(--color-cib-yellow-600); }
+
     /* ---------- Email scan panel (Ticket #340) ---------- */
     .email-scan-panel {
         padding: 10px 4px 12px 48px;
@@ -302,6 +304,31 @@ select:focus[data-flux-control] {
     .email-snippet { margin-top: 3px; color: var(--color-fg-2); }
     .email-link { display: inline-block; margin-top: 4px; color: var(--color-cib-teal-500); font-weight: 700; }
     .email-empty { color: var(--color-fg-3); font-style: italic; }
+
+    /* ---------- Split panel (Ticket #342) ---------- */
+    .split-panel {
+        padding: 10px 4px 12px 48px;
+        border-bottom: 1px solid var(--color-border-1);
+        font: 400 12px/1.4 var(--font-sans);
+        color: var(--color-fg-2);
+    }
+    .split-panel:last-child { border-bottom: 0; }
+    .split-error { color: var(--color-money-owed); font-weight: 700; margin-bottom: 8px; }
+    .split-lines { display: flex; flex-direction: column; gap: 6px; }
+    .split-line {
+        display: grid;
+        grid-template-columns: minmax(0, 2fr) 96px minmax(0, 1.5fr) auto;
+        gap: 8px; align-items: center;
+    }
+    .split-line .split-amount input { text-align: right; }
+    .split-foot {
+        display: flex; justify-content: space-between; align-items: center;
+        gap: 12px; margin-top: 10px; flex-wrap: wrap;
+    }
+    .split-remainder { display: flex; align-items: center; gap: 8px; }
+    .split-remainder-value { font-weight: 700; color: var(--color-money-owed); }
+    .split-remainder-value.is-zero { color: var(--color-cib-green-600); }
+    .split-buttons { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; }
 
     .budget-row {
         display: flex; justify-content: space-between; align-items: center;

--- a/resources/views/components/cib/receipt-summary.blade.php
+++ b/resources/views/components/cib/receipt-summary.blade.php
@@ -1,0 +1,41 @@
+@use('App\Casts\MoneyCast')
+
+@props(['receipt'])
+
+@php
+    $total = is_numeric($receipt['total'] ?? null) ? (int) $receipt['total'] : null;
+    $date = is_string($receipt['date'] ?? null) ? $receipt['date'] : null;
+    $method = is_string($receipt['method'] ?? null) ? $receipt['method'] : null;
+    $last4 = is_string($receipt['last4'] ?? null) ? $receipt['last4'] : null;
+    $items = is_array($receipt['items'] ?? null) ? $receipt['items'] : [];
+@endphp
+
+<div class="receipt">
+    @if($total !== null || $date !== null)
+        <div class="receipt-head">
+            @if($total !== null)
+                <span class="receipt-total">{{ MoneyCast::format($total) }}</span>
+            @endif
+            @if($date !== null)
+                <span class="receipt-date">{{ $date }}</span>
+            @endif
+            @if($method !== null)
+                <span class="receipt-method">{{ $method }}@if($last4) ···· {{ $last4 }}@endif</span>
+            @endif
+        </div>
+    @endif
+
+    @if($items !== [])
+        <div class="receipt-items">
+            @foreach($items as $item)
+                <div class="receipt-item">
+                    <span class="receipt-merchant">{{ $item['merchant'] ?? '—' }}</span>
+                    @if(! empty($item['installment']))
+                        <span class="receipt-installment">{{ $item['installment'] }}</span>
+                    @endif
+                    <span class="receipt-amount">{{ MoneyCast::format((int) ($item['amount'] ?? 0)) }}</span>
+                </div>
+            @endforeach
+        </div>
+    @endif
+</div>

--- a/resources/views/livewire/transaction-list.blade.php
+++ b/resources/views/livewire/transaction-list.blade.php
@@ -197,7 +197,9 @@
                                                         <div class="email-row-body">
                                                             <div class="email-subject">{{ $email->subject }}</div>
                                                             <div class="email-meta">{{ $email->from_name ?? $email->from_address }}@if($email->email_date) · {{ $email->email_date->format('j M Y') }}@endif</div>
-                                                            @if($email->snippet)
+                                                            @if(is_array($email->details))
+                                                                <x-cib.receipt-summary :receipt="$email->details"/>
+                                                            @elseif($email->snippet)
                                                                 <div class="email-snippet">{{ $email->snippet }}</div>
                                                             @endif
                                                             <a href="{{ GmailService::deepLink($email->gmail_message_id) }}" target="_blank" rel="noopener" class="email-link">Open in Gmail</a>
@@ -218,7 +220,9 @@
                                                         <div class="email-row-body">
                                                             <div class="email-subject">{{ $result['subject'] }}</div>
                                                             <div class="email-meta">{{ $result['fromName'] ?? $result['fromAddress'] }}@if($result['date']) · {{ CarbonImmutable::parse($result['date'])->format('j M Y') }}@endif</div>
-                                                            @if($result['snippet'])
+                                                            @if(is_array($result['details'] ?? null))
+                                                                <x-cib.receipt-summary :receipt="$result['details']"/>
+                                                            @elseif($result['snippet'])
                                                                 <div class="email-snippet">{{ $result['snippet'] }}</div>
                                                             @endif
                                                             @php $resultMessageId = $result['messageId'] ?? null; @endphp

--- a/resources/views/livewire/transaction-list.blade.php
+++ b/resources/views/livewire/transaction-list.blade.php
@@ -251,12 +251,12 @@
                                         <div class="split-lines">
                                             @foreach($splitLines as $index => $line)
                                                 <div wire:key="split-line-{{ $transaction->id }}-{{ $index }}" class="split-line">
-                                                    <flux:select wire:model.live="splitLines.{{ $index }}.category_id" size="sm">
-                                                        <flux:select.option value="">Category</flux:select.option>
-                                                        @foreach($splitCategories as $cat)
-                                                            <flux:select.option :value="(string) $cat->id">{{ $cat->fullPath() }}</flux:select.option>
-                                                        @endforeach
-                                                    </flux:select>
+                                                    <x-category-combobox
+                                                        wire:model="splitLines.{{ $index }}.category_id"
+                                                        :categories="$splitCategories"
+                                                        placeholder="Category"
+                                                        size="sm"
+                                                    />
                                                     <flux:input wire:model.live.debounce.400ms="splitLines.{{ $index }}.amount" size="sm" class="split-amount" inputmode="decimal" placeholder="0.00"/>
                                                     <flux:input wire:model.blur="splitLines.{{ $index }}.notes" size="sm" class="split-notes" placeholder="Note (optional)"/>
                                                     <flux:button variant="ghost" size="sm" icon="x-mark"

--- a/resources/views/livewire/transaction-list.blade.php
+++ b/resources/views/livewire/transaction-list.blade.php
@@ -144,8 +144,11 @@
                             @foreach($dayTxns as $transaction)
                                 @php
                                     $tone = $transaction->direction === TransactionDirection::Credit ? 'inc' : 'out';
+                                    $splitCategoryLabel = $transaction->isSplit()
+                                        ? $transaction->splits->map(fn ($s) => $s->category?->name)->filter()->unique()->join(' · ')
+                                        : null;
                                     $metaParts = array_filter([
-                                        $transaction->category?->name,
+                                        $splitCategoryLabel !== null && $splitCategoryLabel !== '' ? $splitCategoryLabel : $transaction->category?->name,
                                         $account === null ? $transaction->account?->name : null,
                                     ]);
                                     $isPlanned = $transaction->planned_transaction_id !== null;
@@ -248,13 +251,14 @@
                                         <div class="split-lines">
                                             @foreach($splitLines as $index => $line)
                                                 <div wire:key="split-line-{{ $transaction->id }}-{{ $index }}" class="split-line">
-                                                    <flux:select wire:model="splitLines.{{ $index }}.category_id" size="sm" placeholder="Category">
+                                                    <flux:select wire:model.live="splitLines.{{ $index }}.category_id" size="sm">
+                                                        <flux:select.option value="">Category</flux:select.option>
                                                         @foreach($splitCategories as $cat)
-                                                            <flux:select.option :value="$cat->id">{{ $cat->fullPath() }}</flux:select.option>
+                                                            <flux:select.option :value="(string) $cat->id">{{ $cat->fullPath() }}</flux:select.option>
                                                         @endforeach
                                                     </flux:select>
-                                                    <flux:input wire:model="splitLines.{{ $index }}.amount" size="sm" class="split-amount" inputmode="decimal" placeholder="0.00"/>
-                                                    <flux:input wire:model="splitLines.{{ $index }}.notes" size="sm" class="split-notes" placeholder="Note (optional)"/>
+                                                    <flux:input wire:model.live.debounce.400ms="splitLines.{{ $index }}.amount" size="sm" class="split-amount" inputmode="decimal" placeholder="0.00"/>
+                                                    <flux:input wire:model.blur="splitLines.{{ $index }}.notes" size="sm" class="split-notes" placeholder="Note (optional)"/>
                                                     <flux:button variant="ghost" size="sm" icon="x-mark"
                                                                  wire:click="removeSplitLine({{ $index }})"
                                                                  data-testid="remove-split-line-{{ $transaction->id }}-{{ $index }}" aria-label="Remove line"/>
@@ -273,7 +277,7 @@
                                                 @if($transaction->isSplit())
                                                     <flux:button variant="ghost" size="sm" icon="arrow-uturn-left" wire:click="unsplit({{ $transaction->id }})" data-testid="unsplit-{{ $transaction->id }}">Unsplit</flux:button>
                                                 @endif
-                                                <flux:button variant="primary" size="sm" wire:click="saveSplit" :disabled="$splitRemainderCents !== 0" data-testid="save-split-{{ $transaction->id }}">Save split</flux:button>
+                                                <flux:button variant="primary" size="sm" wire:click="saveSplit" :disabled="$splitRemainderCents !== 0 || count($splitLines) < 2" data-testid="save-split-{{ $transaction->id }}">Save split</flux:button>
                                             </div>
                                         </div>
                                     </div>

--- a/resources/views/livewire/transaction-list.blade.php
+++ b/resources/views/livewire/transaction-list.blade.php
@@ -2,6 +2,7 @@
     use App\Enums\TransactionDirection;
     use App\Services\GmailService;
     use Carbon\CarbonImmutable;
+    use App\Support\AmountParser;
 @endphp
 <div class="space-y-6">
     <div class="flex flex-wrap items-center justify-between gap-4">
@@ -157,17 +158,23 @@
                                     :icon="$transaction->category?->resolveIcon()"
                                     :click="'$dispatch(\'edit-transaction\', { id: ' . $transaction->id . ' })'"
                                 >
-                                    @if(! empty($metaParts) || $isPlanned || $transaction->emails->isNotEmpty())
-                                        <x-slot:meta>{{ implode(' · ', $metaParts) }}@if($isPlanned) <span class="pill plan">Planned</span>@endif@if($transaction->emails->isNotEmpty()) <span class="pill email">{{ $transaction->emails->count() }} email{{ $transaction->emails->count() > 1 ? 's' : '' }}</span>@endif</x-slot:meta>
+                                    @if(! empty($metaParts) || $isPlanned || $transaction->emails->isNotEmpty() || $transaction->isSplit())
+                                        <x-slot:meta>{{ implode(' · ', $metaParts) }}@if($isPlanned) <span class="pill plan">Planned</span>@endif@if($transaction->isSplit()) <span class="pill split">Split ({{ $transaction->splits->count() }})</span>@endif@if($transaction->emails->isNotEmpty()) <span class="pill email">{{ $transaction->emails->count() }} email{{ $transaction->emails->count() > 1 ? 's' : '' }}</span>@endif</x-slot:meta>
                                     @endif
-                                    @if($gmailEnabled)
-                                        <x-slot:actions>
+                                    <x-slot:actions>
+                                        @if($transaction->transfer_pair_id === null)
+                                            <flux:button variant="ghost" size="sm" icon="scissors"
+                                                         wire:click="toggleSplit({{ $transaction->id }})"
+                                                         wire:loading.attr="disabled" wire:target="toggleSplit({{ $transaction->id }})"
+                                                         data-testid="split-{{ $transaction->id }}" aria-label="Split transaction"/>
+                                        @endif
+                                        @if($gmailEnabled)
                                             <flux:button variant="ghost" size="sm" icon="envelope"
                                                          wire:click="scanEmail({{ $transaction->id }})"
                                                          wire:loading.attr="disabled" wire:target="scanEmail({{ $transaction->id }})"
                                                          data-testid="scan-email-{{ $transaction->id }}" aria-label="Scan email"/>
-                                        </x-slot:actions>
-                                    @endif
+                                        @endif
+                                    </x-slot:actions>
                                 </x-cib.tx-row>
                                 @if($emailPanelTxnId === $transaction->id)
                                     @php
@@ -227,6 +234,48 @@
                                         @if(! $emailScanError && $transaction->emails->isEmpty() && $newResults->isEmpty())
                                             <p class="email-empty">No matching emails found.</p>
                                         @endif
+                                    </div>
+                                @endif
+                                @if($splitPanelTxnId === $transaction->id)
+                                    @php
+                                        $splitRemainderCents = abs((int) $transaction->amount) - collect($splitLines)->sum(fn (array $l): int => AmountParser::parse((string) ($l['amount'] ?? ''))->amount);
+                                    @endphp
+                                    <div wire:key="split-panel-{{ $transaction->id }}" class="split-panel" data-testid="split-panel-{{ $transaction->id }}">
+                                        @if($splitError)
+                                            <p class="split-error" data-testid="split-error-{{ $transaction->id }}">{{ $splitError }}</p>
+                                        @endif
+
+                                        <div class="split-lines">
+                                            @foreach($splitLines as $index => $line)
+                                                <div wire:key="split-line-{{ $transaction->id }}-{{ $index }}" class="split-line">
+                                                    <flux:select wire:model="splitLines.{{ $index }}.category_id" size="sm" placeholder="Category">
+                                                        @foreach($splitCategories as $cat)
+                                                            <flux:select.option :value="$cat->id">{{ $cat->fullPath() }}</flux:select.option>
+                                                        @endforeach
+                                                    </flux:select>
+                                                    <flux:input wire:model="splitLines.{{ $index }}.amount" size="sm" class="split-amount" inputmode="decimal" placeholder="0.00"/>
+                                                    <flux:input wire:model="splitLines.{{ $index }}.notes" size="sm" class="split-notes" placeholder="Note (optional)"/>
+                                                    <flux:button variant="ghost" size="sm" icon="x-mark"
+                                                                 wire:click="removeSplitLine({{ $index }})"
+                                                                 data-testid="remove-split-line-{{ $transaction->id }}-{{ $index }}" aria-label="Remove line"/>
+                                                </div>
+                                            @endforeach
+                                        </div>
+
+                                        <div class="split-foot">
+                                            <div class="split-remainder">
+                                                <span class="cib-label">Remainder</span>
+                                                <span @class(['split-remainder-value', 'is-zero' => $splitRemainderCents === 0]) data-testid="split-remainder-{{ $transaction->id }}">{{ $formatMoney($splitRemainderCents) }}</span>
+                                            </div>
+                                            <div class="split-buttons">
+                                                <flux:button variant="ghost" size="sm" icon="plus" wire:click="addSplitLine" data-testid="add-split-line-{{ $transaction->id }}">Add line</flux:button>
+                                                <flux:button variant="ghost" size="sm" wire:click="assignRemainderToLast" data-testid="assign-remainder-{{ $transaction->id }}">Assign remainder</flux:button>
+                                                @if($transaction->isSplit())
+                                                    <flux:button variant="ghost" size="sm" icon="arrow-uturn-left" wire:click="unsplit({{ $transaction->id }})" data-testid="unsplit-{{ $transaction->id }}">Unsplit</flux:button>
+                                                @endif
+                                                <flux:button variant="primary" size="sm" wire:click="saveSplit" :disabled="$splitRemainderCents !== 0" data-testid="save-split-{{ $transaction->id }}">Save split</flux:button>
+                                            </div>
+                                        </div>
                                     </div>
                                 @endif
                             @endforeach

--- a/tests/Feature/Livewire/TransactionListTest.php
+++ b/tests/Feature/Livewire/TransactionListTest.php
@@ -1557,3 +1557,210 @@ test('emailResults is locked against forged client updates', function () {
         ->set('emailResults', [['messageId' => 'x', 'gmailUrl' => 'javascript:alert(1)']]))
         ->toThrow(CannotUpdateLockedPropertyException::class);
 });
+
+function splitTransaction(User $user, int $amount = -10000): Transaction
+{
+    $account = Account::factory()->for($user)->create();
+
+    return Transaction::factory()->for($user)->for($account)->debit()->create([
+        'description' => 'AFTERPAY PURCHASE',
+        'amount' => $amount,
+        'post_date' => now()->subDays(3),
+    ]);
+}
+
+test('saveSplit persists exact-cover lines carrying the parent sign', function () {
+    $user = User::factory()->create();
+    $transaction = splitTransaction($user, -10000);
+    $groceries = Category::factory()->create();
+    $fuel = Category::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(TransactionList::class)
+        ->call('toggleSplit', $transaction->id)
+        ->set('splitLines', [
+            ['category_id' => $groceries->id, 'amount' => '70.00', 'notes' => 'weekly shop'],
+            ['category_id' => $fuel->id, 'amount' => '30.00', 'notes' => ''],
+        ])
+        ->call('saveSplit')
+        ->assertSet('splitError', null)
+        ->assertSet('splitPanelTxnId', null);
+
+    $this->assertDatabaseHas('transaction_splits', [
+        'transaction_id' => $transaction->id,
+        'category_id' => $groceries->id,
+        'amount' => -7000,
+        'notes' => 'weekly shop',
+    ]);
+    $this->assertDatabaseHas('transaction_splits', [
+        'transaction_id' => $transaction->id,
+        'category_id' => $fuel->id,
+        'amount' => -3000,
+    ]);
+
+    expect($transaction->fresh()->splitRemainder())->toBe(0);
+});
+
+test('saveSplit rejects lines that do not cover the total', function () {
+    $user = User::factory()->create();
+    $transaction = splitTransaction($user, -10000);
+    $groceries = Category::factory()->create();
+    $fuel = Category::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(TransactionList::class)
+        ->call('toggleSplit', $transaction->id)
+        ->set('splitLines', [
+            ['category_id' => $groceries->id, 'amount' => '70.00', 'notes' => ''],
+            ['category_id' => $fuel->id, 'amount' => '20.00', 'notes' => ''],
+        ])
+        ->call('saveSplit')
+        ->assertSet('splitError', 'Split lines must add up to the transaction total.');
+
+    $this->assertDatabaseCount('transaction_splits', 0);
+});
+
+test('saveSplit requires a category on every line', function () {
+    $user = User::factory()->create();
+    $transaction = splitTransaction($user, -10000);
+    $groceries = Category::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(TransactionList::class)
+        ->call('toggleSplit', $transaction->id)
+        ->set('splitLines', [
+            ['category_id' => $groceries->id, 'amount' => '60.00', 'notes' => ''],
+            ['category_id' => null, 'amount' => '40.00', 'notes' => ''],
+        ])
+        ->call('saveSplit')
+        ->assertSet('splitError', 'Every split line needs a category.');
+
+    $this->assertDatabaseCount('transaction_splits', 0);
+});
+
+test('saveSplit rejects a single-line split', function () {
+    $user = User::factory()->create();
+    $transaction = splitTransaction($user, -10000);
+    $groceries = Category::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(TransactionList::class)
+        ->call('toggleSplit', $transaction->id)
+        ->set('splitLines', [
+            ['category_id' => $groceries->id, 'amount' => '100.00', 'notes' => ''],
+        ])
+        ->call('saveSplit')
+        ->assertSet('splitError', 'A split needs at least two lines.');
+
+    $this->assertDatabaseCount('transaction_splits', 0);
+});
+
+test('unsplit removes every split line and reverts to the own category', function () {
+    $user = User::factory()->create();
+    $transaction = splitTransaction($user, -10000);
+    $groceries = Category::factory()->create();
+    $fuel = Category::factory()->create();
+
+    $transaction->splits()->createMany([
+        ['category_id' => $groceries->id, 'amount' => -7000, 'position' => 0],
+        ['category_id' => $fuel->id, 'amount' => -3000, 'position' => 1],
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(TransactionList::class)
+        ->call('unsplit', $transaction->id);
+
+    expect($transaction->fresh()->isSplit())->toBeFalse();
+    $this->assertDatabaseCount('transaction_splits', 0);
+});
+
+test('splitPanelTxnId is locked against forged client updates', function () {
+    $user = User::factory()->create();
+
+    expect(fn () => Livewire::actingAs($user)
+        ->test(TransactionList::class)
+        ->set('splitPanelTxnId', 999))
+        ->toThrow(CannotUpdateLockedPropertyException::class);
+});
+
+test('toggleSplit refuses another users transaction', function () {
+    $user = User::factory()->create();
+    $other = User::factory()->create();
+    $foreign = splitTransaction($other, -5000);
+
+    expect(fn () => Livewire::actingAs($user)
+        ->test(TransactionList::class)
+        ->call('toggleSplit', $foreign->id))
+        ->toThrow(ModelNotFoundException::class);
+});
+
+test('category filter matches transactions by their split lines', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $ownCategory = Category::factory()->create();
+    $groceries = Category::factory()->create();
+
+    $transaction = Transaction::factory()->for($user)->for($account)->debit()->create([
+        'category_id' => $ownCategory->id,
+        'amount' => -10000,
+        'description' => 'SPLIT ME BNPL',
+        'post_date' => now()->subDays(3),
+    ]);
+    $transaction->splits()->createMany([
+        ['category_id' => $groceries->id, 'amount' => -6000, 'position' => 0],
+        ['category_id' => $ownCategory->id, 'amount' => -4000, 'position' => 1],
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(TransactionList::class)
+        ->set('category', $groceries->id)
+        ->assertSee('SPLIT ME BNPL');
+});
+
+test('categorised filter treats a split transaction as categorised', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $groceries = Category::factory()->create();
+    $fuel = Category::factory()->create();
+
+    $transaction = Transaction::factory()->for($user)->for($account)->debit()->create([
+        'category_id' => null,
+        'amount' => -10000,
+        'description' => 'UNCATEGORISED BNPL',
+        'post_date' => now()->subDays(3),
+    ]);
+    $transaction->splits()->createMany([
+        ['category_id' => $groceries->id, 'amount' => -6000, 'position' => 0],
+        ['category_id' => $fuel->id, 'amount' => -4000, 'position' => 1],
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(TransactionList::class)
+        ->set('categorised', 'categorised')
+        ->assertSee('UNCATEGORISED BNPL');
+
+    Livewire::actingAs($user)
+        ->test(TransactionList::class)
+        ->set('categorised', 'uncategorised')
+        ->assertDontSee('UNCATEGORISED BNPL');
+});
+
+test('a transfer-paired transaction cannot be split', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $pair = Transaction::factory()->for($user)->for($account)->credit()->create([
+        'post_date' => now()->subDays(3),
+    ]);
+    $transfer = Transaction::factory()->for($user)->for($account)->debit()->create([
+        'amount' => -10000,
+        'transfer_pair_id' => $pair->id,
+        'description' => 'INTERNAL TRANSFER',
+        'post_date' => now()->subDays(3),
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(TransactionList::class)
+        ->assertDontSee('split-'.$transfer->id)
+        ->call('toggleSplit', $transfer->id)
+        ->assertSet('splitPanelTxnId', null);
+});

--- a/tests/Feature/Livewire/TransactionListTest.php
+++ b/tests/Feature/Livewire/TransactionListTest.php
@@ -1782,3 +1782,48 @@ test('saveSplit rejects a line whose category select was never chosen', function
 
     $this->assertDatabaseCount('transaction_splits', 0);
 });
+
+test('scanEmail surfaces the receipt breakdown and linkEmail persists it', function () {
+    $user = User::factory()->create();
+    $transaction = afterpayTransaction($user);
+
+    $details = [
+        'total' => 11279,
+        'date' => 'Fri, 3 July 2026',
+        'method' => 'Visa',
+        'last4' => '8357',
+        'items' => [
+            ['merchant' => 'Petbarn', 'reference' => '900438021', 'installment' => '4 of 4', 'amount' => 2124],
+            ['merchant' => 'Addicted To Audio', 'reference' => '917982502', 'installment' => '2 of 4', 'amount' => 3475],
+        ],
+    ];
+
+    $this->mock(GmailServiceContract::class, function ($mock) use ($details): void {
+        $mock->shouldReceive('isConfigured')->andReturn(true);
+        $mock->shouldReceive('searchForTransaction')->andReturn(collect([
+            new EmailSearchResult(
+                messageId: 'receipt@mail.gmail.com',
+                subject: 'Your Afterpay payment',
+                fromName: 'Afterpay',
+                fromAddress: 'no-reply@afterpay.com',
+                date: '2026-06-13T10:00:00+10:00',
+                snippet: 'Hi Robert Wilde',
+                gmailUrl: 'https://mail.google.com/mail/u/0/#search/rfc822msgid:receipt',
+                details: $details,
+            ),
+        ]));
+    });
+
+    Livewire::actingAs($user)
+        ->test(TransactionList::class)
+        ->call('scanEmail', $transaction->id)
+        ->assertSee('Petbarn')
+        ->assertSee('Addicted To Audio')
+        ->assertSee('$21.24')
+        ->call('linkEmail', $transaction->id, 0)
+        ->assertSee('Petbarn');
+
+    $email = TransactionEmail::query()->firstOrFail();
+
+    expect($email->details)->toBe($details);
+});

--- a/tests/Feature/Livewire/TransactionListTest.php
+++ b/tests/Feature/Livewire/TransactionListTest.php
@@ -1764,3 +1764,21 @@ test('a transfer-paired transaction cannot be split', function () {
         ->call('toggleSplit', $transfer->id)
         ->assertSet('splitPanelTxnId', null);
 });
+
+test('saveSplit rejects a line whose category select was never chosen', function () {
+    $user = User::factory()->create();
+    $transaction = splitTransaction($user, -10000);
+    $groceries = Category::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(TransactionList::class)
+        ->call('toggleSplit', $transaction->id)
+        ->set('splitLines', [
+            ['category_id' => (string) $groceries->id, 'amount' => '60.00', 'notes' => ''],
+            ['category_id' => '', 'amount' => '40.00', 'notes' => ''],
+        ])
+        ->call('saveSplit')
+        ->assertSet('splitError', 'Every split line needs a category.');
+
+    $this->assertDatabaseCount('transaction_splits', 0);
+});

--- a/tests/Feature/Livewire/TransactionListTest.php
+++ b/tests/Feature/Livewire/TransactionListTest.php
@@ -1,5 +1,7 @@
 <?php
 
+/** @noinspection PhpUnhandledExceptionInspection */
+
 /** @noinspection StaticClosureCanBeUsedInspection */
 
 declare(strict_types=1);
@@ -1599,6 +1601,25 @@ test('saveSplit persists exact-cover lines carrying the parent sign', function (
     ]);
 
     expect($transaction->fresh()->splitRemainder())->toBe(0);
+});
+
+test('saveSplit rejects a line note longer than 255 characters', function () {
+    $user = User::factory()->create();
+    $transaction = splitTransaction($user, -10000);
+    $groceries = Category::factory()->create();
+    $fuel = Category::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(TransactionList::class)
+        ->call('toggleSplit', $transaction->id)
+        ->set('splitLines', [
+            ['category_id' => $groceries->id, 'amount' => '70.00', 'notes' => str_repeat('a', 256)],
+            ['category_id' => $fuel->id, 'amount' => '30.00', 'notes' => ''],
+        ])
+        ->call('saveSplit')
+        ->assertSet('splitError', 'Split notes must be 255 characters or fewer.');
+
+    $this->assertDatabaseCount('transaction_splits', 0);
 });
 
 test('saveSplit rejects lines that do not cover the total', function () {

--- a/tests/Feature/Models/TransactionSplitTest.php
+++ b/tests/Feature/Models/TransactionSplitTest.php
@@ -1,0 +1,89 @@
+<?php
+
+/** @noinspection StaticClosureCanBeUsedInspection */
+
+declare(strict_types=1);
+
+use App\Models\Account;
+use App\Models\Category;
+use App\Models\Transaction;
+use App\Models\TransactionSplit;
+use App\Models\User;
+
+test('factory creates a valid split', function () {
+    $split = TransactionSplit::factory()->create();
+
+    expect($split->exists)->toBeTrue()
+        ->and($split->amount)->toBeInt();
+});
+
+test('split belongs to a transaction and a category', function () {
+    $split = TransactionSplit::factory()->create();
+
+    expect($split->transaction)->toBeInstanceOf(Transaction::class)
+        ->and($split->category)->toBeInstanceOf(Category::class);
+});
+
+test('amount is cast to integer cents', function () {
+    $split = TransactionSplit::factory()->create(['amount' => 1234]);
+
+    expect($split->refresh()->amount)->toBe(1234);
+});
+
+test('transaction has many splits ordered by position', function () {
+    $user = User::factory()->create();
+    $transaction = Transaction::factory()->for($user)->for(Account::factory()->for($user))->create();
+
+    $transaction->splits()->create(['category_id' => Category::factory()->create()->id, 'amount' => 100, 'position' => 2]);
+    $transaction->splits()->create(['category_id' => Category::factory()->create()->id, 'amount' => 200, 'position' => 0]);
+    $transaction->splits()->create(['category_id' => Category::factory()->create()->id, 'amount' => 300, 'position' => 1]);
+
+    expect($transaction->splits()->pluck('amount')->all())->toBe([200, 300, 100]);
+});
+
+test('isSplit reflects presence of splits', function () {
+    $user = User::factory()->create();
+    $transaction = Transaction::factory()->for($user)->for(Account::factory()->for($user))->create();
+
+    expect($transaction->isSplit())->toBeFalse();
+
+    $transaction->splits()->create(['category_id' => Category::factory()->create()->id, 'amount' => 100, 'position' => 0]);
+
+    expect($transaction->fresh()->isSplit())->toBeTrue();
+});
+
+test('splitRemainder returns the uncovered amount', function () {
+    $user = User::factory()->create();
+    $transaction = Transaction::factory()->for($user)->for(Account::factory()->for($user))->create(['amount' => 10000]);
+
+    $transaction->splits()->create(['category_id' => Category::factory()->create()->id, 'amount' => 6000, 'position' => 0]);
+
+    expect($transaction->fresh()->splitTotal())->toBe(6000)
+        ->and($transaction->fresh()->splitRemainder())->toBe(4000);
+
+    $transaction->splits()->create(['category_id' => Category::factory()->create()->id, 'amount' => 4000, 'position' => 1]);
+
+    expect($transaction->fresh()->splitRemainder())->toBe(0);
+});
+
+test('deleting a transaction cascades to its splits', function () {
+    $user = User::factory()->create();
+    $transaction = Transaction::factory()->for($user)->for(Account::factory()->for($user))->create();
+    $split = $transaction->splits()->create(['category_id' => Category::factory()->create()->id, 'amount' => 100, 'position' => 0]);
+
+    $transaction->forceDelete();
+
+    expect(TransactionSplit::query()->whereKey($split->id)->exists())->toBeFalse();
+});
+
+test('deleting a category nullifies split category_id', function () {
+    $user = User::factory()->create();
+    $transaction = Transaction::factory()->for($user)->for(Account::factory()->for($user))->create();
+    $category = Category::factory()->create();
+    $split = $transaction->splits()->create(['category_id' => $category->id, 'amount' => 100, 'position' => 0]);
+
+    $category->delete();
+
+    expect($split->refresh()->category_id)->toBeNull()
+        ->and($split->amount)->toBe(100);
+});

--- a/tests/Feature/Support/Calendar/DayActivityLoaderTest.php
+++ b/tests/Feature/Support/Calendar/DayActivityLoaderTest.php
@@ -343,6 +343,51 @@ test('an unmatched posted transaction is not flagged as matched', function () {
         ->and($day->pips[0]->matched)->toBeFalse();
 });
 
+test('a split reconciled transaction renders per-line pips flagged as matched', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $groceries = Category::factory()->create(['name' => 'Groceries']);
+    $fuel = Category::factory()->create(['name' => 'Fuel']);
+    $planned = Category::factory()->create(['name' => 'Afterpay']);
+    $date = CarbonImmutable::create(2026, 6, 14);
+
+    $plannedTransaction = PlannedTransaction::factory()->for($user)->for($account)->noRepeat()->create([
+        'category_id' => $planned->id,
+        'amount' => 10000,
+        'direction' => TransactionDirection::Debit,
+        'start_date' => $date,
+    ]);
+
+    $transaction = Transaction::factory()->for($user)->debit()->create([
+        'account_id' => $account->id,
+        'category_id' => $planned->id,
+        'amount' => -10000,
+        'post_date' => $date,
+        'planned_transaction_id' => $plannedTransaction->id,
+    ]);
+
+    $transaction->splits()->createMany([
+        ['category_id' => $groceries->id, 'amount' => -7000, 'position' => 0],
+        ['category_id' => $fuel->id, 'amount' => -3000, 'position' => 1],
+    ]);
+
+    $day = (new DayActivityLoader)->load(
+        CarbonImmutable::create(2026, 6, 1),
+        CarbonImmutable::create(2026, 6, 30),
+        $user->id,
+    )[$date->format('Y-m-d')];
+
+    $names = collect($day->pips)->pluck('name')->all();
+
+    expect($day->pips)->toHaveCount(2)
+        ->and($names)->toContain('Groceries')
+        ->and($names)->toContain('Fuel')
+        ->and($names)->not->toContain('Afterpay')
+        ->and(collect($day->pips)->every(fn ($pip) => $pip->matched))->toBeTrue()
+        ->and($day->postedCents)->toBe(10000)
+        ->and($day->plannedCents)->toBe(0);
+});
+
 test('reconciled income credit suppresses the planned income pip', function () {
     $user = User::factory()->create();
     $account = Account::factory()->for($user)->create();

--- a/tests/Feature/Support/Transactions/CategoryAttributionTest.php
+++ b/tests/Feature/Support/Transactions/CategoryAttributionTest.php
@@ -1,0 +1,133 @@
+<?php
+
+/** @noinspection StaticClosureCanBeUsedInspection */
+
+declare(strict_types=1);
+
+use App\Models\Account;
+use App\Models\Category;
+use App\Models\Transaction;
+use App\Models\User;
+use App\Support\Transactions\CategoryAttribution;
+
+function attributionSum(int $userId, int $categoryId): int
+{
+    return (int) CategoryAttribution::query($userId)
+        ->where('category_id', $categoryId)
+        ->sum('amount');
+}
+
+test('unsplit transaction attributes to its own category', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $category = Category::factory()->create();
+
+    Transaction::factory()->for($user)->for($account)->create([
+        'category_id' => $category->id,
+        'amount' => 5000,
+    ]);
+
+    expect(attributionSum($user->id, $category->id))->toBe(5000);
+});
+
+test('split transaction attributes to its lines not its own category', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $ownCategory = Category::factory()->create();
+    $groceries = Category::factory()->create();
+    $fuel = Category::factory()->create();
+
+    $transaction = Transaction::factory()->for($user)->for($account)->create([
+        'category_id' => $ownCategory->id,
+        'amount' => 10000,
+    ]);
+
+    $transaction->splits()->createMany([
+        ['category_id' => $groceries->id, 'amount' => 7000, 'position' => 0],
+        ['category_id' => $fuel->id, 'amount' => 3000, 'position' => 1],
+    ]);
+
+    expect(attributionSum($user->id, $ownCategory->id))->toBe(0)
+        ->and(attributionSum($user->id, $groceries->id))->toBe(7000)
+        ->and(attributionSum($user->id, $fuel->id))->toBe(3000);
+});
+
+test('split preserves parent total across all categories', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $groceries = Category::factory()->create();
+    $fuel = Category::factory()->create();
+
+    $transaction = Transaction::factory()->for($user)->for($account)->create([
+        'category_id' => null,
+        'amount' => -8000,
+    ]);
+
+    $transaction->splits()->createMany([
+        ['category_id' => $groceries->id, 'amount' => -5000, 'position' => 0],
+        ['category_id' => $fuel->id, 'amount' => -3000, 'position' => 1],
+    ]);
+
+    $total = (int) CategoryAttribution::query($user->id)->sum('amount');
+
+    expect($total)->toBe(-8000)
+        ->and(attributionSum($user->id, $groceries->id))->toBe(-5000)
+        ->and(attributionSum($user->id, $fuel->id))->toBe(-3000);
+});
+
+test('versioned transactions are excluded so splits on stale rows do not count', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $category = Category::factory()->create();
+
+    $original = Transaction::factory()->for($user)->for($account)->create([
+        'category_id' => $category->id,
+        'amount' => 4000,
+    ]);
+
+    $original->splits()->create(['category_id' => $category->id, 'amount' => 4000, 'position' => 0]);
+
+    $original->createChild(['amount' => 4200]);
+
+    expect(attributionSum($user->id, $category->id))->toBe(4200);
+});
+
+test('only the given user is attributed', function () {
+    $user = User::factory()->create();
+    $other = User::factory()->create();
+    $category = Category::factory()->create();
+
+    Transaction::factory()->for($user)->for(Account::factory()->for($user))->create([
+        'category_id' => $category->id,
+        'amount' => 1000,
+    ]);
+    Transaction::factory()->for($other)->for(Account::factory()->for($other))->create([
+        'category_id' => $category->id,
+        'amount' => 9999,
+    ]);
+
+    expect(attributionSum($user->id, $category->id))->toBe(1000);
+});
+
+test('distinct transaction count folds multiple lines in one category', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $category = Category::factory()->create();
+
+    $transaction = Transaction::factory()->for($user)->for($account)->create([
+        'category_id' => null,
+        'amount' => 6000,
+    ]);
+
+    $transaction->splits()->createMany([
+        ['category_id' => $category->id, 'amount' => 4000, 'position' => 0],
+        ['category_id' => $category->id, 'amount' => 2000, 'position' => 1],
+    ]);
+
+    $count = (int) CategoryAttribution::query($user->id)
+        ->where('category_id', $category->id)
+        ->distinct()
+        ->count('transaction_id');
+
+    expect($count)->toBe(1);
+});

--- a/tests/Feature/TransactionSplitAttributionTest.php
+++ b/tests/Feature/TransactionSplitAttributionTest.php
@@ -1,0 +1,167 @@
+<?php
+
+/** @noinspection StaticClosureCanBeUsedInspection */
+
+declare(strict_types=1);
+
+use App\Livewire\CategoryEditor;
+use App\Models\Account;
+use App\Models\Budget;
+use App\Models\Category;
+use App\Models\Transaction;
+use App\Models\User;
+use App\Services\Reports\ReportAggregator;
+use App\Support\Calendar\DayActivityLoader;
+use Carbon\CarbonImmutable;
+use Livewire\Livewire;
+
+test('budget spend follows split lines not the parent category', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $ownCategory = Category::factory()->create();
+    $groceries = Category::factory()->create();
+    $fuel = Category::factory()->create();
+
+    $budget = Budget::factory()->for($user)->create([
+        'category_id' => $groceries->id,
+        'limit_amount' => 100000,
+    ]);
+
+    $transaction = Transaction::factory()->for($user)->for($account)->create([
+        'category_id' => $ownCategory->id,
+        'amount' => 10000,
+    ]);
+
+    $transaction->splits()->createMany([
+        ['category_id' => $groceries->id, 'amount' => 7000, 'position' => 0],
+        ['category_id' => $fuel->id, 'amount' => 3000, 'position' => 1],
+    ]);
+
+    $ownBudget = Budget::factory()->for($user)->create([
+        'category_id' => $ownCategory->id,
+        'limit_amount' => 100000,
+    ]);
+
+    expect($budget->remaining())->toBe(93000)
+        ->and($ownBudget->remaining())->toBe(100000);
+});
+
+test('reports break a split transaction into its line categories without double counting', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $ownCategory = Category::factory()->create();
+    $groceries = Category::factory()->create();
+    $fuel = Category::factory()->create();
+
+    $transaction = Transaction::factory()->for($user)->for($account)->debit()->create([
+        'category_id' => $ownCategory->id,
+        'amount' => -10000,
+        'post_date' => CarbonImmutable::create(2026, 6, 10),
+    ]);
+
+    $transaction->splits()->createMany([
+        ['category_id' => $groceries->id, 'amount' => -7000, 'position' => 0],
+        ['category_id' => $fuel->id, 'amount' => -3000, 'position' => 1],
+    ]);
+
+    $atoms = (new ReportAggregator)->atoms(
+        $user,
+        'actual',
+        CarbonImmutable::create(2026, 6, 1),
+        CarbonImmutable::create(2026, 6, 30),
+    );
+
+    $byCategory = collect($atoms)->keyBy('category_id');
+
+    expect($byCategory->has($ownCategory->id))->toBeFalse()
+        ->and((int) $byCategory[$groceries->id]['total'])->toBe(7000)
+        ->and((int) $byCategory[$fuel->id]['total'])->toBe(3000)
+        ->and(collect($atoms)->sum('total'))->toBe(10000);
+});
+
+test('calendar renders one pip per split line and keeps the day total', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $groceries = Category::factory()->create(['name' => 'Groceries']);
+    $fuel = Category::factory()->create(['name' => 'Fuel']);
+
+    $date = CarbonImmutable::create(2026, 6, 12);
+
+    $transaction = Transaction::factory()->for($user)->for($account)->debit()->create([
+        'category_id' => null,
+        'amount' => -10000,
+        'post_date' => $date,
+    ]);
+
+    $transaction->splits()->createMany([
+        ['category_id' => $groceries->id, 'amount' => -7000, 'position' => 0],
+        ['category_id' => $fuel->id, 'amount' => -3000, 'position' => 1],
+    ]);
+
+    $activity = (new DayActivityLoader)->load($date, $date, $user->id);
+    $day = $activity[$date->format('Y-m-d')];
+
+    $names = collect($day->pips)->pluck('name')->all();
+
+    expect($day->pips)->toHaveCount(2)
+        ->and($names)->toContain('Groceries')
+        ->and($names)->toContain('Fuel')
+        ->and($day->postedCents)->toBe(10000);
+});
+
+test('category editor count folds a split transaction once per category', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $groceries = Category::factory()->create();
+    $fuel = Category::factory()->create();
+
+    $transaction = Transaction::factory()->for($user)->for($account)->create([
+        'category_id' => null,
+        'amount' => 10000,
+    ]);
+
+    $transaction->splits()->createMany([
+        ['category_id' => $groceries->id, 'amount' => 4000, 'position' => 0],
+        ['category_id' => $groceries->id, 'amount' => 3000, 'position' => 1],
+        ['category_id' => $fuel->id, 'amount' => 3000, 'position' => 2],
+    ]);
+
+    $rendered = Livewire::actingAs($user)->test(CategoryEditor::class);
+
+    $categories = collect($rendered->viewData('categories'));
+
+    $groceriesRow = $categories->firstWhere('id', $groceries->id);
+    $fuelRow = $categories->firstWhere('id', $fuel->id);
+
+    expect($groceriesRow['transactions_count'])->toBe(1)
+        ->and($fuelRow['transactions_count'])->toBe(1);
+});
+
+test('dashboard budget spend attributes split debits to their line categories', function () {
+    $user = User::factory()->has(Account::factory())->create();
+    $account = $user->accounts()->first();
+    $ownCategory = Category::factory()->create();
+    $groceries = Category::factory()->create();
+
+    Budget::factory()->for($user)->create([
+        'category_id' => $groceries->id,
+        'limit_amount' => 50000,
+    ]);
+
+    $transaction = Transaction::factory()->for($user)->for($account)->debit()->create([
+        'category_id' => $ownCategory->id,
+        'amount' => -10000,
+        'post_date' => CarbonImmutable::now(),
+    ]);
+
+    $transaction->splits()->createMany([
+        ['category_id' => $groceries->id, 'amount' => -6000, 'position' => 0],
+        ['category_id' => $ownCategory->id, 'amount' => -4000, 'position' => 1],
+    ]);
+
+    $rows = Livewire::actingAs($user)->test(App\Livewire\Dashboard::class)->instance()->budgetsThisCycle();
+
+    $groceriesRow = $rows->first(fn (array $row): bool => $row['budget']->category_id === $groceries->id);
+
+    expect((int) $groceriesRow['spent'])->toBe(6000);
+});

--- a/tests/Unit/Support/Email/ReceiptParserTest.php
+++ b/tests/Unit/Support/Email/ReceiptParserTest.php
@@ -1,0 +1,84 @@
+<?php
+
+/** @noinspection StaticClosureCanBeUsedInspection */
+
+declare(strict_types=1);
+
+use App\Support\Email\ReceiptParser;
+
+$afterpayHtml = <<<'HTML'
+<html><head><style>.x{color:red}</style></head><body>
+<h1>Payment confirmation</h1>
+<table>
+  <tr><td>Total amount paid</td><td>$112.79</td></tr>
+  <tr><td>Payment date</td><td>Fri, 3 July 2026</td></tr>
+</table>
+<h2>Repayments</h2>
+<table><tr><td>Payment method</td><td>Visa</td><td>&bull;&bull;&bull;&bull; 8357</td></tr></table>
+<table>
+  <tr><td>Petbarn</td><td>Order #900438021</td><td>4 of 4</td><td>$21.24</td></tr>
+  <tr><td>Petbarn</td><td>Order #900438021</td><td>4 of 4</td><td>$21.24</td></tr>
+  <tr><td>Addicted To Audio</td><td>Order #917982502</td><td>2 of 4</td><td>$34.75</td></tr>
+  <tr><td>Addicted To Audio</td><td>Order #917982502</td><td>2 of 4</td><td>$34.75</td></tr>
+</table>
+</body></html>
+HTML;
+
+test('parses total, date and payment method from an Afterpay receipt', function () use ($afterpayHtml) {
+    $receipt = ReceiptParser::parse(null, $afterpayHtml);
+
+    expect($receipt)->not->toBeNull()
+        ->and($receipt['total'])->toBe(11279)
+        ->and($receipt['date'])->toBe('Fri, 3 July 2026')
+        ->and($receipt['method'])->toBe('Visa')
+        ->and($receipt['last4'])->toBe('8357');
+});
+
+test('deduplicates responsive line-item rows and keeps distinct merchants', function () use ($afterpayHtml) {
+    $receipt = ReceiptParser::parse(null, $afterpayHtml);
+
+    expect($receipt['items'])->toHaveCount(2)
+        ->and($receipt['items'][0])->toBe([
+            'merchant' => 'Petbarn',
+            'reference' => '900438021',
+            'installment' => '4 of 4',
+            'amount' => 2124,
+        ])
+        ->and($receipt['items'][1]['merchant'])->toBe('Addicted To Audio')
+        ->and($receipt['items'][1]['amount'])->toBe(3475);
+});
+
+test('line item amounts sum to the transaction total for a full receipt', function () {
+    $html = <<<'HTML'
+    <body>Payment confirmation Total amount paid $112.79 Payment date Fri, 3 July 2026
+    Repayments Payment method Visa &bull;&bull;&bull;&bull; 8357
+    Petbarn Order #900438021 4 of 4 $21.24
+    Addicted To Audio Order #917982502 2 of 4 $34.75
+    Petbarn Order #919235542 2 of 4 $35.80
+    Petbarn Order #927522361 1 of 4 $21.00</body>
+    HTML;
+
+    $receipt = ReceiptParser::parse(null, $html);
+
+    expect($receipt['items'])->toHaveCount(4)
+        ->and(collect($receipt['items'])->sum('amount'))->toBe($receipt['total']);
+});
+
+test('prefers the plain-text body when present', function () {
+    $text = 'Total amount paid $50.00 Repayments Payment method Visa •••• 1234 Store A Order #1 1 of 4 $50.00';
+
+    $receipt = ReceiptParser::parse($text, '<body>ignored</body>');
+
+    expect($receipt['total'])->toBe(5000)
+        ->and($receipt['items'])->toHaveCount(1)
+        ->and($receipt['items'][0]['merchant'])->toBe('Store A');
+});
+
+test('returns null for a non-receipt email', function () {
+    expect(ReceiptParser::parse('Hi there, just checking in about your order.', null))->toBeNull();
+});
+
+test('returns null for empty bodies', function () {
+    expect(ReceiptParser::parse(null, null))->toBeNull()
+        ->and(ReceiptParser::parse('', ''))->toBeNull();
+});


### PR DESCRIPTION
## Summary

Adds transaction-splitting: a user can carve a single bank transaction (e.g. an Afterpay/BNPL charge bundling several purchases) into N categorised allocation lines while the original transaction stays the one real reconcilable / planned / emailed record. Split categories drive budgets, reports, the calendar and list filters.

Refs #342

## Design

- **Side table `transaction_splits`, not child `Transaction` rows.** Real child rows would enter `current()`-based reconciliation, planned-matching, recurring/income detection, fee-folding and transfer logic and distort account totals. Splits are pure categorisation allocations: `transaction_id` (cascade delete), nullable `category_id` (null on delete), integer-cents `amount`, `notes`, `position`.
- **One shared attribution primitive: `App\Support\Transactions\CategoryAttribution`.** A `UNION ALL` over current transactions: an unsplit transaction contributes one atom under its own `category_id`; a split transaction contributes one atom per line under the line's `category_id`, and its own `category_id` is suppressed — so nothing double-counts. Portable across SQLite (`:memory:` tests) and MySQL (dev/prod).
- **Surfaces refactored through the helper:** `Budget::remaining`, `Dashboard::budgetsThisCycle`, `ReportAggregator::actualAtoms`, `DayActivityLoader` (per-line calendar pips), `CategoryEditor` counts + delete guard, and `TransactionList` category / categorised filters.
- **Exact-cover invariant.** Lines carry the parent's sign and must sum exactly to the primary amount (integer cents). Inline split panel mirrors the email-scan panel: `#[Locked]` server-owned ids, live remainder chip, add/remove line, assign-remainder, unsplit, and Save gated on a zero remainder. Server-side revalidation of ownership, category validity, ≥2 lines and exact cover.

## Decisions (previously left open)

- **Editing a split transaction's amount** re-versions it via `createChild`; the stale splits fall off `current()` and attribution cleanly reverts to the copied `category_id` (lossless). No modal guard needed.
- **Transfers cannot be split** — the scissors action is hidden and `toggleSplit`/`saveSplit` refuse transfer-paired rows.
- Splits do **not** participate in `CategoryRuleGenerator` bulk recategorisation; reconciliation / planned / email stay on the primary row.

## Verification

- `ddev artisan test` — full suite green (new `TransactionSplitTest`, `CategoryAttributionTest`, `TransactionSplitAttributionTest`, and extended `TransactionListTest` covering split CRUD, exact-cover, `#[Locked]` rejection, filter-matches-lines, unsplit revert, transfer refusal, and budgets/reports/calendar/counts reflecting splits without double-count).
- Pint and PHPStan green (GrumPHP pre-commit).

Verified: pass
