### PR TITLE
feat(#351): parse and display PayPal Pay-in-4 receipt details

### DIFF
--- a/app/Services/GmailService.php
+++ b/app/Services/GmailService.php
@@ -24,7 +24,6 @@ use Webklex\PHPIMAP\Exceptions\GetMessagesFailedException;
 use Webklex\PHPIMAP\Exceptions\ImapBadRequestException;
 use Webklex\PHPIMAP\Exceptions\ImapServerErrorException;
 use Webklex\PHPIMAP\Exceptions\InvalidWhereQueryCriteriaException;
-use Webklex\PHPIMAP\Exceptions\MaskNotFoundException;
 use Webklex\PHPIMAP\Exceptions\ResponseException;
 use Webklex\PHPIMAP\Folder;
 use Webklex\PHPIMAP\Message;
@@ -124,10 +123,7 @@ final class GmailService implements GmailServiceContract
     }
 
     /**
-     * @throws \Webklex\PHPIMAP\Exceptions\RuntimeException
-     * @throws ImapBadRequestException
-     * @throws ImapServerErrorException
-     * @throws MaskNotFoundException
+     * @throws GmailSearchException
      */
     public function searchForTransaction(Transaction $transaction): Collection
     {
@@ -135,9 +131,10 @@ final class GmailService implements GmailServiceContract
             throw GmailSearchException::notConfigured();
         }
 
-        $client = Client::account('gmail');
+        $client = null;
 
         try {
+            $client = Client::account('gmail');
             $client->connect();
             $folder = $this->resolveFolder($client);
 
@@ -151,7 +148,10 @@ final class GmailService implements GmailServiceContract
         } catch (Throwable $e) {
             throw GmailSearchException::wrap($e);
         } finally {
-            $client->disconnect();
+            try {
+                $client?->disconnect();
+            } catch (Throwable) {
+            }
         }
     }
 

--- a/app/Services/GmailService.php
+++ b/app/Services/GmailService.php
@@ -176,7 +176,7 @@ final class GmailService implements GmailServiceContract
 
         if (preg_match_all('/\$\s?[\d,]+\.\d{2}\s*AUD\s+(?:will\s+be\s+charged\s+)?on\s+\d{1,2}\s+[A-Za-z]+\s+\d{4}/i', $text, $matches) >= 1) {
             foreach (array_slice(array_values(array_unique($matches[0])), 0, 4) as $line) {
-                $highlights[] = mb_trim(preg_replace('/\s+/', ' ', $line));
+                $highlights[] = mb_trim(preg_replace('/\s+/', ' ', $line) ?? '');
             }
         }
 
@@ -299,7 +299,7 @@ final class GmailService implements GmailServiceContract
 
         $merchant = str_replace('"', ' ', $this->ruleGenerator->suggestMatchValue($transaction));
 
-        return mb_trim(preg_replace('/\s+/', ' ', $merchant));
+        return mb_trim(preg_replace('/\s+/', ' ', $merchant) ?? '');
     }
 
     private function providerSender(string $description): ?string

--- a/app/Services/GmailService.php
+++ b/app/Services/GmailService.php
@@ -18,6 +18,14 @@ use Throwable;
 use Webklex\IMAP\Facades\Client;
 use Webklex\PHPIMAP\Address;
 use Webklex\PHPIMAP\Client as ImapClient;
+use Webklex\PHPIMAP\Exceptions\AuthFailedException;
+use Webklex\PHPIMAP\Exceptions\ConnectionFailedException;
+use Webklex\PHPIMAP\Exceptions\GetMessagesFailedException;
+use Webklex\PHPIMAP\Exceptions\ImapBadRequestException;
+use Webklex\PHPIMAP\Exceptions\ImapServerErrorException;
+use Webklex\PHPIMAP\Exceptions\InvalidWhereQueryCriteriaException;
+use Webklex\PHPIMAP\Exceptions\MaskNotFoundException;
+use Webklex\PHPIMAP\Exceptions\ResponseException;
 use Webklex\PHPIMAP\Folder;
 use Webklex\PHPIMAP\Message;
 use Webklex\PHPIMAP\Support\MessageCollection;
@@ -58,25 +66,16 @@ final class GmailService implements GmailServiceContract
     public function __construct(private readonly CategoryRuleGenerator $ruleGenerator) {}
 
     /**
-     * Build a readable snippet from an email's text and HTML bodies. Prefers
-     * the plain-text part; when empty, converts the HTML — dropping
-     * style/script/head blocks whole (contents included) before stripping
-     * tags, so CSS such as @font-face rules never leaks in. Leads with the
-     * seller and any payment-schedule amounts (the parts a BNPL receipt is
-     * linked for), followed by a short lead of body text for context.
+     * Build a readable snippet from an email's text and HTML bodies. Flattens
+     * the bodies via ReceiptParser (plain-text preferred; HTML has
+     * style/script/head blocks dropped whole before tags are stripped, so CSS
+     * such as @font-face rules never leaks in). Leads with the seller and any
+     * payment-schedule amounts (the parts a BNPL receipt is linked for),
+     * followed by a short lead of body text for context.
      */
     public static function snippetFromBodies(?string $textBody, ?string $htmlBody): ?string
     {
-        $body = mb_trim((string) $textBody);
-
-        if ($body === '') {
-            $html = (string) preg_replace('#<(style|script|head)\b[^>]*>.*?</\1>#is', ' ', (string) $htmlBody);
-            $html = (string) preg_replace('/<[^>]+>/', ' ', $html);
-            $body = html_entity_decode($html, ENT_QUOTES | ENT_HTML5, 'UTF-8');
-        }
-
-        $body = str_replace("\u{00A0}", ' ', $body);
-        $body = mb_trim((string) preg_replace('/\s+/', ' ', $body));
+        $body = ReceiptParser::flatten($textBody, $htmlBody);
 
         if ($body === '') {
             return null;
@@ -124,6 +123,12 @@ final class GmailService implements GmailServiceContract
         return implode(' ', array_filter($parts, static fn (string $part): bool => $part !== ''));
     }
 
+    /**
+     * @throws \Webklex\PHPIMAP\Exceptions\RuntimeException
+     * @throws ImapBadRequestException
+     * @throws ImapServerErrorException
+     * @throws MaskNotFoundException
+     */
     public function searchForTransaction(Transaction $transaction): Collection
     {
         if (! $this->isConfigured()) {
@@ -171,7 +176,7 @@ final class GmailService implements GmailServiceContract
 
         if (preg_match_all('/\$\s?[\d,]+\.\d{2}\s*AUD\s+(?:will\s+be\s+charged\s+)?on\s+\d{1,2}\s+[A-Za-z]+\s+\d{4}/i', $text, $matches) >= 1) {
             foreach (array_slice(array_values(array_unique($matches[0])), 0, 4) as $line) {
-                $highlights[] = mb_trim((string) preg_replace('/\s+/', ' ', $line));
+                $highlights[] = mb_trim(preg_replace('/\s+/', ' ', $line));
             }
         }
 
@@ -195,6 +200,16 @@ final class GmailService implements GmailServiceContract
         throw new RuntimeException('No searchable Gmail folder found ('.implode(', ', self::FOLDER_PATHS).').');
     }
 
+    /**
+     * @throws \Webklex\PHPIMAP\Exceptions\RuntimeException
+     * @throws GetMessagesFailedException
+     * @throws ResponseException
+     * @throws InvalidWhereQueryCriteriaException
+     * @throws ImapBadRequestException
+     * @throws ConnectionFailedException
+     * @throws AuthFailedException
+     * @throws ImapServerErrorException
+     */
     private function runQuery(Folder $folder, string $query): MessageCollection
     {
         return $folder->query()
@@ -284,7 +299,7 @@ final class GmailService implements GmailServiceContract
 
         $merchant = str_replace('"', ' ', $this->ruleGenerator->suggestMatchValue($transaction));
 
-        return mb_trim((string) preg_replace('/\s+/', ' ', $merchant));
+        return mb_trim(preg_replace('/\s+/', ' ', $merchant));
     }
 
     private function providerSender(string $description): ?string

--- a/app/Support/Email/ReceiptParser.php
+++ b/app/Support/Email/ReceiptParser.php
@@ -6,17 +6,19 @@ namespace App\Support\Email;
 
 /**
  * Extracts the structured payment breakdown from a BNPL receipt email
- * (currently Afterpay's "Payment confirmation" layout). Falls back to null
- * for anything that is not a recognisable receipt, so callers keep showing a
- * plain snippet.
+ * (Afterpay's "Payment confirmation" and PayPal's Pay-in-4 plan-payment
+ * layouts). Falls back to null for anything that is not a recognisable
+ * receipt, so callers keep showing a plain snippet.
  *
  * The returned shape is JSON-serialisable and rendered directly:
  *
  * @phpstan-type ReceiptLineItem array{merchant: string, reference: string|null, installment: string|null, amount: int}
- * @phpstan-type Receipt array{total: int|null, date: string|null, method: string|null, last4: string|null, items: list<ReceiptLineItem>}
+ * @phpstan-type Receipt array{total: int|null, date: string|null, method: string|null, last4: string|null, items: list<ReceiptLineItem>, type: string|null, seller: string|null, balance: int|null, loanReference: string|null}
  */
 final class ReceiptParser
 {
+    private const string PAYPAL_LABELS = 'Payment amount|Payment type|Payment method|Posted on|Seller|Current balance|Loan reference number';
+
     /**
      * @return Receipt|null
      */
@@ -28,6 +30,35 @@ final class ReceiptParser
             return null;
         }
 
+        return self::afterpay($text) ?? self::payPal($text, $textBody.' '.$htmlBody);
+    }
+
+    /**
+     * Normalises an email's bodies to a single whitespace-collapsed string:
+     * prefers the plain-text part, else strips style/script/head blocks and
+     * tags from the HTML and decodes entities. Shared with GmailService so the
+     * snippet and the parser flatten identically.
+     */
+    public static function flatten(?string $textBody, ?string $htmlBody): string
+    {
+        $body = mb_trim((string) $textBody);
+
+        if ($body === '') {
+            $html = preg_replace('#<(style|script|head)\b[^>]*>.*?</\1>#is', ' ', (string) $htmlBody);
+            $html = preg_replace('/<[^>]+>/', ' ', $html);
+            $body = html_entity_decode($html, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+        }
+
+        $body = str_replace("\u{00A0}", ' ', $body);
+
+        return mb_trim(preg_replace('/\s+/', ' ', $body));
+    }
+
+    /**
+     * @return Receipt|null
+     */
+    private static function afterpay(string $text): ?array
+    {
         $items = self::lineItems($text);
         $total = self::money($text, '/Total amount paid\s+\$([\d,]+\.\d{2})/i');
 
@@ -43,22 +74,83 @@ final class ReceiptParser
             'method' => $method,
             'last4' => $last4,
             'items' => $items,
+            'type' => null,
+            'seller' => null,
+            'balance' => null,
+            'loanReference' => null,
         ];
     }
 
-    private static function flatten(?string $textBody, ?string $htmlBody): string
+    /**
+     * @return Receipt|null
+     */
+    private static function payPal(string $text, string $rawBodies): ?array
     {
-        $body = mb_trim((string) $textBody);
+        $total = self::money($text, '/Payment amount\s+\$([\d,]+\.\d{2})/i');
 
-        if ($body === '') {
-            $html = (string) preg_replace('#<(style|script|head)\b[^>]*>.*?</\1>#is', ' ', (string) $htmlBody);
-            $html = (string) preg_replace('/<[^>]+>/', ' ', $html);
-            $body = html_entity_decode($html, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+        $date = preg_match('/Posted on\s+(\d{1,2}\s+[A-Za-z]+\s+\d{4})/i', $text, $m) === 1 ? $m[1] : null;
+        $seller = self::payPalField($text, 'Seller');
+        $loanReference = self::loanReference($text, $rawBodies);
+
+        if ($total === null || ($date === null && $seller === null && $loanReference === null)) {
+            return null;
         }
 
-        $body = str_replace("\u{00A0}", ' ', $body);
+        [$method, $last4] = self::payPalMethod($text);
 
-        return mb_trim((string) preg_replace('/\s+/', ' ', $body));
+        return [
+            'total' => $total,
+            'date' => $date,
+            'method' => $method,
+            'last4' => $last4,
+            'items' => [],
+            'type' => self::payPalField($text, 'Payment type'),
+            'seller' => $seller,
+            'balance' => self::money($text, '/Current balance\s+\$([\d,]+\.\d{2})/i'),
+            'loanReference' => $loanReference,
+        ];
+    }
+
+    private static function payPalField(string $text, string $label): ?string
+    {
+        if (preg_match('/'.preg_quote($label, '/').'\s+(.+?)\s*(?='.self::PAYPAL_LABELS.')/iu', $text, $m) !== 1) {
+            return null;
+        }
+
+        $value = mb_trim($m[1]);
+
+        return $value === '' ? null : $value;
+    }
+
+    /**
+     * @return array{0: string|null, 1: string|null}
+     */
+    private static function payPalMethod(string $text): array
+    {
+        $value = self::payPalField($text, 'Payment method');
+
+        if ($value === null) {
+            return [null, null];
+        }
+
+        if (preg_match('/^(.+?)\s+(?:x-|[•*]{2,}\s*)?(\d{4})$/u', $value, $m) === 1) {
+            return [mb_trim($m[1]), $m[2]];
+        }
+
+        return [$value, null];
+    }
+
+    private static function loanReference(string $text, string $rawBodies): ?string
+    {
+        if (preg_match('/Loan reference number\s+([A-Za-z0-9][A-Za-z0-9-]{7,})/i', $text, $m) === 1) {
+            return $m[1];
+        }
+
+        if (preg_match('~paypal\.com/myaccount/ppcredit/plans/([A-Za-z0-9-]{8,})~i', $rawBodies, $m) === 1) {
+            return $m[1];
+        }
+
+        return null;
     }
 
     /**
@@ -72,7 +164,7 @@ final class ReceiptParser
             $block = $bm[1];
         }
 
-        $block = (string) preg_replace('/^.*?Payment method\b.*?\d{4}\b\s*/isu', '', $block);
+        $block = preg_replace('/^.*?Payment method\b.*?\d{4}\b\s*/isu', '', $block);
 
         if (preg_match_all(
             '/([\p{L}\p{N}][\p{L}\p{N} &\'.\-]*?)\s*Order\s*#?(\S+)\s+(\d+)\s+of\s+(\d+)\s+\$([\d,]+\.\d{2})/iu',
@@ -87,7 +179,7 @@ final class ReceiptParser
         $seen = [];
 
         foreach ($matches as $match) {
-            $merchant = mb_trim((string) preg_replace('/\s+/', ' ', $match[1]));
+            $merchant = mb_trim(preg_replace('/\s+/', ' ', $match[1]));
             $reference = $match[2];
             $amount = self::centsFromString($match[5]);
             $key = $reference.'|'.$match[3].'|'.$amount;

--- a/app/Support/Email/ReceiptParser.php
+++ b/app/Support/Email/ReceiptParser.php
@@ -179,7 +179,7 @@ final class ReceiptParser
         $seen = [];
 
         foreach ($matches as $match) {
-            $merchant = mb_trim(preg_replace('/\s+/', ' ', $match[1]));
+            $merchant = mb_trim(preg_replace('/\s+/', ' ', $match[1]) ?? '');
             $reference = $match[2];
             $amount = self::centsFromString($match[5]);
             $key = $reference.'|'.$match[3].'|'.$amount;

--- a/app/Support/Email/ReceiptParser.php
+++ b/app/Support/Email/ReceiptParser.php
@@ -44,14 +44,14 @@ final class ReceiptParser
         $body = mb_trim((string) $textBody);
 
         if ($body === '') {
-            $html = preg_replace('#<(style|script|head)\b[^>]*>.*?</\1>#is', ' ', (string) $htmlBody);
-            $html = preg_replace('/<[^>]+>/', ' ', $html);
+            $html = preg_replace('#<(style|script|head)\b[^>]*>.*?</\1>#is', ' ', (string) $htmlBody) ?? '';
+            $html = preg_replace('/<[^>]+>/', ' ', $html) ?? '';
             $body = html_entity_decode($html, ENT_QUOTES | ENT_HTML5, 'UTF-8');
         }
 
         $body = str_replace("\u{00A0}", ' ', $body);
 
-        return mb_trim(preg_replace('/\s+/', ' ', $body));
+        return mb_trim(preg_replace('/\s+/', ' ', $body) ?? '');
     }
 
     /**
@@ -164,7 +164,7 @@ final class ReceiptParser
             $block = $bm[1];
         }
 
-        $block = preg_replace('/^.*?Payment method\b.*?\d{4}\b\s*/isu', '', $block);
+        $block = preg_replace('/^.*?Payment method\b.*?\d{4}\b\s*/isu', '', $block) ?? '';
 
         if (preg_match_all(
             '/([\p{L}\p{N}][\p{L}\p{N} &\'.\-]*?)\s*Order\s*#?(\S+)\s+(\d+)\s+of\s+(\d+)\s+\$([\d,]+\.\d{2})/iu',

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -13,6 +13,10 @@ parameters:
         - database/seeders
         - routes
 
+    # Pin the analysis target to the project's PHP floor (composer requires ^8.4)
+    # so results are deterministic regardless of which PHP runs PHPStan.
+    phpVersion: 80400
+
     # Be pragmatic; move towards 9 over time.
     level: 6
 

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -13,8 +13,6 @@ parameters:
         - database/seeders
         - routes
 
-    # Pin the analysis target to the project's PHP floor (composer requires ^8.4)
-    # so results are deterministic regardless of which PHP runs PHPStan.
     phpVersion: 80400
 
     # Be pragmatic; move towards 9 over time.

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -326,6 +326,12 @@ select:focus[data-flux-control] {
     .receipt-merchant { font-weight: 700; color: var(--color-fg-1); min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
     .receipt-installment { color: var(--color-fg-3); font-size: 11px; }
     .receipt-amount { font-weight: 700; color: var(--color-fg-2); text-align: right; }
+    .receipt-fields { display: flex; flex-direction: column; gap: 2px; margin-bottom: 6px; }
+    .receipt-field { display: flex; gap: 8px; align-items: baseline; }
+    .receipt-field-label { flex: 0 0 64px; color: var(--color-fg-3); font-size: 11px; text-transform: uppercase; letter-spacing: 0.04em; }
+    .receipt-field-value { color: var(--color-fg-2); min-width: 0; }
+    .receipt-seller { font-weight: 700; color: var(--color-fg-1); }
+    .receipt-ref { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 11px; overflow-wrap: anywhere; }
 
     /* ---------- Split panel (Ticket #342) ---------- */
     .split-panel {

--- a/resources/views/components/cib/receipt-summary.blade.php
+++ b/resources/views/components/cib/receipt-summary.blade.php
@@ -8,10 +8,14 @@
     $method = is_string($receipt['method'] ?? null) ? $receipt['method'] : null;
     $last4 = is_string($receipt['last4'] ?? null) ? $receipt['last4'] : null;
     $items = is_array($receipt['items'] ?? null) ? $receipt['items'] : [];
+    $type = is_string($receipt['type'] ?? null) ? $receipt['type'] : null;
+    $seller = is_string($receipt['seller'] ?? null) ? $receipt['seller'] : null;
+    $balance = is_numeric($receipt['balance'] ?? null) ? (int) $receipt['balance'] : null;
+    $loanReference = is_string($receipt['loanReference'] ?? null) ? $receipt['loanReference'] : null;
 @endphp
 
 <div class="receipt">
-    @if($total !== null || $date !== null)
+    @if($total !== null || $date !== null || $method !== null)
         <div class="receipt-head">
             @if($total !== null)
                 <span class="receipt-total">{{ MoneyCast::format($total) }}</span>
@@ -21,6 +25,23 @@
             @endif
             @if($method !== null)
                 <span class="receipt-method">{{ $method }}@if($last4) ···· {{ $last4 }}@endif</span>
+            @endif
+        </div>
+    @endif
+
+    @if($seller !== null || $type !== null || $balance !== null || $loanReference !== null)
+        <div class="receipt-fields">
+            @if($seller !== null)
+                <div class="receipt-field"><span class="receipt-field-label">Seller</span><span class="receipt-field-value receipt-seller">{{ $seller }}</span></div>
+            @endif
+            @if($type !== null)
+                <div class="receipt-field"><span class="receipt-field-label">Type</span><span class="receipt-field-value">{{ $type }}</span></div>
+            @endif
+            @if($balance !== null)
+                <div class="receipt-field"><span class="receipt-field-label">Balance</span><span class="receipt-field-value">{{ MoneyCast::format($balance) }}</span></div>
+            @endif
+            @if($loanReference !== null)
+                <div class="receipt-field"><span class="receipt-field-label">Loan ref</span><span class="receipt-field-value receipt-ref">{{ $loanReference }}</span></div>
             @endif
         </div>
     @endif

--- a/tests/Feature/Livewire/TransactionListTest.php
+++ b/tests/Feature/Livewire/TransactionListTest.php
@@ -1851,7 +1851,12 @@ test('scanEmail surfaces the receipt breakdown and linkEmail persists it', funct
 
 test('scanEmail renders PayPal plan payment details', function () {
     $user = User::factory()->create();
-    $transaction = afterpayTransaction($user);
+    $account = Account::factory()->for($user)->create();
+    $transaction = Transaction::factory()->for($user)->for($account)->debit()->create([
+        'description' => 'PAYPAL *PYPL PAYIN4',
+        'merchant_name' => 'PayPal',
+        'post_date' => now()->subDays(3),
+    ]);
 
     $details = [
         'total' => 1601,

--- a/tests/Feature/Livewire/TransactionListTest.php
+++ b/tests/Feature/Livewire/TransactionListTest.php
@@ -1848,3 +1848,51 @@ test('scanEmail surfaces the receipt breakdown and linkEmail persists it', funct
 
     expect($email->details)->toBe($details);
 });
+
+test('scanEmail renders PayPal plan payment details', function () {
+    $user = User::factory()->create();
+    $transaction = afterpayTransaction($user);
+
+    $details = [
+        'total' => 1601,
+        'date' => '25 September 2025',
+        'method' => 'BEYOND BANK AUSTRALIA LIMITED Credit Card',
+        'last4' => '8357',
+        'items' => [],
+        'type' => 'Plan payment',
+        'seller' => 'ONLINE STORE',
+        'balance' => 0,
+        'loanReference' => 'eacfa072-30dc-40eb-a93d-acc70b06d4d2',
+    ];
+
+    $this->mock(GmailServiceContract::class, function ($mock) use ($details): void {
+        $mock->shouldReceive('isConfigured')->andReturn(true);
+        $mock->shouldReceive('searchForTransaction')->andReturn(collect([
+            new EmailSearchResult(
+                messageId: 'paypal@mail.gmail.com',
+                subject: 'You sent a payment',
+                fromName: 'PayPal',
+                fromAddress: 'service@paypal.com.au',
+                date: '2026-06-13T10:00:00+10:00',
+                snippet: 'You made a payment for your Pay in 4 plan',
+                gmailUrl: 'https://mail.google.com/mail/u/0/#search/rfc822msgid:paypal',
+                details: $details,
+            ),
+        ]));
+    });
+
+    Livewire::actingAs($user)
+        ->test(TransactionList::class)
+        ->call('scanEmail', $transaction->id)
+        ->assertSee('ONLINE STORE')
+        ->assertSee('Plan payment')
+        ->assertSee('eacfa072-30dc-40eb-a93d-acc70b06d4d2')
+        ->assertSee('$0.00')
+        ->call('linkEmail', $transaction->id, 0)
+        ->assertSee('ONLINE STORE')
+        ->assertSee('eacfa072-30dc-40eb-a93d-acc70b06d4d2');
+
+    $email = TransactionEmail::query()->firstOrFail();
+
+    expect($email->details)->toBe($details);
+});

--- a/tests/Unit/Support/Email/ReceiptParserTest.php
+++ b/tests/Unit/Support/Email/ReceiptParserTest.php
@@ -24,6 +24,25 @@ $afterpayHtml = <<<'HTML'
 </body></html>
 HTML;
 
+$paypalHtml = <<<'HTML'
+<html><head><style>.x{color:red}</style></head><body>
+<h1>You sent a payment</h1>
+<p>You made a $16.01 AUD payment for your Pay in 4 plan. The payment was
+charged to the Credit Card ending in x-8357 on 25 September 2025.</p>
+<h2>Here are the details</h2>
+<table>
+  <tr><td>Payment amount</td><td>$16.01 AUD</td></tr>
+  <tr><td>Payment type</td><td>Plan payment</td></tr>
+  <tr><td>Payment method</td><td>BEYOND BANK AUSTRALIA LIMITED<br>Credit Card<br>x-8357</td></tr>
+  <tr><td>Posted on</td><td>25 September 2025</td></tr>
+  <tr><td>Seller</td><td>ONLINE STORE</td></tr>
+  <tr><td>Current balance</td><td>$0.00 AUD</td></tr>
+  <tr><td>Loan reference number</td><td>eacfa072-30dc-40eb-a93d-acc70b06d4d2</td></tr>
+</table>
+<p><a href="https://www.paypal.com/myaccount/ppcredit/plans/eacfa072-30dc-40eb-a93d-acc70b06d4d2">To make early payments, or to review your PayPal Pay in 4 Contract, log in to your PayPal account.</a></p>
+</body></html>
+HTML;
+
 test('parses total, date and payment method from an Afterpay receipt', function () use ($afterpayHtml) {
     $receipt = ReceiptParser::parse(null, $afterpayHtml);
 
@@ -81,4 +100,38 @@ test('returns null for a non-receipt email', function () {
 test('returns null for empty bodies', function () {
     expect(ReceiptParser::parse(null, null))->toBeNull()
         ->and(ReceiptParser::parse('', ''))->toBeNull();
+});
+
+test('parses a PayPal Pay-in-4 plan payment receipt', function () use ($paypalHtml) {
+    $receipt = ReceiptParser::parse(null, $paypalHtml);
+
+    expect($receipt)->not->toBeNull()
+        ->and($receipt['total'])->toBe(1601)
+        ->and($receipt['type'])->toBe('Plan payment')
+        ->and($receipt['method'])->toBe('BEYOND BANK AUSTRALIA LIMITED Credit Card')
+        ->and($receipt['last4'])->toBe('8357')
+        ->and($receipt['date'])->toBe('25 September 2025')
+        ->and($receipt['seller'])->toBe('ONLINE STORE')
+        ->and($receipt['balance'])->toBe(0)
+        ->and($receipt['loanReference'])->toBe('eacfa072-30dc-40eb-a93d-acc70b06d4d2')
+        ->and($receipt['items'])->toBe([]);
+});
+
+test('falls back to the plan link for the loan reference', function () use ($paypalHtml) {
+    $html = preg_replace('/<tr><td>Loan reference number.*?<\/tr>/s', '', $paypalHtml);
+
+    $receipt = ReceiptParser::parse(null, $html);
+
+    expect($receipt)->not->toBeNull()
+        ->and($receipt['loanReference'])->toBe('eacfa072-30dc-40eb-a93d-acc70b06d4d2');
+});
+
+test('Afterpay receipts leave the PayPal-only fields null', function () use ($afterpayHtml) {
+    $receipt = ReceiptParser::parse(null, $afterpayHtml);
+
+    expect($receipt)->not->toBeNull()
+        ->and($receipt['type'])->toBeNull()
+        ->and($receipt['seller'])->toBeNull()
+        ->and($receipt['balance'])->toBeNull()
+        ->and($receipt['loanReference'])->toBeNull();
 });


### PR DESCRIPTION
## Why
Gmail scan retrieved PayPal Pay-in-4 receipts as an unrefined snippet, missing the fields needed to identify the source. `ReceiptParser` only knew Afterpay's layout.

## What
- Extend `ReceiptParser` to the PayPal plan-payment layout (Payment amount/type/method, Posted on, Seller, Current balance, Loan reference); recover the loan ref from the `ppcredit/plans/<uuid>` link when the labelled field is absent.
- `parse()` flattens once then tries Afterpay -> PayPal; the shared flatten is now `ReceiptParser::flatten()` reused by `GmailService::snippetFromBodies()` (dedup).
- Render Seller/Type/Balance/Loan ref in `receipt-summary.blade.php` (search-result + linked rows) + CSS.
- Pin PHPStan analysis to PHP 8.4 (`phpVersion: 80400`) for deterministic results.

## Verification
- pest ReceiptParserTest 9, TransactionListTest --filter=scanEmail 6, GmailServiceTest 13
- pint --test pass; phpstan analyse no errors (level 6, PHP 8.4)

Refs #351
Verified: pest + pint + phpstan all passing