### PR TITLE
fix(#344): show the pay cycle containing today when the latest deposit is stale

### DIFF
--- a/app/Livewire/Dashboard/PayCycleCalendar.php
+++ b/app/Livewire/Dashboard/PayCycleCalendar.php
@@ -313,7 +313,10 @@ final class PayCycleCalendar extends Component
     /**
      * Resolve the current cycle window. Anchored on the user's most recent actual
      * pay deposit so a late (e.g. Friday) payment shifts the whole fortnight with
-     * it; falls back to the schedule-only bounds when no matching deposit exists.
+     * it; falls back to the schedule-only bounds when no matching deposit exists,
+     * or when the latest deposit is stale (its scheduled payday has already passed
+     * because the current cycle's deposit hasn't been imported yet) — the schedule
+     * fast-forwards to the cycle that contains today.
      *
      * @return array{start: CarbonImmutable, end: CarbonImmutable}|null
      */
@@ -331,13 +334,20 @@ final class PayCycleCalendar extends Component
             return $user->currentPayCycleBounds();
         }
 
+        $end = $this->nextScheduledPaydayAfter(
+            CarbonImmutable::instance($user->next_pay_date),
+            $depositDate,
+            $frequency,
+        );
+
+        // Stale deposit from a prior cycle: defer to the schedule (see docblock).
+        if ($end->lessThanOrEqualTo(CarbonImmutable::today())) {
+            return $user->currentPayCycleBounds();
+        }
+
         return [
             'start' => $depositDate,
-            'end' => $this->nextScheduledPaydayAfter(
-                CarbonImmutable::instance($user->next_pay_date),
-                $depositDate,
-                $frequency,
-            ),
+            'end' => $end,
         ];
     }
 

--- a/tests/Feature/Livewire/Dashboard/PayCycleCalendarTest.php
+++ b/tests/Feature/Livewire/Dashboard/PayCycleCalendarTest.php
@@ -182,11 +182,11 @@ test('a late Friday deposit still ends the cycle on the scheduled Thursday', fun
     $this->travelTo('2026-05-31');
     [$user, $account] = fortnightlyThursdayPayUser();
 
-    // Paid one day late — Friday instead of the scheduled Thursday.
+    // Paid one day late — Friday 22 May instead of the scheduled Thursday 21 May.
     Transaction::factory()->credit()->for($user)->for($account)->create([
         'amount' => 570660,
         'description' => 'Direct Credit WINABLE PAYROLL',
-        'post_date' => '2026-05-08',
+        'post_date' => '2026-05-22',
     ]);
 
     /** @var list<PayCycleDayData> $days */
@@ -196,8 +196,8 @@ test('a late Friday deposit still ends the cycle on the scheduled Thursday', fun
         ->days();
 
     // Window starts on the actual late Friday, but the payday stays on Thursday.
-    expect($days[0]->iso)->toBe('2026-05-08')
-        ->and(end($days)->iso)->toBe('2026-05-21')
+    expect($days[0]->iso)->toBe('2026-05-22')
+        ->and(end($days)->iso)->toBe('2026-06-04')
         ->and(end($days)->isCycleEnd)->toBeTrue();
 });
 
@@ -232,15 +232,15 @@ test('anchors on the same-account amount match when the salary description has d
     $this->travelTo('2026-05-31');
     [$user, $account] = fortnightlyThursdayPayUser();
 
-    // The salary landed late (Friday 8 May) but the bank description has drifted
+    // The salary landed late (Friday 22 May) but the bank description has drifted
     // and no longer contains the configured "WINABLE PAYROLL". The same-account,
     // exact-amount, credit transaction is the only candidate, so the window must
     // anchor on it (deliberate amount-only fallback) rather than silently
-    // reverting to schedule-only bounds (which would start 21 May, end 4 Jun).
+    // reverting to schedule-only bounds (which would start 21 May).
     Transaction::factory()->credit()->for($user)->for($account)->create([
         'amount' => 570660,
         'description' => 'ACME PTY LTD 0042',
-        'post_date' => '2026-05-08',
+        'post_date' => '2026-05-22',
     ]);
 
     /** @var list<PayCycleDayData> $days */
@@ -249,8 +249,8 @@ test('anchors on the same-account amount match when the salary description has d
         ->instance()
         ->days();
 
-    expect($days[0]->iso)->toBe('2026-05-08')
-        ->and(end($days)->iso)->toBe('2026-05-21');
+    expect($days[0]->iso)->toBe('2026-05-22')
+        ->and(end($days)->iso)->toBe('2026-06-04');
 });
 
 test('falls back to schedule bounds when the income has no matching deposit yet', function () {
@@ -267,6 +267,52 @@ test('falls back to schedule bounds when the income has no matching deposit yet'
 
     expect($days[0]->iso)->toBe('2026-05-21')
         ->and(end($days)->iso)->toBe('2026-06-04');
+});
+
+test('falls back to the schedule cycle containing today when the latest deposit is from a prior cycle', function () {
+    // Today sits after a scheduled payday whose deposit has not been imported yet;
+    // the only deposit on record is a fortnight stale (issue: dashboard showed the
+    // cycle ending 16 Jul and "Today" snapped back to it).
+    $this->travelTo('2026-07-19');
+    [$user, $account] = fortnightlyThursdayPayUser('2026-06-04');
+
+    // Deposit from the 2 Jul payday — the 16 Jul deposit hasn't landed yet.
+    Transaction::factory()->credit()->for($user)->for($account)->create([
+        'amount' => 570660,
+        'description' => 'Direct Credit WINABLE PAYROLL',
+        'post_date' => '2026-07-02',
+    ]);
+
+    /** @var list<PayCycleDayData> $days */
+    $days = Livewire::actingAs($user)
+        ->test(PayCycleCalendar::class)
+        ->instance()
+        ->days();
+
+    // The window rolls forward to the cycle that actually contains today.
+    expect($days[0]->iso)->toBe('2026-07-16')
+        ->and(end($days)->iso)->toBe('2026-07-30')
+        ->and(collect($days)->contains(fn (PayCycleDayData $day) => $day->iso === '2026-07-19'))->toBeTrue();
+});
+
+test('goToCurrentCycle selects today within the current cycle when the latest deposit is stale', function () {
+    $this->travelTo('2026-07-19');
+    [$user, $account] = fortnightlyThursdayPayUser('2026-06-04');
+
+    Transaction::factory()->credit()->for($user)->for($account)->create([
+        'amount' => 570660,
+        'description' => 'Direct Credit WINABLE PAYROLL',
+        'post_date' => '2026-07-02',
+    ]);
+
+    $component = Livewire::actingAs($user)->test(PayCycleCalendar::class);
+    $component->call('goToCurrentCycle');
+
+    $selected = $component->instance()->selectedDay();
+
+    expect($component->get('cycleOffset'))->toBe(0)
+        ->and($selected['iso'] ?? null)->toBe('2026-07-19')
+        ->and($selected['isToday'] ?? false)->toBeTrue();
 });
 
 test('matches an income deposit whose description contains a percent sign literally', function () {


### PR DESCRIPTION
## Why
On `/dashboard` the pay-cycle calendar did not show the current pay cycle, and clicking **Today** snapped back to the previous payday (e.g. the 16th).

`PayCycleCalendar::currentCycleBounds()` anchored the window **end** on the first scheduled payday after the *latest imported deposit*. When the current cycle's deposit hasn't been imported yet (normal bank-feed lag), the latest deposit is from a prior cycle whose payday is already past, so the window ended before today. Today fell outside the cycle, and `goToCurrentCycle` recomputed that same stale window — the apparent "jump back to the 16th". `User::currentPayCycleBounds()` never had this problem because it fast-forwards past today.

## What changed
- `currentCycleBounds()` anchors on the deposit only when its cycle still reaches today (`end > today`); otherwise it falls back to `User::currentPayCycleBounds()`, which fast-forwards to the cycle that contains today. Genuine late deposits (payday still ahead) stay deposit-anchored.
- Method docblock updated to describe the stale-deposit fallback.

## Tests
- Two existing late-deposit fixtures used a deposit two cycles before `today` (8 May vs today 31 May) — they encoded the buggy output. Moved to a genuine current-cycle late deposit (Fri 22 May → ends Thu 4 Jun).
- Added two regressions reproducing the report (today 19 Jul, latest deposit 2 Jul): the window rolls forward to 16 Jul → 30 Jul with today inside, and **Today** selects 19 Jul (`selectedDay['iso']`, `isToday`).

## Verification
- `php artisan test tests/Feature/Livewire/Dashboard/PayCycleCalendarTest.php` → 62 passed (203 assertions)
- Pint: pass · PHPStan: no errors

Refs #344
Verified: pest 62 passed, pint pass, phpstan no errors