### PR TITLE
feat: [353] pick any nested category as parent and re-parent existing categories

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -8,8 +8,8 @@
       ]
     },
     "phpstorm": {
-      "url": "http://127.0.0.1:64342/sse",
-      "type": "sse"
+      "url": "http://127.0.0.1:64442/stream",
+      "type": "http"
     }
   }
 }

--- a/app/Livewire/CategoryEditor.php
+++ b/app/Livewire/CategoryEditor.php
@@ -23,6 +23,8 @@ final class CategoryEditor extends Component
 
     public string $editingName = '';
 
+    public ?int $editingParentId = null;
+
     public bool $showCreateForm = false;
 
     public string $newCategoryName = '';
@@ -42,6 +44,7 @@ final class CategoryEditor extends Component
         if ($this->selectedCategoryId === $id) {
             $this->selectedCategoryId = null;
             $this->editingName = '';
+            $this->editingParentId = null;
             $this->showDeleteConfirm = false;
 
             return;
@@ -55,6 +58,7 @@ final class CategoryEditor extends Component
 
         $this->selectedCategoryId = $category->id;
         $this->editingName = $category->name;
+        $this->editingParentId = $category->parent_id;
         $this->showDeleteConfirm = false;
     }
 
@@ -66,10 +70,18 @@ final class CategoryEditor extends Component
 
         $this->validate([
             'editingName' => ['required', 'string', 'max:255'],
+            'editingParentId' => ['nullable', 'integer', 'exists:categories,id'],
         ]);
+
+        if ($this->wouldCreateCycle($this->selectedCategoryId, $this->editingParentId)) {
+            $this->addError('editingParentId', __('A category cannot be moved under itself or one of its subcategories.'));
+
+            return;
+        }
 
         Category::find($this->selectedCategoryId)?->update([
             'name' => $this->editingName,
+            'parent_id' => $this->editingParentId,
         ]);
     }
 
@@ -136,6 +148,7 @@ final class CategoryEditor extends Component
         if ($this->selectedCategoryId === $this->deletingCategoryId) {
             $this->selectedCategoryId = null;
             $this->editingName = '';
+            $this->editingParentId = null;
         }
 
         $this->showDeleteConfirm = false;
@@ -155,15 +168,11 @@ final class CategoryEditor extends Component
             ->select('category_id', DB::raw('COUNT(DISTINCT transaction_id) as aggregate'))
             ->pluck('aggregate', 'category_id');
 
-        $categories = Category::query()
-            ->with(['parent.parent'])
-            ->when(! $this->showHidden, fn ($q) => $q->visible())
-            ->when($isSearching, fn ($q) => $q->where(function ($q) use ($search) {
-                $q->where('name', 'like', "%{$search}%")
-                    ->orWhereHas('parent', fn ($pq) => $pq->where('name', 'like', "%{$search}%"))
-                    ->orWhereHas('parent.parent', fn ($pq) => $pq->where('name', 'like', "%{$search}%"));
-            }))
-            ->get()
+        $categories = Category::allWithLinkedParents()
+            ->when(! $this->showHidden, fn ($c) => $c->reject(fn (Category $category): bool => $category->is_hidden))
+            ->when($isSearching, fn ($c) => $c->filter(
+                fn (Category $category): bool => str_contains(Str::lower($category->fullPath()), Str::lower($search))
+            ))
             ->sortBy(fn (Category $category): string => Str::lower($category->fullPath()), SORT_NATURAL)
             ->values()
             ->map(fn (Category $category) => [
@@ -188,10 +197,7 @@ final class CategoryEditor extends Component
                 ->get()
             : collect();
 
-        $parentOptions = Category::query()
-            ->whereNull('parent_id')
-            ->orderBy('name')
-            ->get(['id', 'name']);
+        $parentOptions = Category::visibleSortedByFullPath();
 
         return view('livewire.category-editor', [
             'categories' => $categories,
@@ -200,5 +206,29 @@ final class CategoryEditor extends Component
             'isSearching' => $isSearching,
             'formatMoney' => MoneyCast::format(...),
         ]);
+    }
+
+    private function wouldCreateCycle(int $categoryId, ?int $newParentId): bool
+    {
+        if ($newParentId === null) {
+            return false;
+        }
+
+        if ($newParentId === $categoryId) {
+            return true;
+        }
+
+        $parents = Category::query()->pluck('parent_id', 'id');
+        $cursor = $newParentId;
+
+        while ($cursor !== null) {
+            if ($cursor === $categoryId) {
+                return true;
+            }
+
+            $cursor = $parents[$cursor] !== null ? (int) $parents[$cursor] : null;
+        }
+
+        return false;
     }
 }

--- a/app/Livewire/CategoryEditor.php
+++ b/app/Livewire/CategoryEditor.php
@@ -161,6 +161,7 @@ final class CategoryEditor extends Component
     {
         $search = $this->search;
         $isSearching = $search !== '';
+        $searchLower = Str::lower($search);
 
         $counts = CategoryAttribution::query(auth()->id())
             ->whereNotNull('category_id')
@@ -171,7 +172,7 @@ final class CategoryEditor extends Component
         $categories = Category::allWithLinkedParents()
             ->when(! $this->showHidden, fn ($c) => $c->reject(fn (Category $category): bool => $category->is_hidden))
             ->when($isSearching, fn ($c) => $c->filter(
-                fn (Category $category): bool => str_contains(Str::lower($category->fullPath()), Str::lower($search))
+                fn (Category $category): bool => str_contains(Str::lower($category->fullPath()), $searchLower)
             ))
             ->sortBy(fn (Category $category): string => Str::lower($category->fullPath()), SORT_NATURAL)
             ->values()
@@ -220,12 +221,14 @@ final class CategoryEditor extends Component
 
         $parents = Category::query()->pluck('parent_id', 'id');
         $cursor = $newParentId;
+        $visited = [];
 
         while ($cursor !== null) {
-            if ($cursor === $categoryId) {
+            if ($cursor === $categoryId || isset($visited[$cursor])) {
                 return true;
             }
 
+            $visited[$cursor] = true;
             $cursor = $parents[$cursor] !== null ? (int) $parents[$cursor] : null;
         }
 

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -47,13 +47,24 @@ final class Category extends Model
         'is_hidden',
     ];
 
+    /** @return Collection<int, self> All categories with parent relations linked in memory (no lazy loads at any depth). */
+    public static function allWithLinkedParents(): Collection
+    {
+        $all = self::query()->get();
+        $byId = $all->keyBy('id');
+
+        foreach ($all as $category) {
+            $category->setRelation('parent', $category->parent_id !== null ? ($byId[$category->parent_id] ?? null) : null);
+        }
+
+        return $all;
+    }
+
     /** @return Collection<int, self> */
     public static function visibleSortedByFullPath(): Collection
     {
-        return self::query()
-            ->visible()
-            ->with(['parent', 'parent.parent'])
-            ->get()
+        return self::allWithLinkedParents()
+            ->reject(fn (self $category): bool => $category->is_hidden)
             ->sortBy(fn (self $category): string => $category->fullPath())
             ->values();
     }

--- a/resources/views/livewire/category-editor.blade.php
+++ b/resources/views/livewire/category-editor.blade.php
@@ -18,7 +18,7 @@
                     <flux:select wire:model="newParentId" size="sm">
                         <flux:select.option value="">{{ __('Top level (no parent)') }}</flux:select.option>
                         @foreach($parentOptions as $parent)
-                            <flux:select.option value="{{ $parent->id }}">{{ $parent->name }}</flux:select.option>
+                            <flux:select.option value="{{ $parent->id }}">{{ $parent->fullPath() }}</flux:select.option>
                         @endforeach
                     </flux:select>
                     <div class="flex gap-2">
@@ -63,6 +63,19 @@
                                 <div class="flex-1">
                                     <label class="cib-label" for="category-name-input">{{ __('Category name') }}</label>
                                     <flux:input id="category-name-input" wire:model="editingName" size="sm"/>
+                                </div>
+                                <div class="flex-1">
+                                    <label class="cib-label" for="category-parent-select">{{ __('Parent category') }}</label>
+                                    <flux:select id="category-parent-select" wire:model="editingParentId" size="sm">
+                                        <flux:select.option value="">{{ __('Top level (no parent)') }}</flux:select.option>
+                                        @foreach($parentOptions as $parent)
+                                            @continue($parent->id === $selectedCategoryId)
+                                            <flux:select.option value="{{ $parent->id }}">{{ $parent->fullPath() }}</flux:select.option>
+                                        @endforeach
+                                    </flux:select>
+                                    @error('editingParentId')
+                                        <flux:text size="sm" class="mt-1 text-red-600">{{ $message }}</flux:text>
+                                    @enderror
                                 </div>
                                 <flux:button wire:click="saveRename" variant="primary" size="sm">{{ __('Save') }}</flux:button>
                                 <flux:button wire:click="toggleHidden({{ $category['id'] }})" variant="ghost" size="sm" icon="eye-slash">

--- a/tests/Feature/Livewire/CategoryEditorTest.php
+++ b/tests/Feature/Livewire/CategoryEditorTest.php
@@ -372,3 +372,88 @@ test('cib: nested rows indent by depth and top-level rows are group headers', fu
         ->and($html)->toContain('padding-left: 0.875rem')
         ->and($html)->toContain('padding-left: 2.125rem');
 });
+
+/* ------------------------------------------------------------------ */
+/*  Nested category parents (issue #353) */
+/* ------------------------------------------------------------------ */
+
+test('parent dropdown lists nested categories by full path', function () {
+    $user = User::factory()->create();
+    $office = Category::factory()->create(['name' => 'Office']);
+    $onlineService = Category::factory()->withParent($office)->create(['name' => 'Online Service']);
+
+    Livewire::actingAs($user)
+        ->test(CategoryEditor::class)
+        ->call('openCreateForm')
+        ->assertSee('Office / Online Service')
+        ->call('openCreateForm', $onlineService->id)
+        ->assertSet('newParentId', $onlineService->id)
+        ->set('newCategoryName', 'Apple')
+        ->call('createCategory');
+
+    $child = Category::query()->where('name', 'Apple')->firstOrFail();
+    expect($child->parent_id)->toBe($onlineService->id)
+        ->and($child->depth())->toBe(2);
+});
+
+test('search matches an ancestor three levels up', function () {
+    $user = User::factory()->create();
+    $a = Category::factory()->create(['name' => 'Alpha']);
+    $b = Category::factory()->withParent($a)->create(['name' => 'Bravo']);
+    $c = Category::factory()->withParent($b)->create(['name' => 'Charlie']);
+    Category::factory()->withParent($c)->create(['name' => 'Delta']);
+
+    Livewire::actingAs($user)
+        ->test(CategoryEditor::class)
+        ->set('search', 'Alpha')
+        ->assertSee('Alpha / Bravo / Charlie / Delta');
+});
+
+test('can re-parent an existing category under a nested category', function () {
+    $user = User::factory()->create();
+    $office = Category::factory()->create(['name' => 'Office']);
+    $onlineService = Category::factory()->withParent($office)->create(['name' => 'Online Service']);
+    $training = Category::factory()->create(['name' => 'Training']);
+
+    Livewire::actingAs($user)
+        ->test(CategoryEditor::class)
+        ->call('selectCategory', $training->id)
+        ->assertSet('editingParentId', null)
+        ->set('editingParentId', $onlineService->id)
+        ->call('saveRename')
+        ->assertHasNoErrors();
+
+    $training->refresh();
+    expect($training->parent_id)->toBe($onlineService->id)
+        ->and($training->fullPath())->toBe('Office / Online Service / Training');
+});
+
+test('re-parent rejects moving a category under its own descendant', function () {
+    $user = User::factory()->create();
+    $a = Category::factory()->create(['name' => 'Alpha']);
+    $b = Category::factory()->withParent($a)->create(['name' => 'Bravo']);
+    $c = Category::factory()->withParent($b)->create(['name' => 'Charlie']);
+
+    Livewire::actingAs($user)
+        ->test(CategoryEditor::class)
+        ->call('selectCategory', $a->id)
+        ->set('editingParentId', $c->id)
+        ->call('saveRename')
+        ->assertHasErrors('editingParentId');
+
+    expect($a->fresh()->parent_id)->toBeNull();
+});
+
+test('re-parent rejects moving a category under itself', function () {
+    $user = User::factory()->create();
+    $office = Category::factory()->create(['name' => 'Office']);
+
+    Livewire::actingAs($user)
+        ->test(CategoryEditor::class)
+        ->call('selectCategory', $office->id)
+        ->set('editingParentId', $office->id)
+        ->call('saveRename')
+        ->assertHasErrors('editingParentId');
+
+    expect($office->fresh()->parent_id)->toBeNull();
+});

--- a/tests/Feature/Models/CategoryTest.php
+++ b/tests/Feature/Models/CategoryTest.php
@@ -264,3 +264,19 @@ test('resolveIcon fires no queries when parent.parent is eager-loaded on a grand
     expect($icon)->toBe('bolt')
         ->and(DB::getQueryLog())->toBeEmpty();
 });
+
+test('allWithLinkedParents then fullPath fires a single query on a deep node', function () {
+    $grandparent = Category::factory()->create(['name' => 'Office']);
+    $parent = Category::factory()->withParent($grandparent)->create(['name' => 'Training']);
+    Category::factory()->withParent($parent)->create(['name' => 'Subscription']);
+
+    DB::enableQueryLog();
+    DB::flushQueryLog();
+
+    $all = Category::allWithLinkedParents();
+    $deep = $all->firstWhere('name', 'Subscription');
+    $path = $deep->fullPath();
+
+    expect($path)->toBe('Office / Training / Subscription')
+        ->and(DB::getQueryLog())->toHaveCount(1);
+});


### PR DESCRIPTION
Why: the /accounts parent dropdown only offered top-level categories, and CategoryEditor search/eager-loading were hardcoded to 2 ancestor levels, blocking deeper nesting.

What: Category::allWithLinkedParents() links parents in memory at any depth; parent pickers (create + edit panel) list every visible category by full path; re-parenting has a cycle guard; search matches the full path.

Verification: Pint, PHPStan, CategoryEditorTest + CategoryTest green in DDEV; manual /accounts walkthrough (create under Office / Online Service, move a subtree, cycle rejection).

Refs #353
Verified: passing