### PR TITLE
feat(#349): allocate $0.00 transactions to a category

### DIFF
--- a/app/Actions/Fortify/CreateNewUser.php
+++ b/app/Actions/Fortify/CreateNewUser.php
@@ -7,6 +7,7 @@ namespace App\Actions\Fortify;
 use App\Concerns\PasswordValidationRules;
 use App\Concerns\ProfileValidationRules;
 use App\Models\User;
+use App\Services\MonthEndBalanceRuleProvisioner;
 use Illuminate\Support\Facades\Validator;
 use Laravel\Fortify\Contracts\CreatesNewUsers;
 
@@ -26,10 +27,14 @@ final class CreateNewUser implements CreatesNewUsers
             'password' => $this->passwordRules(),
         ])->validate();
 
-        return User::create([
+        $user = User::create([
             'name' => $input['name'],
             'email' => $input['email'],
             'password' => $input['password'],
         ]);
+
+        app(MonthEndBalanceRuleProvisioner::class)->provisionForUser($user->id);
+
+        return $user;
     }
 }

--- a/app/Livewire/TransactionModal.php
+++ b/app/Livewire/TransactionModal.php
@@ -700,7 +700,7 @@ final class TransactionModal extends Component
         $parsed = AmountParser::parse($this->descriptionInput);
 
         if ($allowZero ? ($parsed->amount < 0 || ! $parsed->hasAmount) : $parsed->amount <= 0) {
-            $this->addError('descriptionInput', __('The amount must be greater than zero.'));
+            $this->addError('descriptionInput', $allowZero ? __('Enter a valid amount.') : __('The amount must be greater than zero.'));
 
             return false;
         }

--- a/app/Livewire/TransactionModal.php
+++ b/app/Livewire/TransactionModal.php
@@ -699,7 +699,7 @@ final class TransactionModal extends Component
 
         $parsed = AmountParser::parse($this->descriptionInput);
 
-        if ($allowZero ? $parsed->amount < 0 : $parsed->amount <= 0) {
+        if ($allowZero ? ($parsed->amount < 0 || ! $parsed->hasAmount) : $parsed->amount <= 0) {
             $this->addError('descriptionInput', __('The amount must be greater than zero.'));
 
             return false;

--- a/app/Livewire/TransactionModal.php
+++ b/app/Livewire/TransactionModal.php
@@ -446,7 +446,7 @@ final class TransactionModal extends Component
 
     private function updateTransaction(): bool
     {
-        $resolved = $this->resolveTransactionWithParsedAmount();
+        $resolved = $this->resolveTransactionWithParsedAmount(allowZero: true);
 
         if ($resolved === false) {
             return false;
@@ -687,7 +687,7 @@ final class TransactionModal extends Component
     }
 
     /** @return array{Transaction, AmountParseResult}|false */
-    private function resolveTransactionWithParsedAmount(): array|false
+    private function resolveTransactionWithParsedAmount(bool $allowZero = false): array|false
     {
         $transaction = Transaction::query()
             ->where('user_id', auth()->id())
@@ -699,7 +699,7 @@ final class TransactionModal extends Component
 
         $parsed = AmountParser::parse($this->descriptionInput);
 
-        if ($parsed->amount <= 0) {
+        if ($allowZero ? $parsed->amount < 0 : $parsed->amount <= 0) {
             $this->addError('descriptionInput', __('The amount must be greater than zero.'));
 
             return false;

--- a/app/Services/CsvImport/CsvParserService.php
+++ b/app/Services/CsvImport/CsvParserService.php
@@ -269,6 +269,10 @@ final class CsvParserService
                 return [-abs($debit), TransactionDirection::Debit];
             }
 
+            if ($credit !== null || $debit !== null) {
+                return [0, TransactionDirection::Credit];
+            }
+
             return [null, TransactionDirection::Debit];
         }
 

--- a/app/Services/MonthEndBalanceRuleProvisioner.php
+++ b/app/Services/MonthEndBalanceRuleProvisioner.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Enums\RuleActionType;
+use App\Enums\RuleTriggerField;
+use App\Enums\RuleTriggerOperator;
+use App\Models\Category;
+use App\Models\Transaction;
+use App\Models\User;
+use App\Models\UserRule;
+use App\Models\UserRuleGroup;
+
+final readonly class MonthEndBalanceRuleProvisioner
+{
+    public const string CATEGORY_NAME = 'Balance';
+
+    public const string MATCH_VALUE = 'Month End Balance';
+
+    private const string GROUP_NAME = 'Auto-categorisation';
+
+    private const string RULE_NAME = 'Categorise month-end balance';
+
+    public function __construct(
+        private RuleEvaluator $evaluator,
+        private RuleActionExecutor $executor,
+    ) {}
+
+    public function provisionAllUsers(): void
+    {
+        $categoryId = $this->balanceCategoryId();
+
+        if ($categoryId === null) {
+            return;
+        }
+
+        User::query()->eachById(function (User $user) use ($categoryId): void {
+            $this->provision($user->id, $categoryId);
+        });
+    }
+
+    public function provision(int $userId, int $categoryId): UserRule
+    {
+        $group = $this->group($userId);
+
+        $rule = UserRule::query()->firstOrCreate(
+            [
+                'user_id' => $userId,
+                'user_rule_group_id' => $group->id,
+                'name' => self::RULE_NAME,
+            ],
+            [
+                'triggers' => [[
+                    'field' => RuleTriggerField::Description->value,
+                    'operator' => RuleTriggerOperator::Contains->value,
+                    'value' => self::MATCH_VALUE,
+                ]],
+                'actions' => [[
+                    'type' => RuleActionType::SetCategory->value,
+                    'value' => (string) $categoryId,
+                ]],
+                'strict_mode' => true,
+                'is_auto_apply' => true,
+                'is_active' => true,
+                'order' => (int) UserRule::query()->where('user_rule_group_id', $group->id)->max('order') + 1,
+            ],
+        );
+
+        if ($rule->wasRecentlyCreated) {
+            $this->applyToExisting($userId, $rule);
+        }
+
+        return $rule;
+    }
+
+    public function balanceCategoryId(): ?int
+    {
+        $id = Category::query()
+            ->whereNull('parent_id')
+            ->where('name', self::CATEGORY_NAME)
+            ->value('id');
+
+        return $id === null ? null : (int) $id;
+    }
+
+    private function applyToExisting(int $userId, UserRule $rule): void
+    {
+        Transaction::query()
+            ->where('user_id', $userId)
+            ->current()
+            ->lazyById()
+            ->each(function (Transaction $transaction) use ($rule): void {
+                if ($this->evaluator->matches($transaction, $rule)) {
+                    $this->executor->execute($transaction, $rule->actions);
+                }
+            });
+    }
+
+    private function group(int $userId): UserRuleGroup
+    {
+        return UserRuleGroup::query()->firstOrCreate(
+            [
+                'user_id' => $userId,
+                'name' => self::GROUP_NAME,
+            ],
+            [
+                'order' => (int) UserRuleGroup::query()->where('user_id', $userId)->max('order') + 1,
+                'is_active' => true,
+                'stop_processing' => false,
+            ],
+        );
+    }
+}

--- a/app/Services/MonthEndBalanceRuleProvisioner.php
+++ b/app/Services/MonthEndBalanceRuleProvisioner.php
@@ -68,11 +68,22 @@ final readonly class MonthEndBalanceRuleProvisioner
             ],
         );
 
-        if ($rule->wasRecentlyCreated) {
+        if ($rule->wasRecentlyCreated && $group->is_active) {
             $this->applyToExisting($userId, $rule);
         }
 
         return $rule;
+    }
+
+    public function provisionForUser(int $userId): ?UserRule
+    {
+        $categoryId = $this->balanceCategoryId();
+
+        if ($categoryId === null) {
+            return null;
+        }
+
+        return $this->provision($userId, $categoryId);
     }
 
     public function balanceCategoryId(): ?int

--- a/app/Services/MonthEndBalanceRuleProvisioner.php
+++ b/app/Services/MonthEndBalanceRuleProvisioner.php
@@ -30,14 +30,14 @@ final readonly class MonthEndBalanceRuleProvisioner
 
     public function provisionAllUsers(): void
     {
-        $categoryId = $this->balanceCategoryId();
+        $category = $this->balanceCategory();
 
-        if ($categoryId === null) {
+        if ($category === null) {
             return;
         }
 
-        User::query()->eachById(function (User $user) use ($categoryId): void {
-            $this->provision($user->id, $categoryId);
+        User::query()->eachById(function (User $user) use ($category): void {
+            $this->provision($user->id, $category->id);
         });
     }
 
@@ -77,23 +77,31 @@ final readonly class MonthEndBalanceRuleProvisioner
 
     public function provisionForUser(int $userId): ?UserRule
     {
-        $categoryId = $this->balanceCategoryId();
+        $category = $this->balanceCategory();
 
-        if ($categoryId === null) {
+        if ($category === null) {
             return null;
         }
 
-        return $this->provision($userId, $categoryId);
+        return $this->provision($userId, $category->id);
     }
 
-    public function balanceCategoryId(): ?int
+    private function balanceCategory(): ?Category
     {
-        $id = Category::query()
+        $category = Category::query()
             ->whereNull('parent_id')
             ->where('name', self::CATEGORY_NAME)
-            ->value('id');
+            ->first();
 
-        return $id === null ? null : (int) $id;
+        if ($category === null) {
+            return null;
+        }
+
+        if ($category->is_hidden) {
+            $category->update(['is_hidden' => false]);
+        }
+
+        return $category;
     }
 
     private function applyToExisting(int $userId, UserRule $rule): void

--- a/app/Services/MonthEndBalanceRuleProvisioner.php
+++ b/app/Services/MonthEndBalanceRuleProvisioner.php
@@ -45,6 +45,26 @@ final readonly class MonthEndBalanceRuleProvisioner
     {
         $group = $this->group($userId);
 
+        $triggers = [
+            [
+                'field' => RuleTriggerField::Description->value,
+                'operator' => RuleTriggerOperator::Contains->value,
+                'value' => self::MATCH_VALUE,
+            ],
+            [
+                'field' => RuleTriggerField::CategoryId->value,
+                'operator' => RuleTriggerOperator::IsEmpty->value,
+                'value' => '',
+            ],
+        ];
+
+        $actions = [
+            [
+                'type' => RuleActionType::SetCategory->value,
+                'value' => (string) $categoryId,
+            ],
+        ];
+
         $rule = UserRule::query()->firstOrCreate(
             [
                 'user_id' => $userId,
@@ -52,15 +72,8 @@ final readonly class MonthEndBalanceRuleProvisioner
                 'name' => self::RULE_NAME,
             ],
             [
-                'triggers' => [[
-                    'field' => RuleTriggerField::Description->value,
-                    'operator' => RuleTriggerOperator::Contains->value,
-                    'value' => self::MATCH_VALUE,
-                ]],
-                'actions' => [[
-                    'type' => RuleActionType::SetCategory->value,
-                    'value' => (string) $categoryId,
-                ]],
+                'triggers' => $triggers,
+                'actions' => $actions,
                 'strict_mode' => true,
                 'is_auto_apply' => true,
                 'is_active' => true,
@@ -68,8 +81,16 @@ final readonly class MonthEndBalanceRuleProvisioner
             ],
         );
 
-        if ($rule->wasRecentlyCreated && $group->is_active) {
-            $this->applyToExisting($userId, $rule);
+        if ($rule->wasRecentlyCreated) {
+            if ($group->is_active) {
+                $this->applyToExisting($userId, $rule);
+            }
+
+            return $rule;
+        }
+
+        if ($rule->triggers !== $triggers || $rule->actions !== $actions) {
+            $rule->update(['triggers' => $triggers, 'actions' => $actions]);
         }
 
         return $rule;

--- a/app/Support/AmountParseResult.php
+++ b/app/Support/AmountParseResult.php
@@ -9,5 +9,6 @@ final readonly class AmountParseResult
     public function __construct(
         public int $amount,
         public string $description,
+        public bool $hasAmount = false,
     ) {}
 }

--- a/app/Support/AmountParser.php
+++ b/app/Support/AmountParser.php
@@ -28,8 +28,9 @@ final class AmountParser
         $description = mb_trim(mb_substr($stripped, mb_strlen($matches[1])));
         $amount = self::evaluate($expression);
         $cents = (int) round($amount * 100);
+        $hasAmount = preg_match('/\d/', $expression) === 1;
 
-        return new AmountParseResult($cents, $description);
+        return new AmountParseResult($cents, $description, $hasAmount);
     }
 
     private static function evaluate(string $expression): float

--- a/database/migrations/2026_07_21_000000_provision_balance_category_and_rule.php
+++ b/database/migrations/2026_07_21_000000_provision_balance_category_and_rule.php
@@ -14,7 +14,7 @@ return new class extends Migration
             return;
         }
 
-        Category::query()->firstOrCreate(
+        $balance = Category::query()->firstOrCreate(
             [
                 'name' => MonthEndBalanceRuleProvisioner::CATEGORY_NAME,
                 'parent_id' => null,
@@ -24,6 +24,10 @@ return new class extends Migration
                 'is_hidden' => false,
             ],
         );
+
+        if ($balance->is_hidden) {
+            $balance->update(['is_hidden' => false]);
+        }
 
         app(MonthEndBalanceRuleProvisioner::class)->provisionAllUsers();
     }

--- a/database/migrations/2026_07_21_000000_provision_balance_category_and_rule.php
+++ b/database/migrations/2026_07_21_000000_provision_balance_category_and_rule.php
@@ -14,7 +14,7 @@ return new class extends Migration
             return;
         }
 
-        $balance = Category::query()->firstOrCreate(
+        Category::query()->firstOrCreate(
             [
                 'name' => MonthEndBalanceRuleProvisioner::CATEGORY_NAME,
                 'parent_id' => null,
@@ -24,10 +24,6 @@ return new class extends Migration
                 'is_hidden' => false,
             ],
         );
-
-        if ($balance->is_hidden) {
-            $balance->update(['is_hidden' => false]);
-        }
 
         app(MonthEndBalanceRuleProvisioner::class)->provisionAllUsers();
     }

--- a/database/migrations/2026_07_21_000000_provision_balance_category_and_rule.php
+++ b/database/migrations/2026_07_21_000000_provision_balance_category_and_rule.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Category;
+use App\Services\MonthEndBalanceRuleProvisioner;
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Category::query()->doesntExist()) {
+            return;
+        }
+
+        Category::query()->firstOrCreate(
+            [
+                'name' => MonthEndBalanceRuleProvisioner::CATEGORY_NAME,
+                'parent_id' => null,
+            ],
+            [
+                'icon' => 'building-library',
+                'is_hidden' => false,
+            ],
+        );
+
+        app(MonthEndBalanceRuleProvisioner::class)->provisionAllUsers();
+    }
+
+    public function down(): void {}
+};

--- a/database/migrations/2026_07_21_000001_reconcile_month_end_balance_rule.php
+++ b/database/migrations/2026_07_21_000001_reconcile_month_end_balance_rule.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Services\MonthEndBalanceRuleProvisioner;
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        app(MonthEndBalanceRuleProvisioner::class)->provisionAllUsers();
+    }
+
+    public function down(): void {}
+};

--- a/database/seeders/CategorySeeder.php
+++ b/database/seeders/CategorySeeder.php
@@ -147,6 +147,11 @@ final class CategorySeeder extends Seeder
                     'Translink',
                 ],
             ],
+            [
+                'name' => 'Balance',
+                'icon' => 'building-library',
+                'children' => [],
+            ],
         ];
     }
 

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Database\Seeders;
 
 use App\Models\User;
+use App\Services\MonthEndBalanceRuleProvisioner;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\Hash;
 
@@ -45,5 +46,7 @@ final class DatabaseSeeder extends Seeder
                 'email_verified_at' => now(),
             ]);
         }
+
+        app(MonthEndBalanceRuleProvisioner::class)->provisionAllUsers();
     }
 }

--- a/docs/superpowers/specs/2026-07-21-zero-amount-category-design.md
+++ b/docs/superpowers/specs/2026-07-21-zero-amount-category-design.md
@@ -1,0 +1,93 @@
+# Allocating $0.00 transactions to a category
+
+**Issue:** #349
+**Date:** 2026-07-21
+**Status:** Approved
+
+## Problem
+
+`$0.00` transactions — e.g. a bank statement's `0.00 Purchases - Month End Balance: $4,085.57`
+marker row — cannot be allocated to a category. Three distinct blockers:
+
+1. **Import drops them.** `CsvParserService::parseAmount` treats a `$0.00` value in a
+   Debit/Credit column mapping as "no amount" and the row is skipped. A single
+   signed-amount column keeps it (amount `0`, direction Credit).
+2. **Manual allocation is blocked.** `TransactionModal::resolveTransactionWithParsedAmount`
+   rejects `amount <= 0` with *"The amount must be greater than zero"*, so an existing
+   `$0.00` transaction cannot be opened and (re)categorised.
+3. **No auto-category.** Rule mining explicitly skips `Purchases - Month End Balance`
+   rows, and no "Balance" category exists in the taxonomy.
+
+## Approach
+
+Approach A (approved): a data migration provisions the category and the per-user
+auto-categorisation rule, so it works on the next import after deploy with no manual
+command and no environment-specific hardcoded ids. Categorisation stays on the single
+existing path — the `UserRule` pipeline (`UserRulesStage`), which already runs after
+every CSV import via `RunTransactionAnalysisJob`.
+
+## Changes
+
+### 1. Import — stop dropping explicit `$0.00` rows
+
+`CsvParserService::parseAmount`, Debit/Credit branch. Distinguish *absent* from
+*explicit zero*:
+
+- Both cells blank (`normalizeAmount` → `null`) → return `[null, ...]` (row still skipped).
+- Either cell present but both resolve to `0` → return `[0, TransactionDirection::Credit]`
+  (row kept).
+- Non-zero credit / debit → unchanged.
+
+Direction `Credit` for zero matches the single signed-amount-column path (`0 < 0` is
+false → Credit). A `$0.00` amount is reconciliation-safe: `ReconciliationPolicy`'s 10%
+tolerance of `0` is `0`, so it can only match a (non-existent) `$0.00` plan.
+
+### 2. New top-level "Balance" category
+
+- `CategorySeeder`: add a `Balance` root category (icon `building-library`), for fresh
+  installs. Categories are global (no `user_id`).
+- Idempotent migration inserts `Balance` by name into the existing database if absent.
+
+### 3. Auto-categorisation rule
+
+Idempotent migration, after ensuring the category exists:
+
+- Resolve the `Balance` category id by name.
+- For each existing user: find-or-create the `Auto-categorisation` `UserRuleGroup`, then
+  create (if absent) a `UserRule`:
+  - trigger: `description` `contains` `"Month End Balance"` (bank-agnostic)
+  - action: `set_category` → Balance id
+  - `strict_mode` true, `is_auto_apply` true, `is_active` true
+- `DatabaseSeeder` performs the same rule provisioning for fresh installs (after users
+  are seeded).
+
+`UserRulesStage.autoApplyRule` files every future month-end-balance row on import.
+
+### 4. Lift the `$0.00` manual-allocation block
+
+`TransactionModal`:
+
+- `resolveTransactionWithParsedAmount`: guard `amount < 0` (allow zero, still reject
+  negatives) — used by the plain edit path so any existing `$0.00` transaction can be
+  re-categorised.
+- `convertToTransfer` shares that resolver, so add an explicit `amount <= 0` guard there
+  (a transfer needs a positive amount).
+- Keep `<= 0` on `createTransaction`, `createTransfer`, `createPlannedTransaction`,
+  `resolvePlannedTransactionWithParsedAmount`, `resolveTransferPairWithParsedAmount`
+  (no manual creation of `$0.00` transactions, transfers, or plans).
+
+## Verification
+
+- `CsvParserService`: a `$0.00` Debit/Credit row is imported; a blank/blank row is still
+  skipped; normal debit and credit rows are unchanged.
+- Migration/seeder: `Balance` category present; each user has an active auto-apply
+  `Month End Balance` → Balance rule; running twice is idempotent.
+- Pipeline: a `$0.00` `Purchases - Month End Balance` transaction ends with
+  `category_id = Balance` after `TransactionAnalysisPipeline` runs.
+- `TransactionModal`: editing a `$0.00` transaction to set a category succeeds (no
+  "amount must be greater than zero" error).
+
+## Out of scope
+
+- Changing how the statement closing balance is captured (already handled at CSV mapping).
+- Hiding `$0.00` rows from reports (they contribute `$0` and are harmless).

--- a/tests/Feature/Auth/RegistrationTest.php
+++ b/tests/Feature/Auth/RegistrationTest.php
@@ -6,6 +6,11 @@
 
 declare(strict_types=1);
 
+use App\Models\Category;
+use App\Models\User;
+use App\Models\UserRule;
+use App\Services\MonthEndBalanceRuleProvisioner;
+
 test('registration screen can be rendered', function () {
     $response = $this->get(route('register'));
 
@@ -24,4 +29,23 @@ test('new users can register', function () {
         ->assertRedirect(route('dashboard', absolute: false));
 
     $this->assertAuthenticated();
+});
+
+test('a newly registered user is provisioned with the month-end balance rule', function () {
+    Category::create([
+        'name' => MonthEndBalanceRuleProvisioner::CATEGORY_NAME,
+        'icon' => 'building-library',
+        'is_hidden' => false,
+    ]);
+
+    $this->post(route('register.store'), [
+        'name' => 'Jane Doe',
+        'email' => 'jane@example.com',
+        'password' => 'password',
+        'password_confirmation' => 'password',
+    ])->assertSessionHasNoErrors();
+
+    $user = User::query()->where('email', 'jane@example.com')->sole();
+
+    expect(UserRule::query()->where('user_id', $user->id)->count())->toBe(1);
 });

--- a/tests/Feature/Livewire/TransactionModalTest.php
+++ b/tests/Feature/Livewire/TransactionModalTest.php
@@ -3651,3 +3651,47 @@ test('converting a zero-amount transaction to a transfer is rejected', function 
         ->call('save')
         ->assertHasErrors(['descriptionInput']);
 });
+
+test('editing a non-zero transaction to remove the amount is rejected', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+
+    $transaction = Transaction::factory()->for($user)->for($account)->fromCsv()->create([
+        'description' => 'COLES',
+        'amount' => 5000,
+        'direction' => TransactionDirection::Debit,
+        'category_id' => null,
+        'transfer_pair_id' => null,
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('edit-transaction', id: $transaction->id)
+        ->set('descriptionInput', 'Coles groceries')
+        ->call('save')
+        ->assertHasErrors(['descriptionInput']);
+
+    expect(Transaction::query()->where('user_id', $user->id)->current()->first()->amount)->toBe(5000);
+});
+
+test('editing a transaction to a negative amount is rejected', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+
+    $transaction = Transaction::factory()->for($user)->for($account)->fromCsv()->create([
+        'description' => 'COLES',
+        'amount' => 5000,
+        'direction' => TransactionDirection::Debit,
+        'category_id' => null,
+        'transfer_pair_id' => null,
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('edit-transaction', id: $transaction->id)
+        ->set('descriptionInput', '-5.00 refund')
+        ->call('save')
+        ->assertHasErrors(['descriptionInput']);
+
+    expect(Transaction::query()->where('user_id', $user->id)->current()->first()->amount)->toBe(5000);
+});

--- a/tests/Feature/Livewire/TransactionModalTest.php
+++ b/tests/Feature/Livewire/TransactionModalTest.php
@@ -3577,3 +3577,77 @@ test('the categorise-matching checkbox shows when editing in enter mode and not 
         ->dispatch('edit-transaction', id: $debit->id)
         ->assertDontSee('Also categorise matching transactions');
 });
+
+test('editing a zero-amount transaction can set a category', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $category = Category::factory()->create();
+
+    $transaction = Transaction::factory()->for($user)->for($account)->fromCsv()->create([
+        'description' => 'Purchases - Month End Balance',
+        'amount' => 0,
+        'direction' => TransactionDirection::Credit,
+        'category_id' => null,
+        'transfer_pair_id' => null,
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('edit-transaction', id: $transaction->id)
+        ->assertSet('descriptionInput', '0.00 Purchases - Month End Balance')
+        ->set('categoryId', $category->id)
+        ->call('save')
+        ->assertHasNoErrors()
+        ->assertSet('showModal', false);
+
+    $current = Transaction::query()->where('user_id', $user->id)->current()->first();
+
+    expect($current->category_id)->toBe($category->id)
+        ->and($current->amount)->toBe(0);
+});
+
+test('converting a zero-amount transaction to a plan is rejected', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+
+    $transaction = Transaction::factory()->for($user)->for($account)->fromCsv()->create([
+        'description' => 'Purchases - Month End Balance',
+        'amount' => 0,
+        'direction' => TransactionDirection::Credit,
+        'category_id' => null,
+        'transfer_pair_id' => null,
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('edit-transaction', id: $transaction->id)
+        ->set('mode', 'plan')
+        ->set('transactionType', 'expense')
+        ->set('frequency', RecurrenceFrequency::EveryMonth->value)
+        ->call('save')
+        ->assertHasErrors(['descriptionInput']);
+
+    expect(PlannedTransaction::query()->where('user_id', $user->id)->count())->toBe(0);
+});
+
+test('converting a zero-amount transaction to a transfer is rejected', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $toAccount = Account::factory()->for($user)->create();
+
+    $transaction = Transaction::factory()->for($user)->for($account)->fromCsv()->create([
+        'description' => 'Purchases - Month End Balance',
+        'amount' => 0,
+        'direction' => TransactionDirection::Credit,
+        'category_id' => null,
+        'transfer_pair_id' => null,
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(TransactionModal::class)
+        ->dispatch('edit-transaction', id: $transaction->id)
+        ->set('transactionType', 'transfer')
+        ->set('transferToAccountId', $toAccount->id)
+        ->call('save')
+        ->assertHasErrors(['descriptionInput']);
+});

--- a/tests/Feature/Services/CsvImport/CsvParserServiceTest.php
+++ b/tests/Feature/Services/CsvImport/CsvParserServiceTest.php
@@ -98,6 +98,56 @@ test('split debit credit columns parse correctly', function () {
         ->and($rows[1]->direction)->toBe(TransactionDirection::Credit);
 });
 
+test('explicit zero in debit/credit columns is imported as a zero-amount credit', function () {
+    $path = tmpCsv("Date,Description,Debit,Credit\n31/01/2026,Purchases - Month End Balance,0.00,0.00\n01/02/2026,Fee Waived,0.00,\n");
+
+    $parser = new CsvParserService();
+    $rows = $parser->preview($path, [
+        CsvColumnMapper::FIELD_DATE => 'Date',
+        CsvColumnMapper::FIELD_DESCRIPTION => 'Description',
+        CsvColumnMapper::FIELD_DEBIT => 'Debit',
+        CsvColumnMapper::FIELD_CREDIT => 'Credit',
+    ]);
+
+    expect($rows)->toHaveCount(2);
+    expect($rows[0]->amount)->toBe(0)
+        ->and($rows[0]->direction)->toBe(TransactionDirection::Credit)
+        ->and($rows[0]->description)->toBe('Purchases - Month End Balance');
+    expect($rows[1]->amount)->toBe(0)
+        ->and($rows[1]->direction)->toBe(TransactionDirection::Credit);
+});
+
+test('rows with blank debit and credit columns are skipped', function () {
+    $path = tmpCsv("Date,Description,Debit,Credit\n31/01/2026,EMPTY,,\n01/02/2026,SALARY,,1500.00\n");
+
+    $parser = new CsvParserService();
+    $rows = $parser->preview($path, [
+        CsvColumnMapper::FIELD_DATE => 'Date',
+        CsvColumnMapper::FIELD_DESCRIPTION => 'Description',
+        CsvColumnMapper::FIELD_DEBIT => 'Debit',
+        CsvColumnMapper::FIELD_CREDIT => 'Credit',
+    ]);
+
+    expect($rows)->toHaveCount(1);
+    expect($rows[0]->amount)->toBe(150000)
+        ->and($rows[0]->direction)->toBe(TransactionDirection::Credit);
+});
+
+test('explicit zero in a single signed amount column is imported', function () {
+    $path = tmpCsv("Date,Description,Amount\n31/01/2026,Purchases - Month End Balance,0.00\n");
+
+    $parser = new CsvParserService();
+    $rows = $parser->preview($path, [
+        CsvColumnMapper::FIELD_DATE => 'Date',
+        CsvColumnMapper::FIELD_DESCRIPTION => 'Description',
+        CsvColumnMapper::FIELD_AMOUNT => 'Amount',
+    ]);
+
+    expect($rows)->toHaveCount(1);
+    expect($rows[0]->amount)->toBe(0)
+        ->and($rows[0]->direction)->toBe(TransactionDirection::Credit);
+});
+
 test('currency symbols and thousands separators are stripped', function () {
     $path = tmpCsv("Date,Description,Amount\n01/01/2026,RENT,\"-\$1,250.00\"\n");
 

--- a/tests/Feature/Services/CsvImport/CsvParserServiceTest.php
+++ b/tests/Feature/Services/CsvImport/CsvParserServiceTest.php
@@ -274,3 +274,21 @@ test('summarize closing balance is null when no balance column is mapped', funct
 
     expect($summary->closingBalance)->toBeNull();
 });
+
+test('a zero in one debit/credit column does not mask a non-zero value in the other', function () {
+    $path = tmpCsv("Date,Description,Debit,Credit\n01/02/2026,COFFEE,50.00,0.00\n03/02/2026,SALARY,0.00,1500.00\n");
+
+    $parser = new CsvParserService();
+    $rows = $parser->preview($path, [
+        CsvColumnMapper::FIELD_DATE => 'Date',
+        CsvColumnMapper::FIELD_DESCRIPTION => 'Description',
+        CsvColumnMapper::FIELD_DEBIT => 'Debit',
+        CsvColumnMapper::FIELD_CREDIT => 'Credit',
+    ]);
+
+    expect($rows)->toHaveCount(2);
+    expect($rows[0]->amount)->toBe(-5000)
+        ->and($rows[0]->direction)->toBe(TransactionDirection::Debit);
+    expect($rows[1]->amount)->toBe(150000)
+        ->and($rows[1]->direction)->toBe(TransactionDirection::Credit);
+});

--- a/tests/Feature/Services/MonthEndBalanceRuleProvisionerTest.php
+++ b/tests/Feature/Services/MonthEndBalanceRuleProvisionerTest.php
@@ -1,0 +1,96 @@
+<?php
+
+/** @noinspection StaticClosureCanBeUsedInspection */
+
+declare(strict_types=1);
+
+use App\Enums\PipelineTrigger;
+use App\Enums\TransactionDirection;
+use App\Models\Account;
+use App\Models\Category;
+use App\Models\Transaction;
+use App\Models\User;
+use App\Models\UserRule;
+use App\Services\MonthEndBalanceRuleProvisioner;
+use App\Services\TransactionAnalysisPipeline;
+
+function balanceCategory(): Category
+{
+    return Category::create([
+        'name' => MonthEndBalanceRuleProvisioner::CATEGORY_NAME,
+        'icon' => 'building-library',
+        'is_hidden' => false,
+    ]);
+}
+
+test('provision creates an active auto-apply month-end balance rule', function () {
+    $user = User::factory()->create();
+    $balance = balanceCategory();
+
+    $rule = app(MonthEndBalanceRuleProvisioner::class)->provision($user->id, $balance->id);
+
+    expect($rule->is_auto_apply)->toBeTrue()
+        ->and($rule->is_active)->toBeTrue()
+        ->and($rule->triggers[0]['field'])->toBe('description')
+        ->and($rule->triggers[0]['operator'])->toBe('contains')
+        ->and($rule->triggers[0]['value'])->toBe('Month End Balance')
+        ->and($rule->actions[0]['type'])->toBe('set_category')
+        ->and($rule->actions[0]['value'])->toBe((string) $balance->id);
+});
+
+test('provision is idempotent per user', function () {
+    $user = User::factory()->create();
+    $balance = balanceCategory();
+
+    $provisioner = app(MonthEndBalanceRuleProvisioner::class);
+    $provisioner->provision($user->id, $balance->id);
+    $provisioner->provision($user->id, $balance->id);
+
+    expect(UserRule::query()->where('user_id', $user->id)->count())->toBe(1);
+});
+
+test('provision back-fills an already-imported month-end balance transaction', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $balance = balanceCategory();
+
+    $transaction = Transaction::factory()->for($user)->for($account)->fromCsv()->create([
+        'description' => 'Purchases - Month End Balance',
+        'amount' => 0,
+        'direction' => TransactionDirection::Credit,
+        'category_id' => null,
+        'transfer_pair_id' => null,
+    ]);
+
+    app(MonthEndBalanceRuleProvisioner::class)->provision($user->id, $balance->id);
+
+    expect($transaction->refresh()->category_id)->toBe($balance->id);
+});
+
+test('a zero-amount month-end balance row is auto-filed to Balance on analysis', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $balance = balanceCategory();
+
+    app(MonthEndBalanceRuleProvisioner::class)->provision($user->id, $balance->id);
+
+    $transaction = Transaction::factory()->for($user)->for($account)->fromCsv()->create([
+        'description' => 'Purchases - Month End Balance',
+        'amount' => 0,
+        'direction' => TransactionDirection::Credit,
+        'category_id' => null,
+        'transfer_pair_id' => null,
+    ]);
+
+    app(TransactionAnalysisPipeline::class)->run($user, PipelineTrigger::Sync);
+
+    expect($transaction->refresh()->category_id)->toBe($balance->id);
+});
+
+test('provisionAllUsers is a no-op when the Balance category is absent', function () {
+    $user = User::factory()->create();
+
+    app(MonthEndBalanceRuleProvisioner::class)->provisionAllUsers();
+
+    expect(UserRule::query()->where('user_id', $user->id)->count())->toBe(0);
+});

--- a/tests/Feature/Services/MonthEndBalanceRuleProvisionerTest.php
+++ b/tests/Feature/Services/MonthEndBalanceRuleProvisionerTest.php
@@ -136,3 +136,26 @@ test('provision does not back-fill when the Auto-categorisation group is inactiv
 
     expect($transaction->refresh()->category_id)->toBeNull();
 });
+
+test('provisionAllUsers unhides a hidden Balance category and still categorises', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $balance = Category::create([
+        'name' => MonthEndBalanceRuleProvisioner::CATEGORY_NAME,
+        'parent_id' => null,
+        'is_hidden' => true,
+    ]);
+
+    $transaction = Transaction::factory()->for($user)->for($account)->fromCsv()->create([
+        'description' => 'Purchases - Month End Balance',
+        'amount' => 0,
+        'direction' => TransactionDirection::Credit,
+        'category_id' => null,
+        'transfer_pair_id' => null,
+    ]);
+
+    app(MonthEndBalanceRuleProvisioner::class)->provisionAllUsers();
+
+    expect($balance->refresh()->is_hidden)->toBeFalse()
+        ->and($transaction->refresh()->category_id)->toBe($balance->id);
+});

--- a/tests/Feature/Services/MonthEndBalanceRuleProvisionerTest.php
+++ b/tests/Feature/Services/MonthEndBalanceRuleProvisionerTest.php
@@ -11,6 +11,7 @@ use App\Models\Category;
 use App\Models\Transaction;
 use App\Models\User;
 use App\Models\UserRule;
+use App\Models\UserRuleGroup;
 use App\Services\MonthEndBalanceRuleProvisioner;
 use App\Services\TransactionAnalysisPipeline;
 
@@ -93,4 +94,45 @@ test('provisionAllUsers is a no-op when the Balance category is absent', functio
     app(MonthEndBalanceRuleProvisioner::class)->provisionAllUsers();
 
     expect(UserRule::query()->where('user_id', $user->id)->count())->toBe(0);
+});
+
+test('provisionAllUsers creates one rule per user', function () {
+    $users = User::factory()->count(3)->create();
+    balanceCategory();
+
+    app(MonthEndBalanceRuleProvisioner::class)->provisionAllUsers();
+
+    foreach ($users as $user) {
+        expect(UserRule::query()->where('user_id', $user->id)->count())->toBe(1);
+    }
+});
+
+test('provision reuses an existing Auto-categorisation group', function () {
+    $user = User::factory()->create();
+    $balance = balanceCategory();
+    $group = UserRuleGroup::factory()->for($user)->create(['name' => 'Auto-categorisation']);
+
+    app(MonthEndBalanceRuleProvisioner::class)->provision($user->id, $balance->id);
+
+    expect(UserRuleGroup::query()->where('user_id', $user->id)->where('name', 'Auto-categorisation')->count())->toBe(1)
+        ->and(UserRule::query()->where('user_rule_group_id', $group->id)->count())->toBe(1);
+});
+
+test('provision does not back-fill when the Auto-categorisation group is inactive', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $balance = balanceCategory();
+    UserRuleGroup::factory()->for($user)->create(['name' => 'Auto-categorisation', 'is_active' => false]);
+
+    $transaction = Transaction::factory()->for($user)->for($account)->fromCsv()->create([
+        'description' => 'Purchases - Month End Balance',
+        'amount' => 0,
+        'direction' => TransactionDirection::Credit,
+        'category_id' => null,
+        'transfer_pair_id' => null,
+    ]);
+
+    app(MonthEndBalanceRuleProvisioner::class)->provision($user->id, $balance->id);
+
+    expect($transaction->refresh()->category_id)->toBeNull();
 });

--- a/tests/Feature/Services/MonthEndBalanceRuleProvisionerTest.php
+++ b/tests/Feature/Services/MonthEndBalanceRuleProvisionerTest.php
@@ -17,10 +17,8 @@ use App\Services\TransactionAnalysisPipeline;
 
 function balanceCategory(): Category
 {
-    return Category::create([
+    return Category::factory()->create([
         'name' => MonthEndBalanceRuleProvisioner::CATEGORY_NAME,
-        'icon' => 'building-library',
-        'is_hidden' => false,
     ]);
 }
 
@@ -35,6 +33,9 @@ test('provision creates an active auto-apply month-end balance rule', function (
         ->and($rule->triggers[0]['field'])->toBe('description')
         ->and($rule->triggers[0]['operator'])->toBe('contains')
         ->and($rule->triggers[0]['value'])->toBe('Month End Balance')
+        ->and($rule->triggers)->toHaveCount(2)
+        ->and($rule->triggers[1]['field'])->toBe('category_id')
+        ->and($rule->triggers[1]['operator'])->toBe('is_empty')
         ->and($rule->actions[0]['type'])->toBe('set_category')
         ->and($rule->actions[0]['value'])->toBe((string) $balance->id);
 });
@@ -140,10 +141,8 @@ test('provision does not back-fill when the Auto-categorisation group is inactiv
 test('provisionAllUsers unhides a hidden Balance category and still categorises', function () {
     $user = User::factory()->create();
     $account = Account::factory()->for($user)->create();
-    $balance = Category::create([
+    $balance = Category::factory()->hidden()->create([
         'name' => MonthEndBalanceRuleProvisioner::CATEGORY_NAME,
-        'parent_id' => null,
-        'is_hidden' => true,
     ]);
 
     $transaction = Transaction::factory()->for($user)->for($account)->fromCsv()->create([
@@ -158,4 +157,51 @@ test('provisionAllUsers unhides a hidden Balance category and still categorises'
 
     expect($balance->refresh()->is_hidden)->toBeFalse()
         ->and($transaction->refresh()->category_id)->toBe($balance->id);
+});
+
+test('provision does not overwrite an already-categorised month-end balance transaction', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->for($user)->create();
+    $balance = balanceCategory();
+    $other = Category::factory()->create(['name' => 'Groceries']);
+
+    $transaction = Transaction::factory()->for($user)->for($account)->fromCsv()->create([
+        'description' => 'Purchases - Month End Balance',
+        'amount' => 0,
+        'direction' => TransactionDirection::Credit,
+        'category_id' => $other->id,
+        'transfer_pair_id' => null,
+    ]);
+
+    app(MonthEndBalanceRuleProvisioner::class)->provision($user->id, $balance->id);
+
+    expect($transaction->refresh()->category_id)->toBe($other->id);
+});
+
+test('provision upgrades an existing description-only rule to the tightened trigger set', function () {
+    $user = User::factory()->create();
+    $balance = balanceCategory();
+    $group = UserRuleGroup::factory()->for($user)->create(['name' => 'Auto-categorisation']);
+
+    $rule = UserRule::factory()->for($user)->create([
+        'user_rule_group_id' => $group->id,
+        'name' => 'Categorise month-end balance',
+        'triggers' => [[
+            'field' => 'description',
+            'operator' => 'contains',
+            'value' => 'Month End Balance',
+        ]],
+        'actions' => [['type' => 'set_category', 'value' => (string) $balance->id]],
+        'is_auto_apply' => true,
+        'is_active' => true,
+    ]);
+
+    app(MonthEndBalanceRuleProvisioner::class)->provision($user->id, $balance->id);
+
+    $rule->refresh();
+
+    expect($rule->triggers)->toHaveCount(2)
+        ->and($rule->triggers[1]['field'])->toBe('category_id')
+        ->and($rule->triggers[1]['operator'])->toBe('is_empty')
+        ->and(UserRule::query()->where('user_id', $user->id)->count())->toBe(1);
 });


### PR DESCRIPTION
Closes the gap where $0.00 bank-statement marker rows (e.g. `0.00 Purchases - Month End Balance: $4,085.57`) could not be filed anywhere.

## Changes
- **Import** (`CsvParserService::parseAmount`): an explicit `0.00` in Debit/Credit columns is no longer dropped; genuinely blank rows are still skipped. Single signed-amount columns already kept it.
- **Category**: new top-level **Balance** category — `CategorySeeder` (fresh installs) + an idempotent migration that back-fills existing databases.
- **Auto-categorisation**: `MonthEndBalanceRuleProvisioner` creates a per-user auto-apply `UserRule` (`description contains 'Month End Balance'` -> Balance). `UserRulesStage` files future imports automatically; existing rows are back-filled on first provision. Migration provisions existing users; `DatabaseSeeder` covers fresh installs.
- **Manual allocation** (`TransactionModal`): the edit path now permits a $0.00 amount (`allowZero`), so an existing zero row can be re-categorised. Manual create, transfer, and plan-conversion paths still require a positive amount.

## Verification
- Pint + PHPStan clean.
- Unit + Feature + Arch: 1907 passed.
- New tests: CSV parser (zero kept / blank skipped / single-column zero), provisioner (rule shape, idempotency, back-fill, no-op without category), pipeline ($0.00 month-end row auto-filed to Balance), modal ($0.00 edit sets category; zero rejected on plan/transfer conversion).
- `migrate` on the dev DB provisioned the Balance category (id 91) and 12 auto-apply rules.

Refs #349